### PR TITLE
Add a benchmark for the numeric facet builder and use sort.Sort in it (just like for the terms one) 

### DIFF
--- a/search/facets/facet_builder_numeric_test.go
+++ b/search/facets/facet_builder_numeric_test.go
@@ -1,0 +1,49 @@
+package facets
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/blevesearch/bleve/index"
+	nu "github.com/blevesearch/bleve/numeric_util"
+)
+
+var pcodedvalues []nu.PrefixCoded
+
+func init() {
+	pcodedvalues = []nu.PrefixCoded{nu.PrefixCoded{0x20, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1}, nu.PrefixCoded{0x20, 0x0, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f}, nu.PrefixCoded{0x20, 0x0, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7a, 0x1d, 0xa}, nu.PrefixCoded{0x20, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x16, 0x9, 0x4a, 0x7b}}
+}
+
+func BenchmarkNumericFacet10(b *testing.B) {
+	numericFacetN(b, 10)
+}
+
+func BenchmarkNumericFacet100(b *testing.B) {
+	numericFacetN(b, 100)
+}
+
+func BenchmarkNumericFacet1000(b *testing.B) {
+	numericFacetN(b, 1000)
+}
+
+func numericFacetN(b *testing.B, numTerms int) {
+	field := "test"
+	nfb := NewNumericFacetBuilder(field, numTerms)
+	min, max := 0.0, 9999999998.0
+
+	for i := 0; i <= numTerms; i++ {
+		max++
+		min--
+
+		nfb.AddRange("rangename"+strconv.Itoa(i), &min, &max)
+
+		for _, pv := range pcodedvalues {
+			nfb.Update(index.FieldTerms{field: []string{string(pv)}})
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nfb.Result()
+	}
+}


### PR DESCRIPTION
I am not 100% sure that the benchmark is measuring the right thing so some checking would be advised. In its current form it adds 10/100/1000 ranges to the range facet builder and then updates it with a very limited set of 4 prefix coded values over and over again. Afterwards it measures how long the Result() function takes to return its result.

If the benchmark is indeed mimicking real world uses, using the slice-based Result()-implementation is a net win just like with the term facet builder. Here are the numbers (on my i7 under Linux).

Old (using a list):
```
PASS
BenchmarkNumericFacet10   100000             14304 ns/op
BenchmarkNumericFacet100           10000            147730 ns/op
BenchmarkNumericFacet1000            300           4351645 ns/op
...
```

New (using sort.Sort):
```
PASS
BenchmarkNumericFacet10   200000              8603 ns/op
BenchmarkNumericFacet100           20000             73970 ns/op
BenchmarkNumericFacet1000           2000            782526 ns/op
...
```