### PR TITLE
Firestorm: dont gc if no documents

### DIFF
--- a/index/firestorm/garbage.go
+++ b/index/firestorm/garbage.go
@@ -76,6 +76,9 @@ func (gc *GarbageCollector) run() {
 				logger.Printf("garbage collector error getting doc count: %v", err)
 				continue
 			}
+			if docSize == 0 {
+				continue
+			}
 			garbageRatio := int(uint64(garbageSize) / docSize)
 			if garbageRatio > gc.garbageThreshold {
 				gc.cleanup()

--- a/index/firestorm/garbage_test.go
+++ b/index/firestorm/garbage_test.go
@@ -11,6 +11,7 @@ package firestorm
 
 import (
 	"testing"
+	"time"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store/gtreap"
@@ -114,4 +115,18 @@ func TestGarbageCleanup(t *testing.T) {
 		t.Errorf("expected deletedDocsNumbers size to be 0, got %d", f.(*Firestorm).compensator.GarbageCount())
 	}
 
+}
+
+func TestGarbageDontPanicOnEmptyDocs(t *testing.T) {
+	idx, err := NewFirestorm("", nil, index.NewAnalysisQueue(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := idx.(*Firestorm)
+	gc := NewGarbageCollector(f)
+	gc.garbageSleep = 30 * time.Millisecond
+
+	gc.Start()
+	time.Sleep(40 * time.Millisecond)
+	gc.Stop()
 }


### PR DESCRIPTION
This fixes https://github.com/blevesearch/bleve/issues/296 and adds a reproducer so that the problem doesn't show up again later.