### PR TITLE
reducing allocation count

### DIFF
--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -408,10 +408,10 @@ func encodeFieldType(f document.Field) byte {
 func (udc *UpsideDownCouch) indexField(docID string, field document.Field, fieldIndex uint16, fieldLength int, tokenFreqs analysis.TokenFrequencies) ([]index.IndexRow, []*BackIndexTermEntry) {
 
 	rows := make([]index.IndexRow, 0, 100)
-	backIndexTermEntries := make([]*BackIndexTermEntry, 0)
+	backIndexTermEntries := make([]*BackIndexTermEntry, 0, len(tokenFreqs))
 	fieldNorm := float32(1.0 / math.Sqrt(float64(fieldLength)))
 
-	for _, tf := range tokenFreqs {
+	for k, tf := range tokenFreqs {
 		var termFreqRow *TermFrequencyRow
 		if field.Options().IncludeTermVectors() {
 			tv, newFieldRows := udc.termVectorsFromTokenFreq(fieldIndex, tf)
@@ -422,7 +422,7 @@ func (udc *UpsideDownCouch) indexField(docID string, field document.Field, field
 		}
 
 		// record the back index entry
-		backIndexTermEntry := BackIndexTermEntry{Term: proto.String(string(tf.Term)), Field: proto.Uint32(uint32(fieldIndex))}
+		backIndexTermEntry := BackIndexTermEntry{Term: proto.String(k), Field: proto.Uint32(uint32(fieldIndex))}
 		backIndexTermEntries = append(backIndexTermEntries, &backIndexTermEntry)
 
 		rows = append(rows, termFreqRow)


### PR DESCRIPTION
A tiny but steady improvement with no drawbacks.

benchmark                                         old ns/op      new ns/op      delta
BenchmarkAnalyze-2                                192633         184437         -4.25%
BenchmarkBoltDBIndexing1Workers-2                 9091553        8996297        -1.05%
BenchmarkBoltDBIndexing2Workers-2                 9076242        8990708        -0.94%
BenchmarkBoltDBIndexing4Workers-2                 9093248        9045758        -0.52%
BenchmarkBoltDBIndexing1Workers10Batch-2          1372212200     1381494457     +0.68%
BenchmarkBoltDBIndexing2Workers10Batch-2          1412452640     1424967303     +0.89%
BenchmarkBoltDBIndexing4Workers10Batch-2          1381424061     1409152830     +2.01%
BenchmarkBoltDBIndexing1Workers100Batch-2         322874392      332115494      +2.86%
BenchmarkBoltDBIndexing2Workers100Batch-2         320599483      328787705      +2.55%
BenchmarkBoltDBIndexing4Workers100Batch-2         306871434      320076841      +4.30%
BenchmarkBoltBIndexing1Workers1000Batch-2         909362088      888288819      -2.32%
BenchmarkBoltBIndexing2Workers1000Batch-2         895242861      899526602      +0.48%
BenchmarkBoltBIndexing4Workers1000Batch-2         907095230      892011779      -1.66%
BenchmarkGoLevelDBIndexing1Workers-2              3727514        3734672        +0.19%
BenchmarkGoLevelDBIndexing2Workers-2              3772169        3750031        -0.59%
BenchmarkGoLevelDBIndexing4Workers-2              3744232        3726155        -0.48%
BenchmarkGoLevelDBIndexing1Workers10Batch-2       599887224      596686463      -0.53%
BenchmarkGoLevelDBIndexing2Workers10Batch-2       603573765      601208436      -0.39%
BenchmarkGoLevelDBIndexing4Workers10Batch-2       600302099      585272579      -2.50%
BenchmarkGoLevelDBIndexing1Workers100Batch-2      174444254      171295889      -1.80%
BenchmarkGoLevelDBIndexing2Workers100Batch-2      172800642      170478017      -1.34%
BenchmarkGoLevelDBIndexing4Workers100Batch-2      165824028      162483103      -2.01%
BenchmarkGoLevelDBIndexing1Workers1000Batch-2     144710153      137992262      -4.64%
BenchmarkGoLevelDBIndexing2Workers1000Batch-2     143512916      137877715      -3.93%
BenchmarkGoLevelDBIndexing4Workers1000Batch-2     129383069      128520203      -0.67%
BenchmarkGTreapIndexing1Workers-2                 204432         202456         -0.97%
BenchmarkGTreapIndexing2Workers-2                 207990         205478         -1.21%
BenchmarkGTreapIndexing4Workers-2                 208662         206550         -1.01%
BenchmarkGTreapIndexing1Workers10Batch-2          405501218      407618315      +0.52%
BenchmarkGTreapIndexing2Workers10Batch-2          414820549      393666065      -5.10%
BenchmarkGTreapIndexing4Workers10Batch-2          398613394      378142258      -5.14%
BenchmarkGTreapIndexing1Workers100Batch-2         303719545      289611008      -4.65%
BenchmarkGTreapIndexing2Workers100Batch-2         309894871      296176494      -4.43%
BenchmarkGTreapIndexing4Workers100Batch-2         306117177      290536869      -5.09%
BenchmarkGTreapIndexing1Workers1000Batch-2        322844935      278049917      -13.88%
BenchmarkGTreapIndexing2Workers1000Batch-2        286877834      280594079      -2.19%
BenchmarkGTreapIndexing4Workers1000Batch-2        278388784      272843831      -1.99%
BenchmarkInMemIndexing1Workers-2                  210767         206909         -1.83%
BenchmarkInMemIndexing2Workers-2                  211334         210952         -0.18%
BenchmarkInMemIndexing4Workers-2                  213593         211541         -0.96%
BenchmarkInMemIndexing1Workers10Batch-2           309611794      293996118      -5.04%
BenchmarkInMemIndexing2Workers10Batch-2           305189010      291845101      -4.37%
BenchmarkInMemIndexing4Workers10Batch-2           312067276      285839028      -8.40%
BenchmarkInMemIndexing1Workers100Batch-2          287349687      201508614      -29.87%
BenchmarkInMemIndexing2Workers100Batch-2          281798978      201059534      -28.65%
BenchmarkInMemIndexing4Workers100Batch-2          286904858      194726050      -32.13%
BenchmarkInMemIndexing1Workers1000Batch-2         278270474      207769637      -25.34%
BenchmarkInMemIndexing2Workers1000Batch-2         319303856      197314221      -38.20%
BenchmarkInMemIndexing4Workers1000Batch-2         214821485      191429308      -10.89%
BenchmarkNullIndexing1Workers-2                   129710         118854         -8.37%
BenchmarkNullIndexing2Workers-2                   135306         118393         -12.50%
BenchmarkNullIndexing4Workers-2                   117998         115142         -2.42%
BenchmarkNullIndexing1Workers10Batch-2            75960776       73442609       -3.32%
BenchmarkNullIndexing2Workers10Batch-2            94350656       70598480       -25.17%
BenchmarkNullIndexing4Workers10Batch-2            81013945       63747725       -21.31%
BenchmarkNullIndexing1Workers100Batch-2           93836005       77278997       -17.64%
BenchmarkNullIndexing2Workers100Batch-2           87438080       77017690       -11.92%
BenchmarkNullIndexing4Workers100Batch-2           91671980       68941619       -24.80%
BenchmarkNullIndexing1Workers1000Batch-2          129534757      105711288      -18.39%
BenchmarkNullIndexing2Workers1000Batch-2          107038738      104490343      -2.38%
BenchmarkNullIndexing4Workers1000Batch-2          118099734      94539054       -19.95%
BenchmarkTermFrequencyRowEncode-2                 996            828            -16.87%
BenchmarkTermFrequencyRowDecode-2                 1383           1174           -15.11%
BenchmarkBackIndexRowEncode-2                     1149           879            -23.50%
BenchmarkBackIndexRowDecode-2                     1478           1318           -10.83%
BenchmarkStoredRowEncode-2                        393            336            -14.50%
BenchmarkStoredRowDecode-2                        941            769            -18.28%
BenchmarkBatch-2                                  44600032       37661914       -15.56%

benchmark                                         old allocs     new allocs     delta
BenchmarkAnalyze-2                                1142           1044           -8.58%
BenchmarkBoltDBIndexing1Workers-2                 628            609            -3.03%
BenchmarkBoltDBIndexing2Workers-2                 628            609            -3.03%
BenchmarkBoltDBIndexing4Workers-2                 628            609            -3.03%
BenchmarkBoltDBIndexing1Workers10Batch-2          770568         747645         -2.97%
BenchmarkBoltDBIndexing2Workers10Batch-2          770636         747620         -2.99%
BenchmarkBoltDBIndexing4Workers10Batch-2          770577         747710         -2.97%
BenchmarkBoltDBIndexing1Workers100Batch-2         586200         563291         -3.91%
BenchmarkBoltDBIndexing2Workers100Batch-2         586190         563282         -3.91%
BenchmarkBoltDBIndexing4Workers100Batch-2         586190         563288         -3.91%
BenchmarkBoltBIndexing1Workers1000Batch-2         911842         888970         -2.51%
BenchmarkBoltBIndexing2Workers1000Batch-2         911839         888951         -2.51%
BenchmarkBoltBIndexing4Workers1000Batch-2         911853         888970         -2.51%
BenchmarkGoLevelDBIndexing1Workers-2              515            496            -3.69%
BenchmarkGoLevelDBIndexing2Workers-2              515            496            -3.69%
BenchmarkGoLevelDBIndexing4Workers-2              515            496            -3.69%
BenchmarkGoLevelDBIndexing1Workers10Batch-2       597567         574633         -3.84%
BenchmarkGoLevelDBIndexing2Workers10Batch-2       597548         574663         -3.83%
BenchmarkGoLevelDBIndexing4Workers10Batch-2       597545         574662         -3.83%
BenchmarkGoLevelDBIndexing1Workers100Batch-2      418568         395666         -5.47%
BenchmarkGoLevelDBIndexing2Workers100Batch-2      418570         395670         -5.47%
BenchmarkGoLevelDBIndexing4Workers100Batch-2      418572         395674         -5.47%
BenchmarkGoLevelDBIndexing1Workers1000Batch-2     400497         377595         -5.72%
BenchmarkGoLevelDBIndexing2Workers1000Batch-2     400525         377605         -5.72%
BenchmarkGoLevelDBIndexing4Workers1000Batch-2     400494         377598         -5.72%
BenchmarkGTreapIndexing1Workers-2                 800            782            -2.25%
BenchmarkGTreapIndexing2Workers-2                 801            782            -2.37%
BenchmarkGTreapIndexing4Workers-2                 801            782            -2.37%
BenchmarkGTreapIndexing1Workers10Batch-2          1580630        1568622        -0.76%
BenchmarkGTreapIndexing2Workers10Batch-2          1613780        1559073        -3.39%
BenchmarkGTreapIndexing4Workers10Batch-2          1549053        1540845        -0.53%
BenchmarkGTreapIndexing1Workers100Batch-2         1152099        1122951        -2.53%
BenchmarkGTreapIndexing2Workers100Batch-2         1147898        1139438        -0.74%
BenchmarkGTreapIndexing4Workers100Batch-2         1142449        1123986        -1.62%
BenchmarkGTreapIndexing1Workers1000Batch-2        1087725        1067285        -1.88%
BenchmarkGTreapIndexing2Workers1000Batch-2        1091188        1083324        -0.72%
BenchmarkGTreapIndexing4Workers1000Batch-2        1085532        1067130        -1.70%
BenchmarkInMemIndexing1Workers-2                  684            665            -2.78%
BenchmarkInMemIndexing2Workers-2                  683            664            -2.78%
BenchmarkInMemIndexing4Workers-2                  683            664            -2.78%
BenchmarkInMemIndexing1Workers10Batch-2           762004         739107         -3.00%
BenchmarkInMemIndexing2Workers10Batch-2           761999         739099         -3.01%
BenchmarkInMemIndexing4Workers10Batch-2           762006         739099         -3.01%
BenchmarkInMemIndexing1Workers100Batch-2          557191         534293         -4.11%
BenchmarkInMemIndexing2Workers100Batch-2          557218         534303         -4.11%
BenchmarkInMemIndexing4Workers100Batch-2          557239         534310         -4.11%
BenchmarkInMemIndexing1Workers1000Batch-2         536582         513668         -4.27%
BenchmarkInMemIndexing2Workers1000Batch-2         536583         513670         -4.27%
BenchmarkInMemIndexing4Workers1000Batch-2         536587         513672         -4.27%
BenchmarkNullIndexing1Workers-2                   282            263            -6.74%
BenchmarkNullIndexing2Workers-2                   282            263            -6.74%
BenchmarkNullIndexing4Workers-2                   282            263            -6.74%
BenchmarkNullIndexing1Workers10Batch-2            341760         318864         -6.70%
BenchmarkNullIndexing2Workers10Batch-2            341769         318861         -6.70%
BenchmarkNullIndexing4Workers10Batch-2            341761         318862         -6.70%
BenchmarkNullIndexing1Workers100Batch-2           339660         316756         -6.74%
BenchmarkNullIndexing2Workers100Batch-2           339657         316755         -6.74%
BenchmarkNullIndexing4Workers100Batch-2           339669         316751         -6.75%
BenchmarkNullIndexing1Workers1000Batch-2          339300         316392         -6.75%
BenchmarkNullIndexing2Workers1000Batch-2          339303         316400         -6.75%
BenchmarkNullIndexing4Workers1000Batch-2          339303         316401         -6.75%
BenchmarkTermFrequencyRowEncode-2                 5              5              +0.00%
BenchmarkTermFrequencyRowDecode-2                 8              8              +0.00%
BenchmarkBackIndexRowEncode-2                     8              8              +0.00%
BenchmarkBackIndexRowDecode-2                     13             13             +0.00%
BenchmarkStoredRowEncode-2                        4              4              +0.00%
BenchmarkStoredRowDecode-2                        6              6              +0.00%
BenchmarkBatch-2                                  151161         141360         -6.48%

benchmark                                         old bytes     new bytes     delta
BenchmarkAnalyze-2                                61879         59151         -4.41%
BenchmarkBoltDBIndexing1Workers-2                 61178         60778         -0.65%
BenchmarkBoltDBIndexing2Workers-2                 61187         60820         -0.60%
BenchmarkBoltDBIndexing4Workers-2                 61183         60795         -0.63%
BenchmarkBoltDBIndexing1Workers10Batch-2          244357048     243818232     -0.22%
BenchmarkBoltDBIndexing2Workers10Batch-2          244370496     243810480     -0.23%
BenchmarkBoltDBIndexing4Workers10Batch-2          244363720     243840984     -0.21%
BenchmarkBoltDBIndexing1Workers100Batch-2         49256998      48725054      -1.08%
BenchmarkBoltDBIndexing2Workers100Batch-2         49253238      48722300      -1.08%
BenchmarkBoltDBIndexing4Workers100Batch-2         49253336      48722283      -1.08%
BenchmarkBoltBIndexing1Workers1000Batch-2         43856968      43334064      -1.19%
BenchmarkBoltBIndexing2Workers1000Batch-2         43855136      43330040      -1.20%
BenchmarkBoltBIndexing4Workers1000Batch-2         43861984      43333224      -1.21%
BenchmarkGoLevelDBIndexing1Workers-2              39506         39119         -0.98%
BenchmarkGoLevelDBIndexing2Workers-2              39511         39123         -0.98%
BenchmarkGoLevelDBIndexing4Workers-2              39520         39131         -0.98%
BenchmarkGoLevelDBIndexing1Workers10Batch-2       42059424      41531440      -1.26%
BenchmarkGoLevelDBIndexing2Workers10Batch-2       42062664      41571840      -1.17%
BenchmarkGoLevelDBIndexing4Workers10Batch-2       42058376      41615304      -1.05%
BenchmarkGoLevelDBIndexing1Workers100Batch-2      28855233      28250606      -2.10%
BenchmarkGoLevelDBIndexing2Workers100Batch-2      28815118      28368216      -1.55%
BenchmarkGoLevelDBIndexing4Workers100Batch-2      28809640      28415345      -1.37%
BenchmarkGoLevelDBIndexing1Workers1000Batch-2     29673180      29203800      -1.58%
BenchmarkGoLevelDBIndexing2Workers1000Batch-2     29508009      29023867      -1.64%
BenchmarkGoLevelDBIndexing4Workers1000Batch-2     29490881      29082859      -1.38%
BenchmarkGTreapIndexing1Workers-2                 48018         47670         -0.72%
BenchmarkGTreapIndexing2Workers-2                 48063         47699         -0.76%
BenchmarkGTreapIndexing4Workers-2                 48030         47674         -0.74%
BenchmarkGTreapIndexing1Workers10Batch-2          79925093      79912720      -0.02%
BenchmarkGTreapIndexing2Workers10Batch-2          81516245      79457786      -2.53%
BenchmarkGTreapIndexing4Workers10Batch-2          78412240      78584373      +0.22%
BenchmarkGTreapIndexing1Workers100Batch-2         57312806      56483014      -1.45%
BenchmarkGTreapIndexing2Workers100Batch-2         57110060      57274432      +0.29%
BenchmarkGTreapIndexing4Workers100Batch-2         56847612      56535254      -0.55%
BenchmarkGTreapIndexing1Workers1000Batch-2        54940379      54528648      -0.75%
BenchmarkGTreapIndexing2Workers1000Batch-2        55105681      55295966      +0.35%
BenchmarkGTreapIndexing4Workers1000Batch-2        54834139      54519604      -0.57%
BenchmarkInMemIndexing1Workers-2                  54396         54037         -0.66%
BenchmarkInMemIndexing2Workers-2                  54395         54035         -0.66%
BenchmarkInMemIndexing4Workers-2                  54394         54037         -0.66%
BenchmarkInMemIndexing1Workers10Batch-2           49459148      48931043      -1.07%
BenchmarkInMemIndexing2Workers10Batch-2           49457923      48927795      -1.07%
BenchmarkInMemIndexing4Workers10Batch-2           49459561      48928697      -1.07%
BenchmarkInMemIndexing1Workers100Batch-2          36932524      36403136      -1.43%
BenchmarkInMemIndexing2Workers100Batch-2          36938198      36405308      -1.44%
BenchmarkInMemIndexing4Workers100Batch-2          36938979      36406544      -1.44%
BenchmarkInMemIndexing1Workers1000Batch-2         36598897      36067652      -1.45%
BenchmarkInMemIndexing2Workers1000Batch-2         36599153      36067436      -1.45%
BenchmarkInMemIndexing4Workers1000Batch-2         36599579      36067852      -1.45%
BenchmarkNullIndexing1Workers-2                   15277         14917         -2.36%
BenchmarkNullIndexing2Workers-2                   15277         14917         -2.36%
BenchmarkNullIndexing4Workers-2                   15276         14916         -2.36%
BenchmarkNullIndexing1Workers10Batch-2            19239584      18710536      -2.75%
BenchmarkNullIndexing2Workers10Batch-2            19240336      18710001      -2.76%
BenchmarkNullIndexing4Workers10Batch-2            19239577      18710192      -2.75%
BenchmarkNullIndexing1Workers100Batch-2           19689286      19159476      -2.69%
BenchmarkNullIndexing2Workers100Batch-2           19689380      19159124      -2.69%
BenchmarkNullIndexing4Workers100Batch-2           19690152      19157661      -2.70%
BenchmarkNullIndexing1Workers1000Batch-2          19988507      19457340      -2.66%
BenchmarkNullIndexing2Workers1000Batch-2          19988916      19458641      -2.65%
BenchmarkNullIndexing4Workers1000Batch-2          20017532      19488491      -2.64%
BenchmarkTermFrequencyRowEncode-2                 400           400           +0.00%
BenchmarkTermFrequencyRowDecode-2                 376           376           +0.00%
BenchmarkBackIndexRowEncode-2                     256           256           +0.00%
BenchmarkBackIndexRowDecode-2                     400           400           +0.00%
BenchmarkStoredRowEncode-2                        80            80            +0.00%
BenchmarkStoredRowDecode-2                        288           288           +0.00%
BenchmarkBatch-2                                  7726140       7453378       -3.53%