### PR TITLE
compile libcld2 statically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .settings
 .DS_Store
 /analysis/token_filters/cld2/cld2-read-only
+/analysis/token_filters/cld2/libcld2_full.a
 /examples/bleve_index_json/bleve_index_json
 /examples/bleve_index_json/index.bleve/
 /examples/bleve_query/bleve_query

--- a/analysis/token_filters/cld2/README.md
+++ b/analysis/token_filters/cld2/README.md
@@ -8,21 +8,18 @@ In normal usage, you use this with the "single" tokenizer, so there is only one 
 
 1.  Acquire the source to cld2 in this directory.
 
-        $ svn checkout http://cld2.googlecode.com/svn/trunk/ cld2-read-only
+        $ svn checkout -r 167 http://cld2.googlecode.com/svn/trunk/ cld2-read-only
 
 2.  Build cld2
 
-        $ cd cld2-read-only/internal/
-        $ ./compile_libs.sh
+	$ ./compile_cld2.sh
 
+3.  Put the resulting libraries somewhere your linker can find.
 
-3.  Put the resulting libraries somewhere your dynamic linker can find.
-
-        $ cp *.so /usr/local/lib
+        $ cp *.a /usr/local/lib
 
 4.  Run the unit tests
 
-        $ cd ../..
         $ go test -v
         === RUN TestCld2Filter
         --- PASS: TestCld2Filter (0.00 seconds)

--- a/analysis/token_filters/cld2/compile_cld2.sh
+++ b/analysis/token_filters/cld2/compile_cld2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SRC="cldutil cldutil_shared compact_lang_det compact_lang_det_hint_code compact_lang_det_impl debug fixunicodevalue generated_entities generated_language generated_ulscript getonescriptspan lang_script offsetmap scoreonescriptspan tote utf8statetable cld_generated_cjk_uni_prop_80 cld2_generated_cjk_compatible cld_generated_cjk_delta_bi_32 generated_distinct_bi_0 cld2_generated_quad0122 cld2_generated_deltaocta0122 cld2_generated_distinctocta0122 cld_generated_score_quad_octa_0122";
+OBJ="";
+for f in ${SRC}; do
+  g++ -c -fPIC -O2 -m64 -o "cld2-read-only/internal/${f}.o" "cld2-read-only/internal/${f}.cc";
+  OBJ="${OBJ} cld2-read-only/internal/${f}.o";
+done;
+
+ar rcs libcld2_full.a ${OBJ};


### PR DESCRIPTION
This might be super hacky, and there might be a much nicer way to achieve it. I'd love to see some discussion about what that way might be though, so here I am submitting this pull request.

Basically I just don't want the users of my application to have to download libcld2 and go through the build process, which they would currently have to do, as cld2 doesn't exist in a lot of OS repositories. If there's a better way to do this, I'd love to know it.
