### PR TITLE
Fix parsing of the ignored ("-") json tag

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -72,6 +72,9 @@ func mustString(data interface{}) (string, bool) {
 
 // parseJSONTagName extracts the JSON field name from a struct tag
 func parseJSONTagName(tag string) string {
+	if tag == "-" {
+		return ""
+	}
 	if idx := strings.Index(tag, ","); idx != -1 {
 		return tag[:idx]
 	}


### PR DESCRIPTION
The current logic will return `-` as the field name for:

```go
type Demo struct {
	IgnoredField string `json:"-"`
}
```

This small change returns an empty string instead, so the that field is 
populated in the index with it's original name.