### PR TITLE
BoltDB wrapper nano optimization which makes code a bit prettier too

### DIFF
--- a/index/store/boltdb/reader.go
+++ b/index/store/boltdb/reader.go
@@ -15,13 +15,14 @@ import (
 )
 
 type Reader struct {
-	store *Store
-	tx    *bolt.Tx
+	store  *Store
+	tx     *bolt.Tx
+	bucket *bolt.Bucket
 }
 
 func (r *Reader) Get(key []byte) ([]byte, error) {
 	var rv []byte
-	v := r.tx.Bucket([]byte(r.store.bucket)).Get(key)
+	v := r.bucket.Get(key)
 	if v != nil {
 		rv = make([]byte, len(v))
 		copy(rv, v)
@@ -30,8 +31,7 @@ func (r *Reader) Get(key []byte) ([]byte, error) {
 }
 
 func (r *Reader) PrefixIterator(prefix []byte) store.KVIterator {
-	b := r.tx.Bucket([]byte(r.store.bucket))
-	cursor := b.Cursor()
+	cursor := r.bucket.Cursor()
 
 	rv := &Iterator{
 		store:  r.store,
@@ -45,8 +45,7 @@ func (r *Reader) PrefixIterator(prefix []byte) store.KVIterator {
 }
 
 func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
-	b := r.tx.Bucket([]byte(r.store.bucket))
-	cursor := b.Cursor()
+	cursor := r.bucket.Cursor()
 
 	rv := &Iterator{
 		store:  r.store,

--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -83,8 +83,9 @@ func (bs *Store) Reader() (store.KVReader, error) {
 		return nil, err
 	}
 	return &Reader{
-		store: bs,
-		tx:    tx,
+		store:  bs,
+		tx:     tx,
+		bucket: tx.Bucket([]byte(bs.bucket)),
 	}, nil
 }
 


### PR DESCRIPTION
benchmark                                     old ns/op      new ns/op      delta
BenchmarkBoltDBIndexing1Workers-2             9182857        9101477        -0.89%
BenchmarkBoltDBIndexing2Workers-2             9235663        9063540        -1.86%
BenchmarkBoltDBIndexing4Workers-2             9242451        8999922        -2.62%
BenchmarkBoltDBIndexing1Workers10Batch-2      1570988524     1537403316     -2.14%
BenchmarkBoltDBIndexing2Workers10Batch-2      1600295858     1559906635     -2.52%
BenchmarkBoltDBIndexing4Workers10Batch-2      1596448655     1532570284     -4.00%
BenchmarkBoltDBIndexing1Workers100Batch-2     377685284      372590898      -1.35%
BenchmarkBoltDBIndexing2Workers100Batch-2     382156053      369342317      -3.35%
BenchmarkBoltDBIndexing4Workers100Batch-2     349105692      343303744      -1.66%

benchmark                                     old allocs     new allocs     delta
BenchmarkBoltDBIndexing1Workers-2             615            615            +0.00%
BenchmarkBoltDBIndexing2Workers-2             615            615            +0.00%
BenchmarkBoltDBIndexing4Workers-2             615            615            +0.00%
BenchmarkBoltDBIndexing1Workers10Batch-2      750294         748520         -0.24%
BenchmarkBoltDBIndexing2Workers10Batch-2      750295         748527         -0.24%
BenchmarkBoltDBIndexing4Workers10Batch-2      750314         748508         -0.24%
BenchmarkBoltDBIndexing1Workers100Batch-2     565370         563381         -0.35%
BenchmarkBoltDBIndexing2Workers100Batch-2     565348         563380         -0.35%
BenchmarkBoltDBIndexing4Workers100Batch-2     565350         563378         -0.35%

benchmark                                     old bytes     new bytes     delta
BenchmarkBoltDBIndexing1Workers-2             60925         60982         +0.09%
BenchmarkBoltDBIndexing2Workers-2             60931         60972         +0.07%
BenchmarkBoltDBIndexing4Workers-2             60908         60980         +0.12%
BenchmarkBoltDBIndexing1Workers10Batch-2      243862440     243789056     -0.03%
BenchmarkBoltDBIndexing2Workers10Batch-2      243884328     243811368     -0.03%
BenchmarkBoltDBIndexing4Workers10Batch-2      243900152     243797408     -0.04%
BenchmarkBoltDBIndexing1Workers100Batch-2     48443736      48348674      -0.20%
BenchmarkBoltDBIndexing2Workers100Batch-2     48438298      48346325      -0.19%
BenchmarkBoltDBIndexing4Workers100Batch-2     48441645      48347765      -0.19%