### PR TITLE
fix goleveldb's BytesSafeAfterClose() on reader

### DIFF
--- a/index/store/goleveldb/reader.go
+++ b/index/store/goleveldb/reader.go
@@ -28,7 +28,7 @@ func newReader(store *Store) (*Reader, error) {
 }
 
 func (r *Reader) BytesSafeAfterClose() bool {
-	return true
+	return false
 }
 
 func (r *Reader) Get(key []byte) ([]byte, error) {


### PR DESCRIPTION
I just noticed a mistake on my [previous pull request][1].

 The `func (r *Reader) BytesSafeAfterClose()` should have been set to return `false`.

[1]: https://github.com/blevesearch/bleve/pull/190