### PR TITLE
Allow providing a token filter config in custom analyzer

### DIFF
--- a/analysis/analyzers/simple_analyzer/simple_analyzer.go
+++ b/analysis/analyzers/simple_analyzer/simple_analyzer.go
@@ -23,7 +23,7 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/analyzers/standard_analyzer/standard_analyzer.go
+++ b/analysis/analyzers/standard_analyzer/standard_analyzer.go
@@ -24,11 +24,11 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopEnFilter, err := cache.TokenFilterNamed(en.StopName)
+	stopEnFilter, err := cache.TokenFilterNamed(en.StopName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/ar/analyzer_ar.go
+++ b/analysis/language/ar/analyzer_ar.go
@@ -25,20 +25,20 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
 	normalizeFilter := unicode_normalize.MustNewUnicodeNormalizeFilter(unicode_normalize.NFKC)
-	stopArFilter, err := cache.TokenFilterNamed(StopName)
+	stopArFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	normalizeArFilter, err := cache.TokenFilterNamed(NormalizeName)
+	normalizeArFilter, err := cache.TokenFilterNamed(NormalizeName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerArFilter, err := cache.TokenFilterNamed(StemmerName)
+	stemmerArFilter, err := cache.TokenFilterNamed(StemmerName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/cjk/analyzer_cjk.go
+++ b/analysis/language/cjk/analyzer_cjk.go
@@ -26,11 +26,11 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 		return nil, err
 	}
 	normalizeFilter := unicode_normalize.MustNewUnicodeNormalizeFilter(unicode_normalize.NFKD)
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	bigramFilter, err := cache.TokenFilterNamed(BigramName)
+	bigramFilter, err := cache.TokenFilterNamed(BigramName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/en/analyzer_en.go
+++ b/analysis/language/en/analyzer_en.go
@@ -25,19 +25,19 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	possEnFilter, err := cache.TokenFilterNamed(PossessiveName)
+	possEnFilter, err := cache.TokenFilterNamed(PossessiveName, nil)
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopEnFilter, err := cache.TokenFilterNamed(StopName)
+	stopEnFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerEnFilter, err := cache.TokenFilterNamed(porter.Name)
+	stemmerEnFilter, err := cache.TokenFilterNamed(porter.Name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/fr/analyzer_fr.go
+++ b/analysis/language/fr/analyzer_fr.go
@@ -24,19 +24,19 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	elisionFilter, err := cache.TokenFilterNamed(ElisionName)
+	elisionFilter, err := cache.TokenFilterNamed(ElisionName, nil)
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopFrFilter, err := cache.TokenFilterNamed(StopName)
+	stopFrFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerFrFilter, err := cache.TokenFilterNamed(LightStemmerName)
+	stemmerFrFilter, err := cache.TokenFilterNamed(LightStemmerName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/hi/analyzer_hi.go
+++ b/analysis/language/hi/analyzer_hi.go
@@ -25,23 +25,23 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	indicNormalizeFilter, err := cache.TokenFilterNamed(in.NormalizeName)
+	indicNormalizeFilter, err := cache.TokenFilterNamed(in.NormalizeName, nil)
 	if err != nil {
 		return nil, err
 	}
-	hindiNormalizeFilter, err := cache.TokenFilterNamed(NormalizeName)
+	hindiNormalizeFilter, err := cache.TokenFilterNamed(NormalizeName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopHiFilter, err := cache.TokenFilterNamed(StopName)
+	stopHiFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerHiFilter, err := cache.TokenFilterNamed(StemmerName)
+	stemmerHiFilter, err := cache.TokenFilterNamed(StemmerName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/it/analyzer_it.go
+++ b/analysis/language/it/analyzer_it.go
@@ -24,19 +24,19 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	elisionFilter, err := cache.TokenFilterNamed(ElisionName)
+	elisionFilter, err := cache.TokenFilterNamed(ElisionName, nil)
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopItFilter, err := cache.TokenFilterNamed(StopName)
+	stopItFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerItFilter, err := cache.TokenFilterNamed(LightStemmerName)
+	stemmerItFilter, err := cache.TokenFilterNamed(LightStemmerName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/language/pt/analyzer_pt.go
+++ b/analysis/language/pt/analyzer_pt.go
@@ -24,15 +24,15 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 	if err != nil {
 		return nil, err
 	}
-	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name)
+	toLowerFilter, err := cache.TokenFilterNamed(lower_case_filter.Name, nil)
 	if err != nil {
 		return nil, err
 	}
-	stopPtFilter, err := cache.TokenFilterNamed(StopName)
+	stopPtFilter, err := cache.TokenFilterNamed(StopName, nil)
 	if err != nil {
 		return nil, err
 	}
-	stemmerPtFilter, err := cache.TokenFilterNamed(LightStemmerName)
+	stemmerPtFilter, err := cache.TokenFilterNamed(LightStemmerName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -103,8 +103,8 @@ func (c *Cache) DefineTokenMap(name string, config map[string]interface{}) (anal
 	return c.TokenMaps.DefineTokenMap(name, typ, config, c)
 }
 
-func (c *Cache) TokenFilterNamed(name string) (analysis.TokenFilter, error) {
-	return c.TokenFilters.TokenFilterNamed(name, c)
+func (c *Cache) TokenFilterNamed(name string, config map[string]interface{}) (analysis.TokenFilter, error) {
+	return c.TokenFilters.TokenFilterNamed(name, config, c)
 }
 
 func (c *Cache) DefineTokenFilter(name string, config map[string]interface{}) (analysis.TokenFilter, error) {

--- a/registry/token_filter.go
+++ b/registry/token_filter.go
@@ -27,7 +27,7 @@ type TokenFilterConstructor func(config map[string]interface{}, cache *Cache) (a
 type TokenFilterRegistry map[string]TokenFilterConstructor
 type TokenFilterCache map[string]analysis.TokenFilter
 
-func (c TokenFilterCache) TokenFilterNamed(name string, cache *Cache) (analysis.TokenFilter, error) {
+func (c TokenFilterCache) TokenFilterNamed(name string, config map[string]interface{}, cache *Cache) (analysis.TokenFilter, error) {
 	tokenFilter, cached := c[name]
 	if cached {
 		return tokenFilter, nil
@@ -36,7 +36,7 @@ func (c TokenFilterCache) TokenFilterNamed(name string, cache *Cache) (analysis.
 	if !registered {
 		return nil, fmt.Errorf("no token filter with name or type '%s' registered", name)
 	}
-	tokenFilter, err := tokenFilterConstructor(nil, cache)
+	tokenFilter, err := tokenFilterConstructor(config, cache)
 	if err != nil {
 		return nil, fmt.Errorf("error building token filter: %v", err)
 	}


### PR DESCRIPTION
this makes it possible to add a config for token filters when using a custom analyzer, which is necessary for filters such as ngram and edge_ngram