### PR TITLE
adds isolation to reader of in memory store using copy on write

### DIFF
--- a/index/store/inmem/reader.go
+++ b/index/store/inmem/reader.go
@@ -11,20 +11,23 @@ package inmem
 
 import (
 	"github.com/blevesearch/bleve/index/store"
+	"github.com/ryszard/goskiplist/skiplist"
 )
 
 // "newentry" marks a key which was previously empty, but was populated after the creation of the Reader.
 // If the value stored at the key has changed, the value at the time of creation of the Reader is stored in value.
 type readerValue struct {
-	value    []byte
-	newentry bool
-	deleted  bool
+	value      []byte
+	newentry   bool
+	deleted    bool
+	firstValue bool
+	prevKey    string
 }
 
 // This is the readers copy of the data which has changed after the Reader has been created.
 type readerData struct {
-	valueMap        map[string]*readerValue
-	deletedKeysList []string
+	valueMap                map[string]*readerValue
+	prevValuesOfDeletedKeys *skiplist.SkipList
 }
 
 type Reader struct {
@@ -34,8 +37,8 @@ type Reader struct {
 
 func newReader(store *Store) (*Reader, error) {
 	readerData := readerData{
-		valueMap:        make(map[string]*readerValue),
-		deletedKeysList: make([]string, 0),
+		valueMap:                make(map[string]*readerValue),
+		prevValuesOfDeletedKeys: skiplist.NewStringMap(),
 	}
 	store.readersData[&readerData] = &readerData
 

--- a/index/store/inmem/reader_iterator.go
+++ b/index/store/inmem/reader_iterator.go
@@ -1,0 +1,118 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package inmem
+
+import (
+	"github.com/ryszard/goskiplist/skiplist"
+)
+
+// This iterator uses values stored in a Readers storage to do isolated reads.
+type ReaderIterator struct {
+	store             *Store
+	reader            *Reader
+	iterator          skiplist.Iterator
+	valid             bool
+	fromReaderStorage bool
+	currentKey        string
+	posOnDeletedList  int
+}
+
+func newReaderIterator(store *Store, reader *Reader) *ReaderIterator {
+	rv := ReaderIterator{
+		store:    store,
+		iterator: store.list.Iterator(),
+		reader:   reader,
+	}
+	return &rv
+}
+
+func (i *ReaderIterator) SeekFirst() {
+	i.Seek([]byte{0})
+}
+
+func (i *ReaderIterator) Seek(k []byte) {
+	stringkey := string(k)
+	if i.reader.readerData.valueMap[stringkey] != nil {
+		if i.reader.readerData.valueMap[stringkey].newentry {
+			i.valid = false
+			i.fromReaderStorage = false
+		} else {
+			i.valid = true
+			i.fromReaderStorage = true
+			i.currentKey = stringkey
+		}
+		i.iterator.Seek(stringkey)
+	} else {
+		i.valid = i.iterator.Seek(stringkey)
+		i.fromReaderStorage = false
+	}
+}
+
+func (i *ReaderIterator) Next() {
+	hasNextValue := i.iterator.Next()
+	if hasNextValue {
+		key := i.iterator.Key().(string)
+		if i.reader.readerData.valueMap[key] != nil {
+			if i.reader.readerData.valueMap[key].newentry {
+				i.Next()
+			} else {
+				i.valid = true
+				i.fromReaderStorage = true
+				i.currentKey = key
+			}
+		} else {
+			i.valid = true
+			i.fromReaderStorage = false
+		}
+	} else if i.posOnDeletedList < len(i.reader.readerData.deletedKeysList) {
+		i.valid = true
+		i.fromReaderStorage = true
+		i.currentKey = i.reader.readerData.deletedKeysList[i.posOnDeletedList]
+		i.posOnDeletedList++
+	} else {
+		i.valid = false
+	}
+}
+
+func (i *ReaderIterator) Current() ([]byte, []byte, bool) {
+	if i.valid && i.fromReaderStorage {
+		return []byte(i.currentKey), []byte(i.reader.readerData.valueMap[i.currentKey].value), true
+	} else if i.valid {
+		return []byte(i.Key()), []byte(i.Value()), true
+	}
+	return nil, nil, false
+}
+
+func (i *ReaderIterator) Key() []byte {
+	if i.valid && i.fromReaderStorage {
+		return []byte(i.currentKey)
+	} else if i.valid {
+		return []byte(i.iterator.Key().(string))
+	}
+	return nil
+}
+
+func (i *ReaderIterator) Value() []byte {
+	if i.valid && i.fromReaderStorage {
+		return []byte(i.reader.readerData.valueMap[i.currentKey].value)
+	} else if i.valid {
+		return []byte(i.iterator.Value().(string))
+	}
+	return nil
+}
+
+func (i *ReaderIterator) Valid() bool {
+	return i.valid
+}
+
+func (i *ReaderIterator) Close() error {
+	i.iterator.Close()
+	return nil
+}

--- a/index/store/inmem/store_test.go
+++ b/index/store/inmem/store_test.go
@@ -26,6 +26,16 @@ func TestStore(t *testing.T) {
 	CommonTestKVStore(t, s)
 }
 
+func TestReaderIsolation(t *testing.T) {
+	s, err := Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	CommonTestReaderIsolation(t, s)
+}
+
 func CommonTestKVStore(t *testing.T, s store.KVStore) {
 
 	writer, err := s.Writer()


### PR DESCRIPTION
#118 Currently using inbuilt maps instead of a skip list for the copied elements. As the copied elements are temporary, I thought this would be better. Should I change the implementation to use a skip list?