### PR TITLE
upside_down: no need for a goroutine to enqueue AnalysisWork

### DIFF
--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -265,9 +265,7 @@ func (udc *UpsideDownCouch) Update(doc *document.Document) (err error) {
 	resultChan := make(chan *index.AnalysisResult)
 	aw := index.NewAnalysisWork(udc, doc, resultChan)
 	// put the work on the queue
-	go func() {
-		udc.analysisQueue.Queue(aw)
-	}()
+	udc.analysisQueue.Queue(aw)
 
 	// wait for the result
 	result := <-resultChan


### PR DESCRIPTION
It boils down to:
1. client sends some work and a notification channel to a single worker,
   then waits.
2. worker processes the work
3. worker sends the result to the client using the notification channel

I do not see any problem with this, even with unbuffered channels.