### PR TITLE
Process pointer fields, rather than trying to walk them

### DIFF
--- a/mapping_document.go
+++ b/mapping_document.go
@@ -251,7 +251,7 @@ func (dm *DocumentMapping) walkDocument(data interface{}, path []string, indexes
 	case reflect.Ptr:
 		ptrElem := val.Elem()
 		if ptrElem.IsValid() && ptrElem.CanInterface() {
-			dm.walkDocument(ptrElem.Interface(), path, indexes, context)
+			dm.processProperty(ptrElem.Interface(), path, indexes, context)
 		}
 	}
 }


### PR DESCRIPTION
Pointers may be references to any type, existing logic will only handle types
understood by `walkDocument`, instead pass the deref'd element to
`processProperty`, where it can get passed back to `walkDocument` if 
necessary, or be processed as a regular field.

I've done some cursory testing and this has fixed issues I was having, but my
testing has not been extensive and it's possible I've missed something.