### PR TITLE
reducing allocation count

### DIFF
--- a/index/upside_down/row_test.go
+++ b/index/upside_down/row_test.go
@@ -59,19 +59,19 @@ func TestRows(t *testing.T) {
 			[]byte{3, 195, 235, 163, 130, 4},
 		},
 		{
-			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 3, 3.14, []*TermVector{&TermVector{field: 0, pos: 1, start: 3, end: 11}, &TermVector{field: 0, pos: 2, start: 23, end: 31}, &TermVector{field: 0, pos: 3, start: 43, end: 51}}),
+			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 3, 3.14, []TermVector{TermVector{field: 0, pos: 1, start: 3, end: 11}, TermVector{field: 0, pos: 2, start: 23, end: 31}, TermVector{field: 0, pos: 3, start: 43, end: 51}}),
 			[]byte{'t', 0, 0, 'b', 'e', 'e', 'r', ByteSeparator, 'b', 'u', 'd', 'w', 'e', 'i', 's', 'e', 'r'},
 			[]byte{3, 195, 235, 163, 130, 4, 0, 1, 3, 11, 0, 0, 2, 23, 31, 0, 0, 3, 43, 51, 0},
 		},
 		// test larger varints
 		{
-			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 25896, 3.14, []*TermVector{&TermVector{field: 255, pos: 1, start: 3, end: 11}, &TermVector{field: 0, pos: 2198, start: 23, end: 31}, &TermVector{field: 0, pos: 3, start: 43, end: 51}}),
+			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 25896, 3.14, []TermVector{TermVector{field: 255, pos: 1, start: 3, end: 11}, TermVector{field: 0, pos: 2198, start: 23, end: 31}, TermVector{field: 0, pos: 3, start: 43, end: 51}}),
 			[]byte{'t', 0, 0, 'b', 'e', 'e', 'r', ByteSeparator, 'b', 'u', 'd', 'w', 'e', 'i', 's', 'e', 'r'},
 			[]byte{168, 202, 1, 195, 235, 163, 130, 4, 255, 1, 1, 3, 11, 0, 0, 150, 17, 23, 31, 0, 0, 3, 43, 51, 0},
 		},
 		// test vectors with arrayPositions
 		{
-			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 25896, 3.14, []*TermVector{&TermVector{field: 255, pos: 1, start: 3, end: 11, arrayPositions: []uint64{0}}, &TermVector{field: 0, pos: 2198, start: 23, end: 31, arrayPositions: []uint64{1, 2}}, &TermVector{field: 0, pos: 3, start: 43, end: 51, arrayPositions: []uint64{3, 4, 5}}}),
+			NewTermFrequencyRowWithTermVectors([]byte{'b', 'e', 'e', 'r'}, 0, "budweiser", 25896, 3.14, []TermVector{TermVector{field: 255, pos: 1, start: 3, end: 11, arrayPositions: []uint64{0}}, TermVector{field: 0, pos: 2198, start: 23, end: 31, arrayPositions: []uint64{1, 2}}, TermVector{field: 0, pos: 3, start: 43, end: 51, arrayPositions: []uint64{3, 4, 5}}}),
 			[]byte{'t', 0, 0, 'b', 'e', 'e', 'r', ByteSeparator, 'b', 'u', 'd', 'w', 'e', 'i', 's', 'e', 'r'},
 			[]byte{168, 202, 1, 195, 235, 163, 130, 4, 255, 1, 1, 3, 11, 1, 0, 0, 150, 17, 23, 31, 2, 1, 2, 0, 3, 43, 51, 3, 3, 4, 5},
 		},
@@ -263,20 +263,20 @@ func BenchmarkTermFrequencyRowEncode(b *testing.B) {
 			"budweiser",
 			3,
 			3.14,
-			[]*TermVector{
-				&TermVector{
+			[]TermVector{
+				TermVector{
 					field: 0,
 					pos:   1,
 					start: 3,
 					end:   11,
 				},
-				&TermVector{
+				TermVector{
 					field: 0,
 					pos:   2,
 					start: 23,
 					end:   31,
 				},
-				&TermVector{
+				TermVector{
 					field: 0,
 					pos:   3,
 					start: 43,

--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -541,8 +541,8 @@ func frequencyFromTokenFreq(tf *analysis.TokenFreq) int {
 	return len(tf.Locations)
 }
 
-func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFreq) ([]*TermVector, []index.IndexRow) {
-	rv := make([]*TermVector, len(tf.Locations))
+func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFreq) ([]TermVector, []index.IndexRow) {
+	rv := make([]TermVector, len(tf.Locations))
 	newFieldRows := make([]index.IndexRow, 0)
 
 	for i, l := range tf.Locations {
@@ -555,20 +555,19 @@ func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.
 				newFieldRows = append(newFieldRows, newFieldRow)
 			}
 		}
-		tv := TermVector{
+		rv[i] = TermVector{
 			field:          fieldIndex,
 			arrayPositions: l.ArrayPositions,
 			pos:            uint64(l.Position),
 			start:          uint64(l.Start),
 			end:            uint64(l.End),
 		}
-		rv[i] = &tv
 	}
 
 	return rv, newFieldRows
 }
 
-func (udc *UpsideDownCouch) termFieldVectorsFromTermVectors(in []*TermVector) []*index.TermFieldVector {
+func (udc *UpsideDownCouch) termFieldVectorsFromTermVectors(in []TermVector) []*index.TermFieldVector {
 	rv := make([]*index.TermFieldVector, len(in))
 
 	for i, tv := range in {


### PR DESCRIPTION
Hello.

Found this by benchmarking my code which puts documents into bleve index. mallocgc and its friends are at the top of my CPU profile and it looks like bleve does too much allocations. This simple path significantly decrease allocations count in my test case.