### PR TITLE
moves goleveldb to a build tag

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,7 +102,6 @@ import (
 
 	// kv stores
 	_ "github.com/blevesearch/bleve/index/store/boltdb"
-	_ "github.com/blevesearch/bleve/index/store/goleveldb"
 	_ "github.com/blevesearch/bleve/index/store/gtreap"
 	_ "github.com/blevesearch/bleve/index/store/inmem"
 

--- a/config_goleveldb.go
+++ b/config_goleveldb.go
@@ -1,0 +1,21 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+// +build goleveldb full
+
+package bleve
+
+import (
+	_ "github.com/blevesearch/bleve/index/store/goleveldb"
+)
+
+func init() {
+	// install leveldb as the default kv store
+	Config.DefaultKVStore = "goleveldb"
+}


### PR DESCRIPTION
The default k/v store is now boltdb. So it made sense to me to isolate the building of goleveldb to a build tag for those not using goleveldb.


We recently encountered problems using bleve, because of this https://github.com/syndtr/goleveldb/commit/a065095 and this https://github.com/syndtr/goleveldb/commit/ca34d8a. The dependency changes in goleveldb were being picked up by `go get` but confused godeps in ways causing our builds to fail. Since we were not familiar with goleveldb, this caused a lot of build headaches.

That's the problem I'm trying to solve here. I tried to adhere best to the patterns found in the repo about putting this kv store behind a build tag. Please let me know if this makes sense to you!