### PR TITLE
Check all return errors

### DIFF
--- a/index_meta.go
+++ b/index_meta.go
@@ -46,10 +46,10 @@ func openIndexMeta(path string) (*indexMeta, error) {
 	return &im, nil
 }
 
-func (i *indexMeta) Save(path string) error {
+func (i *indexMeta) Save(path string) (err error) {
 	indexMetaPath := indexMetaPath(path)
 	// ensure any necessary parent directories exist
-	err := os.Mkdir(path, 0700)
+	err = os.Mkdir(path, 0700)
 	if err != nil {
 		return ErrorIndexPathExists
 	}
@@ -64,7 +64,11 @@ func (i *indexMeta) Save(path string) error {
 		}
 		return err
 	}
-	defer indexMetaFile.Close()
+	defer func() {
+		if ierr := indexMetaFile.Close(); err == nil && ierr != nil {
+			err = ierr
+		}
+	}()
 	_, err = indexMetaFile.Write(metaBytes)
 	if err != nil {
 		return err


### PR DESCRIPTION
- Fix the following errors found by [errcheck](https://github.com/kisielk/errcheck) :

  ```
  $ bleve git:(master) errcheck github.com/blevesearch/bleve
  github.com/blevesearch/bleve/index_impl.go:206:25  defer indexReader.Close()
  github.com/blevesearch/bleve/index_impl.go:317:25  defer indexReader.Close()
  github.com/blevesearch/bleve/index_impl.go:353:25  defer indexReader.Close()
  github.com/blevesearch/bleve/index_impl.go:359:22  defer searcher.Close()
  github.com/blevesearch/bleve/index_impl.go:497:25  defer indexReader.Close()
  github.com/blevesearch/bleve/index_impl.go:644:20  defer reader.Close()
  github.com/blevesearch/bleve/index_meta.go:67:27   defer indexMetaFile.Close()
  ```

- I've added named return parameters to capture the errors from the deferred calls. Thoughts?