### PR TITLE
row: expose TermFrequencyRow term and freq fields

### DIFF
--- a/index/upside_down/row.go
+++ b/index/upside_down/row.go
@@ -355,6 +355,14 @@ type TermFrequencyRow struct {
 	vectors []*TermVector
 }
 
+func (tfr *TermFrequencyRow) Term() []byte {
+	return tfr.term
+}
+
+func (tfr *TermFrequencyRow) Freq() uint64 {
+	return tfr.freq
+}
+
 func (tfr *TermFrequencyRow) ScanPrefixForField() []byte {
 	buf := make([]byte, 3)
 	buf[0] = 't'


### PR DESCRIPTION
Rows content is an implementation detail of bleve index and may change
in the future. That said, they also contains information valuable to
assess the quality of the index or understand its performances. So, as
long as we agree that type asserting rows should only be done if you
know what you are doing and are ready to deal with future changes, I see
no reason to hide the row fields from external packages.

Fix #268 

I made the smallest version solving my problem (which means `1 file changed, 1 insertion(+), 30 deletions(-)` in my client code, see https://github.com/pmezard/apec/blob/master/histogram.go#L32 ). I have no strong feelings about it, you can tell me to:
- Extend it to all other fields
- Let is as it is, and let people extend it when required.
- Forget it