### PR TITLE
mapping_field: document IncludeTermVectors

### DIFF
--- a/mapping_field.go
+++ b/mapping_field.go
@@ -30,8 +30,13 @@ type FieldMapping struct {
 
 	// Store indicates whether to store field values in the index. Stored
 	// values can be retrieved from search results using SearchRequest.Fields.
-	Store              bool   `json:"store,omitempty"`
-	Index              bool   `json:"index,omitempty"`
+	Store bool `json:"store,omitempty"`
+	Index bool `json:"index,omitempty"`
+
+	// IncludeTermVectors, if true, makes terms occurrences to be recorded for
+	// this field. It includes the term position within the terms sequence and
+	// the term offsets in the source document field. Term vectors are required
+	// to perform phrase queries or terms highlighting in source documents.
 	IncludeTermVectors bool   `json:"include_term_vectors,omitempty"`
 	IncludeInAll       bool   `json:"include_in_all,omitempty"`
 	DateFormat         string `json:"date_format,omitempty"`

--- a/query_match_phrase.go
+++ b/query_match_phrase.go
@@ -30,7 +30,8 @@ type matchPhraseQuery struct {
 // Input text is analyzed using this analyzer.
 // Token terms resulting from this analysis are
 // used to build a search phrase.  Result documents
-// must match this phrase.
+// must match this phrase. Queried field must have been indexed with
+// IncludeTermVectors set to true.
 func NewMatchPhraseQuery(matchPhrase string) *matchPhraseQuery {
 	return &matchPhraseQuery{
 		MatchPhrase: matchPhrase,

--- a/query_phrase.go
+++ b/query_phrase.go
@@ -28,7 +28,8 @@ type phraseQuery struct {
 // exact term phrases in the index.
 // The provided terms must exist in the correct
 // order, at the correct index offsets, in the
-// specified field.
+// specified field. Queried field must have been indexed with
+// IncludeTermVectors set to true.
 func NewPhraseQuery(terms []string, field string) *phraseQuery {
 	termQueries := make([]Query, 0)
 	for _, term := range terms {


### PR DESCRIPTION
And mention it is required for phrase and match phrase queries to
succeed.

Fix #280