### PR TITLE
Add search for dates and times.

### DIFF
--- a/query_string.nn.go
+++ b/query_string.nn.go
@@ -26,6 +26,8 @@ type lexer struct {
 	// Since then, I introduced the built-in Line() and Column() functions.
 	l, c int
 
+	parseResult interface{}
+
 	// The following line makes it easy for scripts to insert fields in the
 	// generated code.
 	// [NEX_END_OF_LEXER_STRUCT]
@@ -162,7 +164,7 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 	}
 	go scan(bufio.NewReader(in), yylex.ch, []dfa{
 		// \"((\\\")|(\\\\)|(\\\/)|(\\b)|(\\f)|(\\n)|(\\r)|(\\t)|(\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])|[^\"])*\"
-		{[]bool{false, false, true, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false}, []func(rune) int{ // Transitions
+		{[]bool{false, false, true, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false}, []func(rune) int{ // Transitions
 			func(r rune) int {
 				switch r {
 				case 34:
@@ -185,68 +187,6 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 					return -1
 				}
 				switch {
-				case 65 <= r && r <= 70:
-					return -1
-				case 48 <= r && r <= 57:
-					return -1
-				case 97 <= r && r <= 102:
-					return -1
-				}
-				return -1
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return -1
-				case 47:
-					return -1
-				case 92:
-					return -1
-				case 98:
-					return -1
-				case 102:
-					return -1
-				case 110:
-					return -1
-				case 114:
-					return -1
-				case 116:
-					return -1
-				case 117:
-					return -1
-				}
-				switch {
 				case 97 <= r && r <= 102:
 					return -1
 				case 65 <= r && r <= 70:
@@ -280,9 +220,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 3
-				case 48 <= r && r <= 57:
-					return 3
 				case 65 <= r && r <= 70:
+					return 3
+				case 48 <= r && r <= 57:
 					return 3
 				}
 				return 3
@@ -290,209 +230,271 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 			func(r rune) int {
 				switch r {
 				case 34:
-					return 6
+					return -1
 				case 47:
-					return 7
+					return -1
+				case 92:
+					return -1
+				case 98:
+					return -1
+				case 102:
+					return -1
+				case 110:
+					return -1
+				case 114:
+					return -1
+				case 116:
+					return -1
+				case 117:
+					return -1
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return -1
+				case 48 <= r && r <= 57:
+					return -1
+				case 65 <= r && r <= 70:
+					return -1
+				}
+				return -1
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 5
+				case 47:
+					return 11
 				case 92:
 					return 10
 				case 98:
-					return 11
-				case 102:
 					return 12
+				case 102:
+					return 6
 				case 110:
-					return 8
+					return 13
 				case 114:
 					return 9
 				case 116:
-					return 13
-				case 117:
-					return 5
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 14
-				case 102:
-					return 14
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 14
-				case 65 <= r && r <= 70:
-					return 14
-				case 48 <= r && r <= 57:
-					return 14
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 6
-				case 47:
 					return 7
+				case 117:
+					return 8
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 14
+				case 102:
+					return 14
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 14
+				case 65 <= r && r <= 70:
+					return 14
+				case 48 <= r && r <= 57:
+					return 14
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 5
+				case 47:
+					return 11
 				case 92:
 					return 10
 				case 98:
-					return 11
-				case 102:
 					return 12
+				case 102:
+					return 6
 				case 110:
-					return 8
+					return 13
 				case 114:
 					return 9
 				case 116:
-					return 13
+					return 7
 				case 117:
-					return 5
+					return 8
 				}
 				switch {
 				case 97 <= r && r <= 102:
@@ -500,37 +502,6 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				case 65 <= r && r <= 70:
 					return 3
 				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				case 65 <= r && r <= 70:
 					return 3
 				}
 				return 3
@@ -588,9 +559,40 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 					return 3
 				}
 				switch {
+				case 97 <= r && r <= 102:
+					return 3
 				case 65 <= r && r <= 70:
 					return 3
 				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
 					return 3
 				case 97 <= r && r <= 102:
 					return 3
@@ -621,9 +623,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 15
-				case 48 <= r && r <= 57:
-					return 15
 				case 65 <= r && r <= 70:
+					return 15
+				case 48 <= r && r <= 57:
 					return 15
 				}
 				return 3
@@ -652,9 +654,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 16
-				case 65 <= r && r <= 70:
-					return 16
 				case 48 <= r && r <= 57:
+					return 16
+				case 65 <= r && r <= 70:
 					return 16
 				}
 				return 3
@@ -1234,12 +1236,18 @@ func (yylex *lexer) Text() string {
 // Line returns the current line number.
 // The first line is 0.
 func (yylex *lexer) Line() int {
+	if len(yylex.stack) == 0 {
+		return 0
+	}
 	return yylex.stack[len(yylex.stack)-1].line
 }
 
 // Column returns the current column number.
 // The first column is 0.
 func (yylex *lexer) Column() int {
+	if len(yylex.stack) == 0 {
+		return 0
+	}
 	return yylex.stack[len(yylex.stack)-1].column
 }
 

--- a/query_string.nn.go
+++ b/query_string.nn.go
@@ -26,8 +26,6 @@ type lexer struct {
 	// Since then, I introduced the built-in Line() and Column() functions.
 	l, c int
 
-	parseResult interface{}
-
 	// The following line makes it easy for scripts to insert fields in the
 	// generated code.
 	// [NEX_END_OF_LEXER_STRUCT]
@@ -164,7 +162,7 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 	}
 	go scan(bufio.NewReader(in), yylex.ch, []dfa{
 		// \"((\\\")|(\\\\)|(\\\/)|(\\b)|(\\f)|(\\n)|(\\r)|(\\t)|(\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])|[^\"])*\"
-		{[]bool{false, false, true, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false}, []func(rune) int{ // Transitions
+		{[]bool{false, false, true, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false}, []func(rune) int{ // Transitions
 			func(r rune) int {
 				switch r {
 				case 34:
@@ -187,6 +185,68 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 					return -1
 				}
 				switch {
+				case 65 <= r && r <= 70:
+					return -1
+				case 48 <= r && r <= 57:
+					return -1
+				case 97 <= r && r <= 102:
+					return -1
+				}
+				return -1
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return -1
+				case 47:
+					return -1
+				case 92:
+					return -1
+				case 98:
+					return -1
+				case 102:
+					return -1
+				case 110:
+					return -1
+				case 114:
+					return -1
+				case 116:
+					return -1
+				case 117:
+					return -1
+				}
+				switch {
 				case 97 <= r && r <= 102:
 					return -1
 				case 65 <= r && r <= 70:
@@ -220,9 +280,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 3
-				case 65 <= r && r <= 70:
-					return 3
 				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
 					return 3
 				}
 				return 3
@@ -230,271 +290,209 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 			func(r rune) int {
 				switch r {
 				case 34:
-					return -1
+					return 6
 				case 47:
-					return -1
-				case 92:
-					return -1
-				case 98:
-					return -1
-				case 102:
-					return -1
-				case 110:
-					return -1
-				case 114:
-					return -1
-				case 116:
-					return -1
-				case 117:
-					return -1
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return -1
-				case 48 <= r && r <= 57:
-					return -1
-				case 65 <= r && r <= 70:
-					return -1
-				}
-				return -1
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 5
-				case 47:
-					return 11
+					return 7
 				case 92:
 					return 10
 				case 98:
-					return 12
+					return 11
 				case 102:
-					return 6
+					return 12
 				case 110:
-					return 13
+					return 8
 				case 114:
 					return 9
 				case 116:
-					return 7
+					return 13
 				case 117:
-					return 8
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 3
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 14
-				case 102:
-					return 14
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 97 <= r && r <= 102:
-					return 14
-				case 65 <= r && r <= 70:
-					return 14
-				case 48 <= r && r <= 57:
-					return 14
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
-					return 3
-				case 97 <= r && r <= 102:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
 					return 5
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
 				case 47:
-					return 11
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 14
+				case 102:
+					return 14
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 14
+				case 65 <= r && r <= 70:
+					return 14
+				case 48 <= r && r <= 57:
+					return 14
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 97 <= r && r <= 102:
+					return 3
+				case 48 <= r && r <= 57:
+					return 3
+				case 65 <= r && r <= 70:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 6
+				case 47:
+					return 7
 				case 92:
 					return 10
 				case 98:
-					return 12
+					return 11
 				case 102:
-					return 6
+					return 12
 				case 110:
-					return 13
+					return 8
 				case 114:
 					return 9
 				case 116:
-					return 7
+					return 13
 				case 117:
-					return 8
+					return 5
 				}
 				switch {
 				case 97 <= r && r <= 102:
@@ -502,6 +500,37 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				case 65 <= r && r <= 70:
 					return 3
 				case 48 <= r && r <= 57:
+					return 3
+				}
+				return 3
+			},
+			func(r rune) int {
+				switch r {
+				case 34:
+					return 2
+				case 47:
+					return 3
+				case 92:
+					return 4
+				case 98:
+					return 3
+				case 102:
+					return 3
+				case 110:
+					return 3
+				case 114:
+					return 3
+				case 116:
+					return 3
+				case 117:
+					return 3
+				}
+				switch {
+				case 48 <= r && r <= 57:
+					return 3
+				case 97 <= r && r <= 102:
+					return 3
+				case 65 <= r && r <= 70:
 					return 3
 				}
 				return 3
@@ -559,40 +588,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 					return 3
 				}
 				switch {
-				case 97 <= r && r <= 102:
-					return 3
 				case 65 <= r && r <= 70:
 					return 3
 				case 48 <= r && r <= 57:
-					return 3
-				}
-				return 3
-			},
-			func(r rune) int {
-				switch r {
-				case 34:
-					return 2
-				case 47:
-					return 3
-				case 92:
-					return 4
-				case 98:
-					return 3
-				case 102:
-					return 3
-				case 110:
-					return 3
-				case 114:
-					return 3
-				case 116:
-					return 3
-				case 117:
-					return 3
-				}
-				switch {
-				case 48 <= r && r <= 57:
-					return 3
-				case 65 <= r && r <= 70:
 					return 3
 				case 97 <= r && r <= 102:
 					return 3
@@ -623,9 +621,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 15
-				case 65 <= r && r <= 70:
-					return 15
 				case 48 <= r && r <= 57:
+					return 15
+				case 65 <= r && r <= 70:
 					return 15
 				}
 				return 3
@@ -654,9 +652,9 @@ func newLexerWithInit(in io.Reader, initFun func(*lexer)) *lexer {
 				switch {
 				case 97 <= r && r <= 102:
 					return 16
-				case 48 <= r && r <= 57:
-					return 16
 				case 65 <= r && r <= 70:
+					return 16
+				case 48 <= r && r <= 57:
 					return 16
 				}
 				return 3
@@ -1236,18 +1234,12 @@ func (yylex *lexer) Text() string {
 // Line returns the current line number.
 // The first line is 0.
 func (yylex *lexer) Line() int {
-	if len(yylex.stack) == 0 {
-		return 0
-	}
 	return yylex.stack[len(yylex.stack)-1].line
 }
 
 // Column returns the current column number.
 // The first column is 0.
 func (yylex *lexer) Column() int {
-	if len(yylex.stack) == 0 {
-		return 0
-	}
 	return yylex.stack[len(yylex.stack)-1].column
 }
 

--- a/query_string.y
+++ b/query_string.y
@@ -11,11 +11,10 @@ var dateFormats = []string{"02-01-2006", "01-02-2006", time.RFC822,
                            time.UnixDate, time.RFC3339, time.RFC3339Nano}
 
 func logDebugGrammar(format string, v ...interface{}) {
-    if debugParser {
-        logger.Printf(format, v...)
+	if debugParser {
+    	logger.Printf(format, v...)
     }
 }
-
 %}
 
 %union {
@@ -41,112 +40,112 @@ tEQUAL tTILDE tTILDENUMBER
 
 input:
 searchParts {
-    logDebugGrammar("INPUT")
+	logDebugGrammar("INPUT")
 };
 
 searchParts:
 searchPart searchParts {
-    logDebugGrammar("SEARCH PARTS")
+	logDebugGrammar("SEARCH PARTS")
 }
 |
 searchPart {
-    logDebugGrammar("SEARCH PART")
+	logDebugGrammar("SEARCH PART")
 };
 
 searchPart:
 searchPrefix searchBase searchSuffix {
-    query := $2
-    query.SetBoost($3)
-    switch($1) {
-        case queryShould:
-            yylex.(*lexerWrapper).query.AddShould(query)
-        case queryMust:
-            yylex.(*lexerWrapper).query.AddMust(query)
-        case queryMustNot:
-            yylex.(*lexerWrapper).query.AddMustNot(query)
-    }
+	query := $2
+	query.SetBoost($3)
+	switch($1) {
+		case queryShould:
+			yylex.(*lexerWrapper).query.AddShould(query)
+		case queryMust:
+			yylex.(*lexerWrapper).query.AddMust(query)
+		case queryMustNot:
+			yylex.(*lexerWrapper).query.AddMustNot(query)
+	}
 };
 
 
 searchPrefix:
 /* empty */ {
-    $$ = queryShould
+	$$ = queryShould
 }
 |
 searchMustMustNot {
-    $$ = $1
+	$$ = $1
 }
 ;
 
 searchMustMustNot:
 tPLUS {
-    logDebugGrammar("PLUS")
-    $$ = queryMust
+	logDebugGrammar("PLUS")
+	$$ = queryMust
 }
 |
 tMINUS {
-    logDebugGrammar("MINUS")
-    $$ = queryMustNot
+	logDebugGrammar("MINUS")
+	$$ = queryMustNot
 };
 
 searchBase:
 tSTRING {
-    str := $1
-    logDebugGrammar("STRING - %s", str)
-    q := NewMatchQuery(str)
-    $$ = q
+	str := $1
+	logDebugGrammar("STRING - %s", str)
+	q := NewMatchQuery(str)
+	$$ = q
 }
 |
 tSTRING tTILDE {
-    str := $1
-    logDebugGrammar("FUZZY STRING - %s", str)
-    q := NewMatchQuery(str)
-    q.SetFuzziness(1)
-    $$ = q
+	str := $1
+	logDebugGrammar("FUZZY STRING - %s", str)
+	q := NewMatchQuery(str)
+	q.SetFuzziness(1)
+	$$ = q
 }
 |
 tSTRING tCOLON tSTRING tTILDE {
-    field := $1
-    str := $3
-    logDebugGrammar("FIELD - %s FUZZY STRING - %s", field, str)
-    q := NewMatchQuery(str)
-    q.SetFuzziness(1)
-    q.SetField(field)
-    $$ = q
+	field := $1
+	str := $3
+	logDebugGrammar("FIELD - %s FUZZY STRING - %s", field, str)
+	q := NewMatchQuery(str)
+	q.SetFuzziness(1)
+	q.SetField(field)
+	$$ = q
 }
 |
 tSTRING tTILDENUMBER {
-    str := $1
-    fuzziness, _ := strconv.ParseFloat($2, 64)
-    logDebugGrammar("FUZZY STRING - %s", str)
-    q := NewMatchQuery(str)
-    q.SetFuzziness(int(fuzziness))
-    $$ = q
+	str := $1
+	fuzziness, _ := strconv.ParseFloat($2, 64)
+	logDebugGrammar("FUZZY STRING - %s", str)
+	q := NewMatchQuery(str)
+	q.SetFuzziness(int(fuzziness))
+	$$ = q
 }
 |
 tSTRING tCOLON tSTRING tTILDENUMBER {
-    field := $1
-    str := $3
-    fuzziness, _ := strconv.ParseFloat($4, 64)
-    logDebugGrammar("FIELD - %s FUZZY-%f STRING - %s", field, fuzziness, str)
-    q := NewMatchQuery(str)
-    q.SetFuzziness(int(fuzziness))
-    q.SetField(field)
-    $$ = q
+	field := $1
+	str := $3
+	fuzziness, _ := strconv.ParseFloat($4, 64)
+	logDebugGrammar("FIELD - %s FUZZY-%f STRING - %s", field, fuzziness, str)
+	q := NewMatchQuery(str)
+	q.SetFuzziness(int(fuzziness))
+	q.SetField(field)
+	$$ = q
 }
 |
 tNUMBER {
-    str := $1
-    logDebugGrammar("STRING - %s", str)
-    q := NewMatchQuery(str)
-    $$ = q
+	str := $1
+	logDebugGrammar("STRING - %s", str)
+	q := NewMatchQuery(str)
+	$$ = q
 }
 |
 tPHRASE {
-    phrase := $1
-    logDebugGrammar("PHRASE - %s", phrase)
-    q := NewMatchPhraseQuery(phrase)
-    $$ = q
+	phrase := $1
+	logDebugGrammar("PHRASE - %s", phrase)
+	q := NewMatchPhraseQuery(phrase)
+	$$ = q
 }
 |
 tSTRING tCOLON tGREATER tPHRASE {
@@ -210,75 +209,75 @@ tSTRING tCOLON tLESS tEQUAL tPHRASE {
 }
 |
 tSTRING tCOLON tSTRING {
-    field := $1
-    str := $3
-    logDebugGrammar("FIELD - %s STRING - %s", field, str)
-    q := NewMatchQuery(str).SetField(field)
-    $$ = q
+	field := $1
+	str := $3
+	logDebugGrammar("FIELD - %s STRING - %s", field, str)
+	q := NewMatchQuery(str).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tNUMBER {
-    field := $1
-    str := $3
-    logDebugGrammar("FIELD - %s STRING - %s", field, str)
-    q := NewMatchQuery(str).SetField(field)
-    $$ = q
+	field := $1
+	str := $3
+	logDebugGrammar("FIELD - %s STRING - %s", field, str)
+	q := NewMatchQuery(str).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tPHRASE {
-    field := $1
-    phrase := $3
-    logDebugGrammar("FIELD - %s PHRASE - %s", field, phrase)
-    q := NewMatchPhraseQuery(phrase).SetField(field)
-    $$ = q
+	field := $1
+	phrase := $3
+	logDebugGrammar("FIELD - %s PHRASE - %s", field, phrase)
+	q := NewMatchPhraseQuery(phrase).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tGREATER tNUMBER {
-    field := $1
-    min, _ := strconv.ParseFloat($4, 64)
-    minInclusive := false
-    logDebugGrammar("FIELD - GREATER THAN %f", min)
-    q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
-    $$ = q
+	field := $1
+	min, _ := strconv.ParseFloat($4, 64)
+	minInclusive := false
+	logDebugGrammar("FIELD - GREATER THAN %f", min)
+	q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tGREATER tEQUAL tNUMBER {
-    field := $1
-    min, _ := strconv.ParseFloat($5, 64)
-    minInclusive := true
-    logDebugGrammar("FIELD - GREATER THAN OR EQUAL %f", min)
-    q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
-    $$ = q
+	field := $1
+	min, _ := strconv.ParseFloat($5, 64)
+	minInclusive := true
+	logDebugGrammar("FIELD - GREATER THAN OR EQUAL %f", min)
+	q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tLESS tNUMBER {
-    field := $1
-    max, _ := strconv.ParseFloat($4, 64)
-    maxInclusive := false
-    logDebugGrammar("FIELD - LESS THAN %f", max)
-    q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
-    $$ = q
+	field := $1
+	max, _ := strconv.ParseFloat($4, 64)
+	maxInclusive := false
+	logDebugGrammar("FIELD - LESS THAN %f", max)
+	q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
+	$$ = q
 }
 |
 tSTRING tCOLON tLESS tEQUAL tNUMBER {
-    field := $1
-    max, _ := strconv.ParseFloat($5, 64)
-    maxInclusive := true
-    logDebugGrammar("FIELD - LESS THAN OR EQUAL %f", max)
-    q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
-    $$ = q
+	field := $1
+	max, _ := strconv.ParseFloat($5, 64)
+	maxInclusive := true
+	logDebugGrammar("FIELD - LESS THAN OR EQUAL %f", max)
+	q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
+	$$ = q
 };
 
 searchBoost:
 tBOOST tNUMBER {
-    boost, _ := strconv.ParseFloat($2, 64)
-    $$ = boost
-    logDebugGrammar("BOOST %f", boost)
+	boost, _ := strconv.ParseFloat($2, 64)
+	$$ = boost
+	logDebugGrammar("BOOST %f", boost)
 };
 
 searchSuffix:
 /* empty */ {
-    $$ = 1.0
+	$$ = 1.0
 }
 |
 searchBoost {

--- a/query_string.y
+++ b/query_string.y
@@ -1,16 +1,25 @@
 %{
 package bleve
-import "strconv"
+import ("strconv"
+        "time"
+)
+
+// Format 02-01-2015 is used for specifying date without any time. It's a
+// reference layout for DD-MM-YYYY date format.
+// See here for more: https://golang.org/pkg/time/#pkg-constants
+var dateFormats = []string{"02-01-2006", "01-02-2006", time.RFC822,
+                           time.UnixDate, time.RFC3339, time.RFC3339Nano}
 
 func logDebugGrammar(format string, v ...interface{}) {
-	if debugParser {
-    	logger.Printf(format, v...)
+    if debugParser {
+        logger.Printf(format, v...)
     }
 }
+
 %}
 
-%union { 
-s string 
+%union {
+s string
 n int
 f float64
 q Query}
@@ -30,188 +39,248 @@ tEQUAL tTILDE tTILDENUMBER
 
 %%
 
-input: 
+input:
 searchParts {
-	logDebugGrammar("INPUT")
+    logDebugGrammar("INPUT")
 };
 
 searchParts:
 searchPart searchParts {
-	logDebugGrammar("SEARCH PARTS")
+    logDebugGrammar("SEARCH PARTS")
 }
 |
 searchPart {
-	logDebugGrammar("SEARCH PART")
+    logDebugGrammar("SEARCH PART")
 };
 
 searchPart:
 searchPrefix searchBase searchSuffix {
-	query := $2
-	query.SetBoost($3)
-	switch($1) {
-		case queryShould:
-			yylex.(*lexerWrapper).query.AddShould(query)
-		case queryMust:
-			yylex.(*lexerWrapper).query.AddMust(query)
-		case queryMustNot:
-			yylex.(*lexerWrapper).query.AddMustNot(query)
-	}
+    query := $2
+    query.SetBoost($3)
+    switch($1) {
+        case queryShould:
+            yylex.(*lexerWrapper).query.AddShould(query)
+        case queryMust:
+            yylex.(*lexerWrapper).query.AddMust(query)
+        case queryMustNot:
+            yylex.(*lexerWrapper).query.AddMustNot(query)
+    }
 };
 
 
 searchPrefix:
 /* empty */ {
-	$$ = queryShould
+    $$ = queryShould
 }
 |
 searchMustMustNot {
-	$$ = $1
+    $$ = $1
 }
 ;
 
 searchMustMustNot:
 tPLUS {
-	logDebugGrammar("PLUS")
-	$$ = queryMust
+    logDebugGrammar("PLUS")
+    $$ = queryMust
 }
 |
 tMINUS {
-	logDebugGrammar("MINUS")
-	$$ = queryMustNot
+    logDebugGrammar("MINUS")
+    $$ = queryMustNot
 };
 
 searchBase:
 tSTRING {
-	str := $1
-	logDebugGrammar("STRING - %s", str)
-	q := NewMatchQuery(str)
-	$$ = q
+    str := $1
+    logDebugGrammar("STRING - %s", str)
+    q := NewMatchQuery(str)
+    $$ = q
 }
 |
 tSTRING tTILDE {
-	str := $1
-	logDebugGrammar("FUZZY STRING - %s", str)
-	q := NewMatchQuery(str)
-	q.SetFuzziness(1)
-	$$ = q
+    str := $1
+    logDebugGrammar("FUZZY STRING - %s", str)
+    q := NewMatchQuery(str)
+    q.SetFuzziness(1)
+    $$ = q
 }
 |
 tSTRING tCOLON tSTRING tTILDE {
-	field := $1
-	str := $3
-	logDebugGrammar("FIELD - %s FUZZY STRING - %s", field, str)
-	q := NewMatchQuery(str)
-	q.SetFuzziness(1)
-	q.SetField(field)
-	$$ = q
+    field := $1
+    str := $3
+    logDebugGrammar("FIELD - %s FUZZY STRING - %s", field, str)
+    q := NewMatchQuery(str)
+    q.SetFuzziness(1)
+    q.SetField(field)
+    $$ = q
 }
 |
 tSTRING tTILDENUMBER {
-	str := $1
-	fuzziness, _ := strconv.ParseFloat($2, 64)
-	logDebugGrammar("FUZZY STRING - %s", str)
-	q := NewMatchQuery(str)
-	q.SetFuzziness(int(fuzziness))
-	$$ = q
+    str := $1
+    fuzziness, _ := strconv.ParseFloat($2, 64)
+    logDebugGrammar("FUZZY STRING - %s", str)
+    q := NewMatchQuery(str)
+    q.SetFuzziness(int(fuzziness))
+    $$ = q
 }
 |
 tSTRING tCOLON tSTRING tTILDENUMBER {
-	field := $1
-	str := $3
-	fuzziness, _ := strconv.ParseFloat($4, 64)
-	logDebugGrammar("FIELD - %s FUZZY-%f STRING - %s", field, fuzziness, str)
-	q := NewMatchQuery(str)
-	q.SetFuzziness(int(fuzziness))
-	q.SetField(field)
-	$$ = q
+    field := $1
+    str := $3
+    fuzziness, _ := strconv.ParseFloat($4, 64)
+    logDebugGrammar("FIELD - %s FUZZY-%f STRING - %s", field, fuzziness, str)
+    q := NewMatchQuery(str)
+    q.SetFuzziness(int(fuzziness))
+    q.SetField(field)
+    $$ = q
 }
 |
 tNUMBER {
-	str := $1
-	logDebugGrammar("STRING - %s", str)
-	q := NewMatchQuery(str)
-	$$ = q
+    str := $1
+    logDebugGrammar("STRING - %s", str)
+    q := NewMatchQuery(str)
+    $$ = q
 }
 |
 tPHRASE {
-	phrase := $1
-	logDebugGrammar("PHRASE - %s", phrase)
-	q := NewMatchPhraseQuery(phrase)
-	$$ = q
+    phrase := $1
+    logDebugGrammar("PHRASE - %s", phrase)
+    q := NewMatchPhraseQuery(phrase)
+    $$ = q
+}
+|
+tSTRING tCOLON tGREATER tPHRASE {
+    field := $1
+    minInclusive := false
+    phrase := $4
+
+    for _, format := range dateFormats {
+        if _, err := time.Parse(format, phrase); err == nil {
+            logDebugGrammar("PHRASE - GREATER THAN %f", phrase)
+            q := NewDateRangeInclusiveQuery(&phrase, nil, &minInclusive, nil).SetField(field)
+            $$ = q
+            break
+        }
+    }
+}
+|
+tSTRING tCOLON tGREATER tEQUAL tPHRASE {
+    field := $1
+    minInclusive := true
+    phrase := $5
+
+    for _, format := range dateFormats {
+        if _, err := time.Parse(format, phrase); err == nil {
+            logDebugGrammar("PHRASE - GREATER EQUAL THAN %f", phrase)
+            q := NewDateRangeInclusiveQuery(&phrase, nil, &minInclusive, nil).SetField(field)
+            $$ = q
+            break
+        }
+    }
+}
+|
+tSTRING tCOLON tLESS tPHRASE {
+    field := $1
+    maxInclusive := false
+    phrase := $4
+
+    for _, format := range dateFormats {
+        if _, err := time.Parse(format, phrase); err == nil {
+            logDebugGrammar("PHRASE - LESS THAN %f", phrase)
+            q := NewDateRangeInclusiveQuery(nil, &phrase, nil, &maxInclusive).SetField(field)
+            $$ = q
+            break
+        }
+    }
+}
+|
+tSTRING tCOLON tLESS tEQUAL tPHRASE {
+    field := $1
+    maxInclusive := true
+    phrase := $5
+
+    for _, format := range dateFormats {
+        if _, err := time.Parse(format, phrase); err == nil {
+            logDebugGrammar("PHRASE - LESS THAN %f", phrase)
+            q := NewDateRangeInclusiveQuery(nil, &phrase, nil, &maxInclusive).SetField(field)
+            $$ = q
+            break
+        }
+    }
 }
 |
 tSTRING tCOLON tSTRING {
-	field := $1
-	str := $3
-	logDebugGrammar("FIELD - %s STRING - %s", field, str)
-	q := NewMatchQuery(str).SetField(field)
-	$$ = q
+    field := $1
+    str := $3
+    logDebugGrammar("FIELD - %s STRING - %s", field, str)
+    q := NewMatchQuery(str).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tNUMBER {
-	field := $1
-	str := $3
-	logDebugGrammar("FIELD - %s STRING - %s", field, str)
-	q := NewMatchQuery(str).SetField(field)
-	$$ = q
+    field := $1
+    str := $3
+    logDebugGrammar("FIELD - %s STRING - %s", field, str)
+    q := NewMatchQuery(str).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tPHRASE {
-	field := $1
-	phrase := $3
-	logDebugGrammar("FIELD - %s PHRASE - %s", field, phrase)
-	q := NewMatchPhraseQuery(phrase).SetField(field)
-	$$ = q
+    field := $1
+    phrase := $3
+    logDebugGrammar("FIELD - %s PHRASE - %s", field, phrase)
+    q := NewMatchPhraseQuery(phrase).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tGREATER tNUMBER {
-	field := $1
-	min, _ := strconv.ParseFloat($4, 64)
-	minInclusive := false
-	logDebugGrammar("FIELD - GREATER THAN %f", min)
-	q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
-	$$ = q
+    field := $1
+    min, _ := strconv.ParseFloat($4, 64)
+    minInclusive := false
+    logDebugGrammar("FIELD - GREATER THAN %f", min)
+    q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tGREATER tEQUAL tNUMBER {
-	field := $1
-	min, _ := strconv.ParseFloat($5, 64)
-	minInclusive := true
-	logDebugGrammar("FIELD - GREATER THAN OR EQUAL %f", min)
-	q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
-	$$ = q
+    field := $1
+    min, _ := strconv.ParseFloat($5, 64)
+    minInclusive := true
+    logDebugGrammar("FIELD - GREATER THAN OR EQUAL %f", min)
+    q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tLESS tNUMBER {
-	field := $1
-	max, _ := strconv.ParseFloat($4, 64)
-	maxInclusive := false
-	logDebugGrammar("FIELD - LESS THAN %f", max)
-	q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
-	$$ = q
+    field := $1
+    max, _ := strconv.ParseFloat($4, 64)
+    maxInclusive := false
+    logDebugGrammar("FIELD - LESS THAN %f", max)
+    q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
+    $$ = q
 }
 |
 tSTRING tCOLON tLESS tEQUAL tNUMBER {
-	field := $1
-	max, _ := strconv.ParseFloat($5, 64)
-	maxInclusive := true
-	logDebugGrammar("FIELD - LESS THAN OR EQUAL %f", max)
-	q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
-	$$ = q
+    field := $1
+    max, _ := strconv.ParseFloat($5, 64)
+    maxInclusive := true
+    logDebugGrammar("FIELD - LESS THAN OR EQUAL %f", max)
+    q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
+    $$ = q
 };
 
 searchBoost:
 tBOOST tNUMBER {
-	boost, _ := strconv.ParseFloat($2, 64)
-	$$ = boost
-	logDebugGrammar("BOOST %f", boost)
+    boost, _ := strconv.ParseFloat($2, 64)
+    $$ = boost
+    logDebugGrammar("BOOST %f", boost)
 };
 
 searchSuffix:
 /* empty */ {
-	$$ = 1.0
+    $$ = 1.0
 }
 |
 searchBoost {
-	
+
 };

--- a/query_string.y.go
+++ b/query_string.y.go
@@ -1,3 +1,4 @@
+//line query_string.y:2
 package bleve
 
 import __yyfmt__ "fmt"
@@ -11,8 +12,8 @@ import (
 // Format 02-01-2015 is used for specifying date without any time. It's a
 // reference layout for DD-MM-YYYY date format.
 // See here for more: https://golang.org/pkg/time/#pkg-constants
-var dateFormats = []string{"02-01-2006", time.RFC822, time.UnixDate, time.RFC3339,
-	time.RFC3339Nano}
+var dateFormats = []string{"02-01-2006", "01-02-2006", time.RFC822,
+	time.UnixDate, time.RFC3339, time.RFC3339Nano}
 
 func logDebugGrammar(format string, v ...interface{}) {
 	if debugParser {
@@ -20,7 +21,7 @@ func logDebugGrammar(format string, v ...interface{}) {
 	}
 }
 
-//line query_string.y:21
+//line query_string.y:20
 type yySymType struct {
 	yys int
 	s   string
@@ -486,25 +487,25 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:43
+		//line query_string.y:42
 		{
 			logDebugGrammar("INPUT")
 		}
 	case 2:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line query_string.y:48
+		//line query_string.y:47
 		{
 			logDebugGrammar("SEARCH PARTS")
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:52
+		//line query_string.y:51
 		{
 			logDebugGrammar("SEARCH PART")
 		}
 	case 4:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line query_string.y:57
+		//line query_string.y:56
 		{
 			query := yyDollar[2].q
 			query.SetBoost(yyDollar[3].f)
@@ -519,33 +520,33 @@ yydefault:
 		}
 	case 5:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line query_string.y:72
+		//line query_string.y:71
 		{
 			yyVAL.n = queryShould
 		}
 	case 6:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:76
+		//line query_string.y:75
 		{
 			yyVAL.n = yyDollar[1].n
 		}
 	case 7:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:82
+		//line query_string.y:81
 		{
 			logDebugGrammar("PLUS")
 			yyVAL.n = queryMust
 		}
 	case 8:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:87
+		//line query_string.y:86
 		{
 			logDebugGrammar("MINUS")
 			yyVAL.n = queryMustNot
 		}
 	case 9:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:93
+		//line query_string.y:92
 		{
 			str := yyDollar[1].s
 			logDebugGrammar("STRING - %s", str)
@@ -554,7 +555,7 @@ yydefault:
 		}
 	case 10:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line query_string.y:100
+		//line query_string.y:99
 		{
 			str := yyDollar[1].s
 			logDebugGrammar("FUZZY STRING - %s", str)
@@ -564,7 +565,7 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:108
+		//line query_string.y:107
 		{
 			field := yyDollar[1].s
 			str := yyDollar[3].s
@@ -576,7 +577,7 @@ yydefault:
 		}
 	case 12:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line query_string.y:118
+		//line query_string.y:117
 		{
 			str := yyDollar[1].s
 			fuzziness, _ := strconv.ParseFloat(yyDollar[2].s, 64)
@@ -587,7 +588,7 @@ yydefault:
 		}
 	case 13:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:127
+		//line query_string.y:126
 		{
 			field := yyDollar[1].s
 			str := yyDollar[3].s
@@ -600,7 +601,7 @@ yydefault:
 		}
 	case 14:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:138
+		//line query_string.y:137
 		{
 			str := yyDollar[1].s
 			logDebugGrammar("STRING - %s", str)
@@ -609,7 +610,7 @@ yydefault:
 		}
 	case 15:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:145
+		//line query_string.y:144
 		{
 			phrase := yyDollar[1].s
 			logDebugGrammar("PHRASE - %s", phrase)
@@ -618,7 +619,7 @@ yydefault:
 		}
 	case 16:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:152
+		//line query_string.y:151
 		{
 			field := yyDollar[1].s
 			minInclusive := false
@@ -635,7 +636,7 @@ yydefault:
 		}
 	case 17:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line query_string.y:167
+		//line query_string.y:166
 		{
 			field := yyDollar[1].s
 			minInclusive := true
@@ -652,7 +653,7 @@ yydefault:
 		}
 	case 18:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:182
+		//line query_string.y:181
 		{
 			field := yyDollar[1].s
 			maxInclusive := false
@@ -669,7 +670,7 @@ yydefault:
 		}
 	case 19:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line query_string.y:197
+		//line query_string.y:196
 		{
 			field := yyDollar[1].s
 			maxInclusive := true
@@ -686,7 +687,7 @@ yydefault:
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line query_string.y:212
+		//line query_string.y:211
 		{
 			field := yyDollar[1].s
 			str := yyDollar[3].s
@@ -696,7 +697,7 @@ yydefault:
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line query_string.y:220
+		//line query_string.y:219
 		{
 			field := yyDollar[1].s
 			str := yyDollar[3].s
@@ -706,7 +707,7 @@ yydefault:
 		}
 	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line query_string.y:228
+		//line query_string.y:227
 		{
 			field := yyDollar[1].s
 			phrase := yyDollar[3].s
@@ -716,7 +717,7 @@ yydefault:
 		}
 	case 23:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:236
+		//line query_string.y:235
 		{
 			field := yyDollar[1].s
 			min, _ := strconv.ParseFloat(yyDollar[4].s, 64)
@@ -727,7 +728,7 @@ yydefault:
 		}
 	case 24:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line query_string.y:245
+		//line query_string.y:244
 		{
 			field := yyDollar[1].s
 			min, _ := strconv.ParseFloat(yyDollar[5].s, 64)
@@ -738,7 +739,7 @@ yydefault:
 		}
 	case 25:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line query_string.y:254
+		//line query_string.y:253
 		{
 			field := yyDollar[1].s
 			max, _ := strconv.ParseFloat(yyDollar[4].s, 64)
@@ -749,7 +750,7 @@ yydefault:
 		}
 	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line query_string.y:263
+		//line query_string.y:262
 		{
 			field := yyDollar[1].s
 			max, _ := strconv.ParseFloat(yyDollar[5].s, 64)
@@ -760,7 +761,7 @@ yydefault:
 		}
 	case 27:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line query_string.y:273
+		//line query_string.y:272
 		{
 			boost, _ := strconv.ParseFloat(yyDollar[2].s, 64)
 			yyVAL.f = boost
@@ -768,13 +769,13 @@ yydefault:
 		}
 	case 28:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line query_string.y:280
+		//line query_string.y:279
 		{
 			yyVAL.f = 1.0
 		}
 	case 29:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line query_string.y:284
+		//line query_string.y:283
 		{
 
 		}

--- a/query_string.y.go
+++ b/query_string.y.go
@@ -3,7 +3,16 @@ package bleve
 import __yyfmt__ "fmt"
 
 //line query_string.y:2
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
+
+// Format 02-01-2015 is used for specifying date without any time. It's a
+// reference layout for DD-MM-YYYY date format.
+// See here for more: https://golang.org/pkg/time/#pkg-constants
+var dateFormats = []string{"02-01-2006", time.RFC822, time.UnixDate, time.RFC3339,
+	time.RFC3339Nano}
 
 func logDebugGrammar(format string, v ...interface{}) {
 	if debugParser {
@@ -11,7 +20,7 @@ func logDebugGrammar(format string, v ...interface{}) {
 	}
 }
 
-//line query_string.y:12
+//line query_string.y:21
 type yySymType struct {
 	yys int
 	s   string
@@ -35,7 +44,10 @@ const tEQUAL = 57357
 const tTILDE = 57358
 const tTILDENUMBER = 57359
 
-var yyToknames = []string{
+var yyToknames = [...]string{
+	"$end",
+	"error",
+	"$unk",
 	"tSTRING",
 	"tPHRASE",
 	"tPLUS",
@@ -51,14 +63,14 @@ var yyToknames = []string{
 	"tTILDE",
 	"tTILDENUMBER",
 }
-var yyStatenames = []string{}
+var yyStatenames = [...]string{}
 
 const yyEofCode = 1
 const yyErrCode = 2
 const yyMaxDepth = 200
 
 //line yacctab:1
-var yyExca = []int{
+var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -67,89 +79,117 @@ var yyExca = []int{
 	-2, 5,
 }
 
-const yyNprod = 26
+const yyNprod = 30
 const yyPrivate = 57344
 
 var yyTokenNames []string
 var yyStates []string
 
-const yyLast = 32
+const yyLast = 36
 
-var yyAct = []int{
+var yyAct = [...]int{
 
-	17, 25, 26, 20, 22, 32, 31, 29, 16, 18,
-	30, 21, 23, 24, 27, 10, 12, 28, 19, 15,
-	6, 7, 2, 11, 3, 1, 8, 14, 5, 4,
-	13, 9,
+	17, 25, 26, 20, 24, 19, 15, 30, 16, 18,
+	3, 23, 21, 22, 32, 27, 35, 31, 10, 12,
+	33, 1, 29, 36, 14, 28, 11, 34, 6, 7,
+	2, 5, 4, 13, 8, 9,
 }
-var yyPact = []int{
+var yyPact = [...]int{
 
-	14, -1000, -1000, 14, 11, -1000, -1000, -1000, -1000, 10,
-	-8, -1000, -1000, -1000, -1000, 6, -1000, -1, -1000, -1000,
-	-15, -1000, -1000, 2, -5, -1000, -1000, -1000, -6, -1000,
-	-7, -1000, -1000,
+	22, -1000, -1000, 22, 14, -1000, -1000, -1000, -1000, -3,
+	-8, -1000, -1000, -1000, -1000, -7, -1000, -1, -1000, -1000,
+	-15, 10, 2, -1000, -1000, -1000, -1000, -1000, 15, -1000,
+	-1000, 11, -1000, -1000, -1000, -1000, -1000,
 }
-var yyPgo = []int{
+var yyPgo = [...]int{
 
-	0, 31, 30, 29, 28, 27, 25, 22, 24,
+	0, 35, 33, 32, 31, 24, 21, 30, 10,
 }
-var yyR1 = []int{
+var yyR1 = [...]int{
 
 	0, 6, 7, 7, 8, 3, 3, 4, 4, 1,
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 5, 2, 2,
+	1, 1, 1, 1, 1, 1, 1, 5, 2, 2,
 }
-var yyR2 = []int{
+var yyR2 = [...]int{
 
 	0, 1, 2, 1, 3, 0, 1, 1, 1, 1,
-	2, 4, 2, 4, 1, 1, 3, 3, 3, 4,
-	5, 4, 5, 2, 0, 1,
+	2, 4, 2, 4, 1, 1, 4, 5, 4, 5,
+	3, 3, 3, 4, 5, 4, 5, 2, 0, 1,
 }
-var yyChk = []int{
+var yyChk = [...]int{
 
 	-1000, -6, -7, -8, -3, -4, 6, 7, -7, -1,
 	4, 12, 5, -2, -5, 9, 16, 8, 17, 12,
-	4, 12, 5, 13, 14, 16, 17, 12, 15, 12,
-	15, 12, 12,
+	4, 13, 14, 12, 5, 16, 17, 5, 15, 12,
+	5, 15, 12, 5, 12, 5, 12,
 }
-var yyDef = []int{
+var yyDef = [...]int{
 
-	5, -2, 1, -2, 0, 6, 7, 8, 2, 24,
-	9, 14, 15, 4, 25, 0, 10, 0, 12, 23,
-	16, 17, 18, 0, 0, 11, 13, 19, 0, 21,
-	0, 20, 22,
+	5, -2, 1, -2, 0, 6, 7, 8, 2, 28,
+	9, 14, 15, 4, 29, 0, 10, 0, 12, 27,
+	20, 0, 0, 21, 22, 11, 13, 16, 0, 23,
+	18, 0, 25, 17, 24, 19, 26,
 }
-var yyTok1 = []int{
+var yyTok1 = [...]int{
 
 	1,
 }
-var yyTok2 = []int{
+var yyTok2 = [...]int{
 
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17,
 }
-var yyTok3 = []int{
+var yyTok3 = [...]int{
 	0,
 }
+
+var yyErrorMessages = [...]struct {
+	state int
+	token int
+	msg   string
+}{}
 
 //line yaccpar:1
 
 /*	parser for yacc output	*/
 
-var yyDebug = 0
+var (
+	yyDebug        = 0
+	yyErrorVerbose = false
+)
 
 type yyLexer interface {
 	Lex(lval *yySymType) int
 	Error(s string)
 }
 
+type yyParser interface {
+	Parse(yyLexer) int
+	Lookahead() int
+}
+
+type yyParserImpl struct {
+	lookahead func() int
+}
+
+func (p *yyParserImpl) Lookahead() int {
+	return p.lookahead()
+}
+
+func yyNewParser() yyParser {
+	p := &yyParserImpl{
+		lookahead: func() int { return -1 },
+	}
+	return p
+}
+
 const yyFlag = -1000
 
 func yyTokname(c int) string {
-	// 4 is TOKSTART above
-	if c >= 4 && c-4 < len(yyToknames) {
-		if yyToknames[c-4] != "" {
-			return yyToknames[c-4]
+	if c >= 1 && c-1 < len(yyToknames) {
+		if yyToknames[c-1] != "" {
+			return yyToknames[c-1]
 		}
 	}
 	return __yyfmt__.Sprintf("tok-%v", c)
@@ -164,51 +204,129 @@ func yyStatname(s int) string {
 	return __yyfmt__.Sprintf("state-%v", s)
 }
 
-func yylex1(lex yyLexer, lval *yySymType) int {
-	c := 0
-	char := lex.Lex(lval)
+func yyErrorMessage(state, lookAhead int) string {
+	const TOKSTART = 4
+
+	if !yyErrorVerbose {
+		return "syntax error"
+	}
+
+	for _, e := range yyErrorMessages {
+		if e.state == state && e.token == lookAhead {
+			return "syntax error: " + e.msg
+		}
+	}
+
+	res := "syntax error: unexpected " + yyTokname(lookAhead)
+
+	// To match Bison, suggest at most four expected tokens.
+	expected := make([]int, 0, 4)
+
+	// Look for shiftable tokens.
+	base := yyPact[state]
+	for tok := TOKSTART; tok-1 < len(yyToknames); tok++ {
+		if n := base + tok; n >= 0 && n < yyLast && yyChk[yyAct[n]] == tok {
+			if len(expected) == cap(expected) {
+				return res
+			}
+			expected = append(expected, tok)
+		}
+	}
+
+	if yyDef[state] == -2 {
+		i := 0
+		for yyExca[i] != -1 || yyExca[i+1] != state {
+			i += 2
+		}
+
+		// Look for tokens that we accept or reduce.
+		for i += 2; yyExca[i] >= 0; i += 2 {
+			tok := yyExca[i]
+			if tok < TOKSTART || yyExca[i+1] == 0 {
+				continue
+			}
+			if len(expected) == cap(expected) {
+				return res
+			}
+			expected = append(expected, tok)
+		}
+
+		// If the default action is to accept or reduce, give up.
+		if yyExca[i+1] != 0 {
+			return res
+		}
+	}
+
+	for i, tok := range expected {
+		if i == 0 {
+			res += ", expecting "
+		} else {
+			res += " or "
+		}
+		res += yyTokname(tok)
+	}
+	return res
+}
+
+func yylex1(lex yyLexer, lval *yySymType) (char, token int) {
+	token = 0
+	char = lex.Lex(lval)
 	if char <= 0 {
-		c = yyTok1[0]
+		token = yyTok1[0]
 		goto out
 	}
 	if char < len(yyTok1) {
-		c = yyTok1[char]
+		token = yyTok1[char]
 		goto out
 	}
 	if char >= yyPrivate {
 		if char < yyPrivate+len(yyTok2) {
-			c = yyTok2[char-yyPrivate]
+			token = yyTok2[char-yyPrivate]
 			goto out
 		}
 	}
 	for i := 0; i < len(yyTok3); i += 2 {
-		c = yyTok3[i+0]
-		if c == char {
-			c = yyTok3[i+1]
+		token = yyTok3[i+0]
+		if token == char {
+			token = yyTok3[i+1]
 			goto out
 		}
 	}
 
 out:
-	if c == 0 {
-		c = yyTok2[1] /* unknown char */
+	if token == 0 {
+		token = yyTok2[1] /* unknown char */
 	}
 	if yyDebug >= 3 {
-		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(c), uint(char))
+		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(token), uint(char))
 	}
-	return c
+	return char, token
 }
 
 func yyParse(yylex yyLexer) int {
+	return yyNewParser().Parse(yylex)
+}
+
+func (yyrcvr *yyParserImpl) Parse(yylex yyLexer) int {
 	var yyn int
 	var yylval yySymType
 	var yyVAL yySymType
+	var yyDollar []yySymType
+	_ = yyDollar // silence set and not used
 	yyS := make([]yySymType, yyMaxDepth)
 
 	Nerrs := 0   /* number of errors */
 	Errflag := 0 /* error recovery flag */
 	yystate := 0
 	yychar := -1
+	yytoken := -1 // yychar translated into internal numbering
+	yyrcvr.lookahead = func() int { return yychar }
+	defer func() {
+		// Make sure we report no lookahead when not parsing.
+		yystate = -1
+		yychar = -1
+		yytoken = -1
+	}()
 	yyp := -1
 	goto yystack
 
@@ -221,7 +339,7 @@ ret1:
 yystack:
 	/* put a state and value onto the stack */
 	if yyDebug >= 4 {
-		__yyfmt__.Printf("char %v in %v\n", yyTokname(yychar), yyStatname(yystate))
+		__yyfmt__.Printf("char %v in %v\n", yyTokname(yytoken), yyStatname(yystate))
 	}
 
 	yyp++
@@ -239,15 +357,16 @@ yynewstate:
 		goto yydefault /* simple state */
 	}
 	if yychar < 0 {
-		yychar = yylex1(yylex, &yylval)
+		yychar, yytoken = yylex1(yylex, &yylval)
 	}
-	yyn += yychar
+	yyn += yytoken
 	if yyn < 0 || yyn >= yyLast {
 		goto yydefault
 	}
 	yyn = yyAct[yyn]
-	if yyChk[yyn] == yychar { /* valid shift */
+	if yyChk[yyn] == yytoken { /* valid shift */
 		yychar = -1
+		yytoken = -1
 		yyVAL = yylval
 		yystate = yyn
 		if Errflag > 0 {
@@ -261,7 +380,7 @@ yydefault:
 	yyn = yyDef[yystate]
 	if yyn == -2 {
 		if yychar < 0 {
-			yychar = yylex1(yylex, &yylval)
+			yychar, yytoken = yylex1(yylex, &yylval)
 		}
 
 		/* look through exception table */
@@ -274,7 +393,7 @@ yydefault:
 		}
 		for xi += 2; ; xi += 2 {
 			yyn = yyExca[xi+0]
-			if yyn < 0 || yyn == yychar {
+			if yyn < 0 || yyn == yytoken {
 				break
 			}
 		}
@@ -287,11 +406,11 @@ yydefault:
 		/* error ... attempt to resume parsing */
 		switch Errflag {
 		case 0: /* brand new error */
-			yylex.Error("syntax error")
+			yylex.Error(yyErrorMessage(yystate, yytoken))
 			Nerrs++
 			if yyDebug >= 1 {
 				__yyfmt__.Printf("%s", yyStatname(yystate))
-				__yyfmt__.Printf(" saw %s\n", yyTokname(yychar))
+				__yyfmt__.Printf(" saw %s\n", yyTokname(yytoken))
 			}
 			fallthrough
 
@@ -319,12 +438,13 @@ yydefault:
 
 		case 3: /* no shift yet; clobber input char */
 			if yyDebug >= 2 {
-				__yyfmt__.Printf("error recovery discards %s\n", yyTokname(yychar))
+				__yyfmt__.Printf("error recovery discards %s\n", yyTokname(yytoken))
 			}
-			if yychar == yyEofCode {
+			if yytoken == yyEofCode {
 				goto ret1
 			}
 			yychar = -1
+			yytoken = -1
 			goto yynewstate /* try again in the same state */
 		}
 	}
@@ -339,6 +459,13 @@ yydefault:
 	_ = yypt // guard against "declared and not used"
 
 	yyp -= yyR2[yyn]
+	// yyp is now the index of $0. Perform the default action. Iff the
+	// reduced production is ε, $1 is possibly out of range.
+	if yyp+1 >= len(yyS) {
+		nyys := make([]yySymType, len(yyS)*2)
+		copy(nyys, yyS)
+		yyS = nyys
+	}
 	yyVAL = yyS[yyp+1]
 
 	/* consult goto table to find next state */
@@ -358,26 +485,30 @@ yydefault:
 	switch yynt {
 
 	case 1:
-		//line query_string.y:34
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:43
 		{
 			logDebugGrammar("INPUT")
 		}
 	case 2:
-		//line query_string.y:39
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line query_string.y:48
 		{
 			logDebugGrammar("SEARCH PARTS")
 		}
 	case 3:
-		//line query_string.y:43
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:52
 		{
 			logDebugGrammar("SEARCH PART")
 		}
 	case 4:
-		//line query_string.y:48
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line query_string.y:57
 		{
-			query := yyS[yypt-1].q
-			query.SetBoost(yyS[yypt-0].f)
-			switch yyS[yypt-2].n {
+			query := yyDollar[2].q
+			query.SetBoost(yyDollar[3].f)
+			switch yyDollar[1].n {
 			case queryShould:
 				yylex.(*lexerWrapper).query.AddShould(query)
 			case queryMust:
@@ -387,49 +518,56 @@ yydefault:
 			}
 		}
 	case 5:
-		//line query_string.y:63
+		yyDollar = yyS[yypt-0 : yypt+1]
+		//line query_string.y:72
 		{
 			yyVAL.n = queryShould
 		}
 	case 6:
-		//line query_string.y:67
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:76
 		{
-			yyVAL.n = yyS[yypt-0].n
+			yyVAL.n = yyDollar[1].n
 		}
 	case 7:
-		//line query_string.y:73
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:82
 		{
 			logDebugGrammar("PLUS")
 			yyVAL.n = queryMust
 		}
 	case 8:
-		//line query_string.y:78
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:87
 		{
 			logDebugGrammar("MINUS")
 			yyVAL.n = queryMustNot
 		}
 	case 9:
-		//line query_string.y:84
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:93
 		{
-			str := yyS[yypt-0].s
+			str := yyDollar[1].s
 			logDebugGrammar("STRING - %s", str)
 			q := NewMatchQuery(str)
 			yyVAL.q = q
 		}
 	case 10:
-		//line query_string.y:91
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line query_string.y:100
 		{
-			str := yyS[yypt-1].s
+			str := yyDollar[1].s
 			logDebugGrammar("FUZZY STRING - %s", str)
 			q := NewMatchQuery(str)
 			q.SetFuzziness(1)
 			yyVAL.q = q
 		}
 	case 11:
-		//line query_string.y:99
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:108
 		{
-			field := yyS[yypt-3].s
-			str := yyS[yypt-1].s
+			field := yyDollar[1].s
+			str := yyDollar[3].s
 			logDebugGrammar("FIELD - %s FUZZY STRING - %s", field, str)
 			q := NewMatchQuery(str)
 			q.SetFuzziness(1)
@@ -437,21 +575,23 @@ yydefault:
 			yyVAL.q = q
 		}
 	case 12:
-		//line query_string.y:109
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line query_string.y:118
 		{
-			str := yyS[yypt-1].s
-			fuzziness, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			str := yyDollar[1].s
+			fuzziness, _ := strconv.ParseFloat(yyDollar[2].s, 64)
 			logDebugGrammar("FUZZY STRING - %s", str)
 			q := NewMatchQuery(str)
 			q.SetFuzziness(int(fuzziness))
 			yyVAL.q = q
 		}
 	case 13:
-		//line query_string.y:118
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:127
 		{
-			field := yyS[yypt-3].s
-			str := yyS[yypt-1].s
-			fuzziness, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			field := yyDollar[1].s
+			str := yyDollar[3].s
+			fuzziness, _ := strconv.ParseFloat(yyDollar[4].s, 64)
 			logDebugGrammar("FIELD - %s FUZZY-%f STRING - %s", field, fuzziness, str)
 			q := NewMatchQuery(str)
 			q.SetFuzziness(int(fuzziness))
@@ -459,102 +599,182 @@ yydefault:
 			yyVAL.q = q
 		}
 	case 14:
-		//line query_string.y:129
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:138
 		{
-			str := yyS[yypt-0].s
+			str := yyDollar[1].s
 			logDebugGrammar("STRING - %s", str)
 			q := NewMatchQuery(str)
 			yyVAL.q = q
 		}
 	case 15:
-		//line query_string.y:136
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:145
 		{
-			phrase := yyS[yypt-0].s
+			phrase := yyDollar[1].s
 			logDebugGrammar("PHRASE - %s", phrase)
 			q := NewMatchPhraseQuery(phrase)
 			yyVAL.q = q
 		}
 	case 16:
-		//line query_string.y:143
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:152
 		{
-			field := yyS[yypt-2].s
-			str := yyS[yypt-0].s
-			logDebugGrammar("FIELD - %s STRING - %s", field, str)
-			q := NewMatchQuery(str).SetField(field)
-			yyVAL.q = q
+			field := yyDollar[1].s
+			minInclusive := false
+			phrase := yyDollar[4].s
+
+			for _, format := range dateFormats {
+				if _, err := time.Parse(format, phrase); err == nil {
+					logDebugGrammar("PHRASE - GREATER THAN %f", phrase)
+					q := NewDateRangeInclusiveQuery(&phrase, nil, &minInclusive, nil).SetField(field)
+					yyVAL.q = q
+					break
+				}
+			}
 		}
 	case 17:
-		//line query_string.y:151
+		yyDollar = yyS[yypt-5 : yypt+1]
+		//line query_string.y:167
 		{
-			field := yyS[yypt-2].s
-			str := yyS[yypt-0].s
+			field := yyDollar[1].s
+			minInclusive := true
+			phrase := yyDollar[5].s
+
+			for _, format := range dateFormats {
+				if _, err := time.Parse(format, phrase); err == nil {
+					logDebugGrammar("PHRASE - GREATER EQUAL THAN %f", phrase)
+					q := NewDateRangeInclusiveQuery(&phrase, nil, &minInclusive, nil).SetField(field)
+					yyVAL.q = q
+					break
+				}
+			}
+		}
+	case 18:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:182
+		{
+			field := yyDollar[1].s
+			maxInclusive := false
+			phrase := yyDollar[4].s
+
+			for _, format := range dateFormats {
+				if _, err := time.Parse(format, phrase); err == nil {
+					logDebugGrammar("PHRASE - LESS THAN %f", phrase)
+					q := NewDateRangeInclusiveQuery(nil, &phrase, nil, &maxInclusive).SetField(field)
+					yyVAL.q = q
+					break
+				}
+			}
+		}
+	case 19:
+		yyDollar = yyS[yypt-5 : yypt+1]
+		//line query_string.y:197
+		{
+			field := yyDollar[1].s
+			maxInclusive := true
+			phrase := yyDollar[5].s
+
+			for _, format := range dateFormats {
+				if _, err := time.Parse(format, phrase); err == nil {
+					logDebugGrammar("PHRASE - LESS THAN %f", phrase)
+					q := NewDateRangeInclusiveQuery(nil, &phrase, nil, &maxInclusive).SetField(field)
+					yyVAL.q = q
+					break
+				}
+			}
+		}
+	case 20:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line query_string.y:212
+		{
+			field := yyDollar[1].s
+			str := yyDollar[3].s
 			logDebugGrammar("FIELD - %s STRING - %s", field, str)
 			q := NewMatchQuery(str).SetField(field)
 			yyVAL.q = q
 		}
-	case 18:
-		//line query_string.y:159
+	case 21:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line query_string.y:220
 		{
-			field := yyS[yypt-2].s
-			phrase := yyS[yypt-0].s
+			field := yyDollar[1].s
+			str := yyDollar[3].s
+			logDebugGrammar("FIELD - %s STRING - %s", field, str)
+			q := NewMatchQuery(str).SetField(field)
+			yyVAL.q = q
+		}
+	case 22:
+		yyDollar = yyS[yypt-3 : yypt+1]
+		//line query_string.y:228
+		{
+			field := yyDollar[1].s
+			phrase := yyDollar[3].s
 			logDebugGrammar("FIELD - %s PHRASE - %s", field, phrase)
 			q := NewMatchPhraseQuery(phrase).SetField(field)
 			yyVAL.q = q
 		}
-	case 19:
-		//line query_string.y:167
+	case 23:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:236
 		{
-			field := yyS[yypt-3].s
-			min, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			field := yyDollar[1].s
+			min, _ := strconv.ParseFloat(yyDollar[4].s, 64)
 			minInclusive := false
 			logDebugGrammar("FIELD - GREATER THAN %f", min)
 			q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
 			yyVAL.q = q
 		}
-	case 20:
-		//line query_string.y:176
+	case 24:
+		yyDollar = yyS[yypt-5 : yypt+1]
+		//line query_string.y:245
 		{
-			field := yyS[yypt-4].s
-			min, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			field := yyDollar[1].s
+			min, _ := strconv.ParseFloat(yyDollar[5].s, 64)
 			minInclusive := true
 			logDebugGrammar("FIELD - GREATER THAN OR EQUAL %f", min)
 			q := NewNumericRangeInclusiveQuery(&min, nil, &minInclusive, nil).SetField(field)
 			yyVAL.q = q
 		}
-	case 21:
-		//line query_string.y:185
+	case 25:
+		yyDollar = yyS[yypt-4 : yypt+1]
+		//line query_string.y:254
 		{
-			field := yyS[yypt-3].s
-			max, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			field := yyDollar[1].s
+			max, _ := strconv.ParseFloat(yyDollar[4].s, 64)
 			maxInclusive := false
 			logDebugGrammar("FIELD - LESS THAN %f", max)
 			q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
 			yyVAL.q = q
 		}
-	case 22:
-		//line query_string.y:194
+	case 26:
+		yyDollar = yyS[yypt-5 : yypt+1]
+		//line query_string.y:263
 		{
-			field := yyS[yypt-4].s
-			max, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			field := yyDollar[1].s
+			max, _ := strconv.ParseFloat(yyDollar[5].s, 64)
 			maxInclusive := true
 			logDebugGrammar("FIELD - LESS THAN OR EQUAL %f", max)
 			q := NewNumericRangeInclusiveQuery(nil, &max, nil, &maxInclusive).SetField(field)
 			yyVAL.q = q
 		}
-	case 23:
-		//line query_string.y:204
+	case 27:
+		yyDollar = yyS[yypt-2 : yypt+1]
+		//line query_string.y:273
 		{
-			boost, _ := strconv.ParseFloat(yyS[yypt-0].s, 64)
+			boost, _ := strconv.ParseFloat(yyDollar[2].s, 64)
 			yyVAL.f = boost
 			logDebugGrammar("BOOST %f", boost)
 		}
-	case 24:
-		//line query_string.y:211
+	case 28:
+		yyDollar = yyS[yypt-0 : yypt+1]
+		//line query_string.y:280
 		{
 			yyVAL.f = 1.0
 		}
-	case 25:
-		//line query_string.y:215
+	case 29:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line query_string.y:284
 		{
 
 		}

--- a/query_string_parser_test.go
+++ b/query_string_parser_test.go
@@ -18,6 +18,7 @@ func TestQuerySyntaxParserValid(t *testing.T) {
 	fivePointOh := 5.0
 	theTruth := true
 	theFalsehood := false
+	theDate := "02 Jan 06 15:04 MST"
 	tests := []struct {
 		input   string
 		result  Query
@@ -324,6 +325,46 @@ func TestQuerySyntaxParserValid(t *testing.T) {
 				},
 				nil),
 		},
+		{
+			input:   `field:>"02 Jan 06 15:04 MST"`,
+			mapping: NewIndexMapping(),
+			result: NewBooleanQuery(
+				nil,
+				[]Query{
+					NewDateRangeInclusiveQuery(&theDate, nil, &theFalsehood, nil).SetField("field"),
+				},
+				nil),
+		},
+		{
+			input:   `field:>="02 Jan 06 15:04 MST"`,
+			mapping: NewIndexMapping(),
+			result: NewBooleanQuery(
+				nil,
+				[]Query{
+					NewDateRangeInclusiveQuery(&theDate, nil, &theTruth, nil).SetField("field"),
+				},
+				nil),
+		},
+		{
+			input:   `field:<"02 Jan 06 15:04 MST"`,
+			mapping: NewIndexMapping(),
+			result: NewBooleanQuery(
+				nil,
+				[]Query{
+					NewDateRangeInclusiveQuery(nil, &theDate, nil, &theFalsehood).SetField("field"),
+				},
+				nil),
+		},
+		{
+			input:   `field:<="02 Jan 06 15:04 MST"`,
+			mapping: NewIndexMapping(),
+			result: NewBooleanQuery(
+				nil,
+				[]Query{
+					NewDateRangeInclusiveQuery(nil, &theDate, nil, &theTruth).SetField("field"),
+				},
+				nil),
+		},
 	}
 
 	// turn on lexer debugging
@@ -358,6 +399,10 @@ func TestQuerySyntaxParserInvalid(t *testing.T) {
 		{"field:~text"},
 		{"field:^text"},
 		{"field::text"},
+		{`field:>"Random phrase"`},
+		{`field:>="Random phrase"`},
+		{`field:<"Random phrase"`},
+		{`field:<="Random phrase"`},
 	}
 
 	// turn on lexer debugging


### PR DESCRIPTION
This patch extends parser capabilities for date searching.
Parser's grammar has been extended for following cases:

* tLESS tPHRASE (<)
* tLESS tEQUAL tPHRASE (<=)
* tGREATER tPHRASE (>)
* tGREATER tEQUAL tPHRASE (>=)

As currently there is no logic for interpreting strings with operators
for anything but dates we assume user provided input for searching on
date/time attributes in their mappings. Bleve supports few basic formats
of date and/or datetime:

* date only (US format): 02-01-2006
* date only (European format): 01-02-2006
* RFC822: 02 Jan 06 15:04 MST
* UnixDate: Mon Jan _2 15:04:05 MST 2006
* RFC3339: 2006-01-02T15:04:05Z07:00
* RFC3339Nano: 2006-01-02T15:04:05.999999999Z07:00