### PR TITLE
add boltdb storage type

### DIFF
--- a/index/store/boltdb/batch.go
+++ b/index/store/boltdb/batch.go
@@ -1,0 +1,63 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+package boltdb
+
+import (
+	"github.com/boltdb/bolt"
+)
+
+type op struct {
+	k []byte
+	v []byte
+}
+
+type BoltDBBatch struct {
+	store *BoltDBStore
+	ops   []op
+}
+
+func newBoltDBBatch(store *BoltDBStore) *BoltDBBatch {
+	rv := BoltDBBatch{
+		store: store,
+		ops:   make([]op, 0),
+	}
+	return &rv
+}
+
+func (i *BoltDBBatch) Set(key, val []byte) {
+	i.ops = append(i.ops, op{key, val})
+}
+
+func (i *BoltDBBatch) Delete(key []byte) {
+	i.ops = append(i.ops, op{key, nil})
+}
+
+func (i *BoltDBBatch) Execute() error {
+	return i.store.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(i.store.bucket))
+
+		for _, o := range i.ops {
+			if o.v == nil {
+				if err := b.Delete(o.k); err != nil {
+					return err
+				}
+			} else {
+				if err := b.Put(o.k, o.v); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+func (i *BoltDBBatch) Close() error {
+	return nil
+}

--- a/index/store/boltdb/iterator.go
+++ b/index/store/boltdb/iterator.go
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+package boltdb
+
+import (
+	"github.com/boltdb/bolt"
+)
+
+type BoltDBIterator struct {
+	store  *BoltDBStore
+	tx     *bolt.Tx
+	cursor *bolt.Cursor
+	valid  bool
+	key    []byte
+	val    []byte
+}
+
+func newBoltDBIterator(store *BoltDBStore) *BoltDBIterator {
+	tx, _ := store.db.Begin(false)
+	b := tx.Bucket([]byte(store.bucket))
+	cursor := b.Cursor()
+
+	return &BoltDBIterator{
+		store:  store,
+		tx:     tx,
+		cursor: cursor,
+	}
+}
+
+func (i *BoltDBIterator) SeekFirst() {
+	i.key, i.val = i.cursor.First()
+
+	i.valid = (i.key != nil)
+}
+
+func (i *BoltDBIterator) Seek(k []byte) {
+	i.key, i.val = i.cursor.Seek(k)
+
+	i.valid = (i.key != nil)
+}
+
+func (i *BoltDBIterator) Next() {
+	i.key, i.val = i.cursor.Next()
+
+	i.valid = (i.key != nil)
+}
+
+func (i *BoltDBIterator) Current() ([]byte, []byte, bool) {
+	return i.key, i.val, i.valid
+}
+
+func (i *BoltDBIterator) Key() []byte {
+	return i.key
+}
+
+func (i *BoltDBIterator) Value() []byte {
+	return i.val
+}
+
+func (i *BoltDBIterator) Valid() bool {
+	return i.valid
+}
+
+func (i *BoltDBIterator) Close() {
+	i.tx.Commit()
+}

--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -1,0 +1,109 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+package boltdb
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/couchbaselabs/bleve/index/store"
+	"github.com/couchbaselabs/bleve/registry"
+)
+
+const Name = "boltdb"
+
+type BoltDBStore struct {
+	path   string
+	bucket string
+	db     *bolt.DB
+}
+
+func Open(path string, bucket string) (*BoltDBStore, error) {
+	rv := BoltDBStore{
+		path:   path,
+		bucket: bucket,
+	}
+
+	var err error
+	rv.db, err = bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = rv.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(rv.bucket))
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &rv, nil
+}
+
+func (bs *BoltDBStore) Get(key []byte) ([]byte, error) {
+	var rv []byte = nil
+
+	err := bs.db.View(func(tx *bolt.Tx) error {
+		rv = tx.Bucket([]byte(bs.bucket)).Get(key)
+
+		return nil
+	})
+
+	return rv, err
+}
+
+func (bs *BoltDBStore) Set(key, val []byte) error {
+	return bs.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(bs.bucket)).Put(key, val)
+	})
+}
+
+func (bs *BoltDBStore) Delete(key []byte) error {
+	return bs.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(bs.bucket)).Delete(key)
+	})
+}
+
+func (bs *BoltDBStore) Commit() error {
+	return nil
+}
+
+func (bs *BoltDBStore) Close() error {
+	return bs.db.Close()
+}
+
+func (bs *BoltDBStore) Iterator(key []byte) store.KVIterator {
+	rv := newBoltDBIterator(bs)
+	rv.Seek(key)
+	return rv
+}
+
+func (bs *BoltDBStore) NewBatch() store.KVBatch {
+	return newBoltDBBatch(bs)
+}
+
+func StoreConstructor(config map[string]interface{}) (store.KVStore, error) {
+	path, ok := config["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("must specify path")
+	}
+
+	bucket, ok := config["bucket"].(string)
+	if !ok {
+		bucket = "index"
+	}
+
+	return Open(path, bucket)
+}
+
+func init() {
+	registry.RegisterKVStore(Name, StoreConstructor)
+}

--- a/index/store/boltdb/store_test.go
+++ b/index/store/boltdb/store_test.go
@@ -1,0 +1,26 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+package boltdb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/couchbaselabs/bleve/index/store/test"
+)
+
+func TestBoltDBStore(t *testing.T) {
+	s, err := Open("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("test")
+
+	store_test.CommonTestKVStore(t, s)
+}


### PR DESCRIPTION
Does what it says. The tests all pass, but you'll need to tell them to actually use the new backend for them to mean anything. The following patch will do just that:

```
diff --git a/config.go b/config.go
index f93375f..1d24293 100644
--- a/config.go
+++ b/config.go
@@ -82,6 +82,7 @@ import (
    _ "github.com/couchbaselabs/bleve/analysis/language/tr"

    // kv stores
+   _ "github.com/couchbaselabs/bleve/index/store/boltdb"
    _ "github.com/couchbaselabs/bleve/index/store/inmem"
    _ "github.com/couchbaselabs/bleve/index/store/leveldb"
 )
@@ -135,7 +136,7 @@ func init() {
    Config.DefaultHighlighter = &htmlHighlighterName

    // default kv store
-   Config.DefaultKVStore = "leveldb"
+   Config.DefaultKVStore = "boltdb"

    bootDuration := time.Since(bootStart)
    bleveExpVar.Add("bootDuration", int64(bootDuration))
diff --git a/index_meta_test.go b/index_meta_test.go
index b130b6d..a4cf99d 100644
--- a/index_meta_test.go
+++ b/index_meta_test.go
@@ -24,7 +24,7 @@ func TestIndexMeta(t *testing.T) {
    }

    // create meta
-   im := &indexMeta{Storage: "leveldb"}
+   im := &indexMeta{Storage: "boltdb"}
    err = im.Save(testIndexPath)
    if err != nil {
        t.Error(err)
@@ -36,8 +36,8 @@ func TestIndexMeta(t *testing.T) {
    if err != nil {
        t.Error(err)
    }
-   if im.Storage != "leveldb" {
-       t.Errorf("expected storage 'leveldb', got '%s'", im.Storage)
+   if im.Storage != "boltdb" {
+       t.Errorf("expected storage 'boltdb', got '%s'", im.Storage)
    }

    // save a meta that already exists
```
