### PR TITLE
mapping_index: add IndexMapping.FieldAnalyzer()

### DIFF
--- a/mapping_index.go
+++ b/mapping_index.go
@@ -507,3 +507,8 @@ func (im *IndexMapping) AnalyzeText(analyzerName string, text []byte) (analysis.
 	}
 	return analyzer.Analyze(text), nil
 }
+
+// FieldAnalyzer returns the name of the analyzer used on a field.
+func (im *IndexMapping) FieldAnalyzer(field string) string {
+	return im.analyzerNameForPath(field)
+}


### PR DESCRIPTION
It returns the name of the analyzer used on a field, which can be passed
to IndexMapping.AnalyzeText().

Fix #282