### PR TITLE
perf 20160102

### DIFF
--- a/analysis/freq.go
+++ b/analysis/freq.go
@@ -55,28 +55,28 @@ func (tfs TokenFrequencies) MergeAll(remoteField string, other TokenFrequencies)
 func TokenFrequency(tokens TokenStream, arrayPositions []uint64) TokenFrequencies {
 	rv := make(map[string]*TokenFreq, len(tokens))
 
+	tls := make([]TokenLocation, len(tokens))
+	tlNext := 0
+
 	for _, token := range tokens {
+		tls[tlNext] = TokenLocation{
+			ArrayPositions: arrayPositions,
+			Start:          token.Start,
+			End:            token.End,
+			Position:       token.Position,
+		}
+
 		curr, ok := rv[string(token.Term)]
 		if ok {
-			curr.Locations = append(curr.Locations, &TokenLocation{
-				ArrayPositions: arrayPositions,
-				Start:          token.Start,
-				End:            token.End,
-				Position:       token.Position,
-			})
+			curr.Locations = append(curr.Locations, &tls[tlNext])
 		} else {
 			rv[string(token.Term)] = &TokenFreq{
-				Term: token.Term,
-				Locations: []*TokenLocation{
-					&TokenLocation{
-						ArrayPositions: arrayPositions,
-						Start:          token.Start,
-						End:            token.End,
-						Position:       token.Position,
-					},
-				},
+				Term:      token.Term,
+				Locations: []*TokenLocation{&tls[tlNext]},
 			}
 		}
+
+		tlNext++
 	}
 
 	return rv

--- a/analysis/tokenizers/unicode/unicode.go
+++ b/analysis/tokenizers/unicode/unicode.go
@@ -26,26 +26,33 @@ func NewUnicodeTokenizer() *UnicodeTokenizer {
 }
 
 func (rt *UnicodeTokenizer) Tokenize(input []byte) analysis.TokenStream {
+	rvx := make([]analysis.TokenStream, 0, 10) // When rv gets full, append to rvx.
+	rv := make(analysis.TokenStream, 0, 1)
+
 	ta := []analysis.Token(nil)
 	taNext := 0
-
-	rv := make(analysis.TokenStream, 0)
 
 	segmenter := segment.NewWordSegmenterDirect(input)
 	start := 0
 	pos := 1
+
+	guessRemaining := func(end int) int {
+		avgSegmentLen := end / (len(rv) + 1)
+		if avgSegmentLen < 1 {
+			avgSegmentLen = 1
+		}
+
+		remainingLen := len(input) - end
+
+		return remainingLen / avgSegmentLen
+	}
+
 	for segmenter.Segment() {
 		segmentBytes := segmenter.Bytes()
 		end := start + len(segmentBytes)
 		if segmenter.Type() != segment.None {
 			if taNext >= len(ta) {
-				avgSegmentLen := end / (len(rv) + 1)
-				if avgSegmentLen < 1 {
-					avgSegmentLen = 1
-				}
-
-				remainingLen := len(input) - end
-				remainingSegments := remainingLen / avgSegmentLen
+				remainingSegments := guessRemaining(end)
 				if remainingSegments > 1000 {
 					remainingSegments = 1000
 				}
@@ -66,11 +73,35 @@ func (rt *UnicodeTokenizer) Tokenize(input []byte) analysis.TokenStream {
 			token.Position = pos
 			token.Type = convertType(segmenter.Type())
 
+			if len(rv) >= cap(rv) { // When rv is full, save it into rvx.
+				rvx = append(rvx, rv)
+
+				rvCap := cap(rv) * 2
+				if rvCap > 256 {
+					rvCap = 256
+				}
+
+				rv = make(analysis.TokenStream, 0, rvCap) // Next rv cap is bigger.
+			}
+
 			rv = append(rv, token)
 			pos++
 		}
 		start = end
 	}
+
+	if len(rvx) > 0 {
+		n := len(rv)
+		for _, r := range rvx {
+			n += len(r)
+		}
+		rall := make(analysis.TokenStream, 0, n)
+		for _, r := range rvx {
+			rall = append(rall, r...)
+		}
+		return append(rall, rv...)
+	}
+
 	return rv
 }
 

--- a/index/firestorm/analysis.go
+++ b/index/firestorm/analysis.go
@@ -26,21 +26,21 @@ func (f *Firestorm) Analyze(d *document.Document) *index.AnalysisResult {
 
 	docIDBytes := []byte(d.ID)
 
+	// add the _id row
+	rv.Rows = append(rv.Rows, NewTermFreqRow(0, nil, docIDBytes, d.Number, 0, 0, nil))
+
 	// information we collate as we merge fields with same name
 	fieldTermFreqs := make(map[uint16]analysis.TokenFrequencies)
 	fieldLengths := make(map[uint16]int)
 	fieldIncludeTermVectors := make(map[uint16]bool)
 	fieldNames := make(map[uint16]string)
 
-	for _, field := range d.Fields {
+	analyzeField := func(field document.Field, storable bool) {
 		fieldIndex, newFieldRow := f.fieldIndexOrNewRow(field.Name())
 		if newFieldRow != nil {
 			rv.Rows = append(rv.Rows, newFieldRow)
 		}
 		fieldNames[fieldIndex] = field.Name()
-
-		// add the _id row
-		rv.Rows = append(rv.Rows, NewTermFreqRow(0, nil, docIDBytes, d.Number, 0, 0, nil))
 
 		if field.Options().IsIndexed() {
 			fieldLength, tokenFreqs := field.Analyze()
@@ -55,11 +55,34 @@ func (f *Firestorm) Analyze(d *document.Document) *index.AnalysisResult {
 			fieldIncludeTermVectors[fieldIndex] = field.Options().IncludeTermVectors()
 		}
 
-		if field.Options().IsStored() {
+		if storable && field.Options().IsStored() {
 			storeRow := f.storeField(docIDBytes, d.Number, field, fieldIndex)
 			rv.Rows = append(rv.Rows, storeRow)
 		}
 	}
+
+	for _, field := range d.Fields {
+		analyzeField(field, true)
+	}
+
+	for fieldIndex, tokenFreqs := range fieldTermFreqs {
+		// see if any of the composite fields need this
+		for _, compositeField := range d.CompositeFields {
+			compositeField.Compose(fieldNames[fieldIndex], fieldLengths[fieldIndex], tokenFreqs)
+		}
+	}
+
+	for _, compositeField := range d.CompositeFields {
+		analyzeField(compositeField, false)
+	}
+
+	rowsCapNeeded := len(rv.Rows)
+	for _, tokenFreqs := range fieldTermFreqs {
+		rowsCapNeeded += len(tokenFreqs)
+	}
+
+	rows := make([]index.IndexRow, 0, rowsCapNeeded)
+	rv.Rows = append(rows, rv.Rows...)
 
 	// walk through the collated information and proccess
 	// once for each indexed field (unique name)
@@ -67,63 +90,39 @@ func (f *Firestorm) Analyze(d *document.Document) *index.AnalysisResult {
 		fieldLength := fieldLengths[fieldIndex]
 		includeTermVectors := fieldIncludeTermVectors[fieldIndex]
 
-		// see if any of the composite fields need this
-		for _, compositeField := range d.CompositeFields {
-			compositeField.Compose(fieldNames[fieldIndex], fieldLength, tokenFreqs)
-		}
-
-		// encode this field
-		indexRows := f.indexField(docIDBytes, d.Number, includeTermVectors, fieldIndex, fieldLength, tokenFreqs)
-		rv.Rows = append(rv.Rows, indexRows...)
-	}
-
-	// now index the composite fields
-	for _, compositeField := range d.CompositeFields {
-		fieldIndex, newFieldRow := f.fieldIndexOrNewRow(compositeField.Name())
-		if newFieldRow != nil {
-			rv.Rows = append(rv.Rows, newFieldRow)
-		}
-		if compositeField.Options().IsIndexed() {
-			fieldLength, tokenFreqs := compositeField.Analyze()
-			// encode this field
-			indexRows := f.indexField(docIDBytes, d.Number, compositeField.Options().IncludeTermVectors(), fieldIndex, fieldLength, tokenFreqs)
-			rv.Rows = append(rv.Rows, indexRows...)
-		}
+		rv.Rows = f.indexField(docIDBytes, d.Number, includeTermVectors, fieldIndex, fieldLength, tokenFreqs, rv.Rows)
 	}
 
 	return rv
 }
 
-func (f *Firestorm) indexField(docID []byte, docNum uint64, includeTermVectors bool, fieldIndex uint16, fieldLength int, tokenFreqs analysis.TokenFrequencies) []index.IndexRow {
+func (f *Firestorm) indexField(docID []byte, docNum uint64, includeTermVectors bool, fieldIndex uint16, fieldLength int, tokenFreqs analysis.TokenFrequencies, rows []index.IndexRow) []index.IndexRow {
 
 	tfrs := make([]TermFreqRow, len(tokenFreqs))
 
 	fieldNorm := float32(1.0 / math.Sqrt(float64(fieldLength)))
 
 	if !includeTermVectors {
-		rows := make([]index.IndexRow, len(tokenFreqs))
 		i := 0
 		for _, tf := range tokenFreqs {
-			rows[i] = InitTermFreqRow(&tfrs[i], fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, nil)
+			rows = append(rows, InitTermFreqRow(&tfrs[i], fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, nil))
 			i++
 		}
 		return rows
 	}
 
-	rows := make([]index.IndexRow, 0, len(tokenFreqs))
 	i := 0
 	for _, tf := range tokenFreqs {
-		tv, newFieldRows := f.termVectorsFromTokenFreq(fieldIndex, tf)
-		rows = append(rows, newFieldRows...)
+		var tv []*TermVector
+		tv, rows = f.termVectorsFromTokenFreq(fieldIndex, tf, rows)
 		rows = append(rows, InitTermFreqRow(&tfrs[i], fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, tv))
 		i++
 	}
 	return rows
 }
 
-func (f *Firestorm) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFreq) ([]*TermVector, []index.IndexRow) {
+func (f *Firestorm) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFreq, rows []index.IndexRow) ([]*TermVector, []index.IndexRow) {
 	rv := make([]*TermVector, len(tf.Locations))
-	newFieldRows := make([]index.IndexRow, 0)
 
 	for i, l := range tf.Locations {
 		var newFieldRow *FieldRow
@@ -132,14 +131,14 @@ func (f *Firestorm) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFre
 			// lookup correct field
 			fieldIndex, newFieldRow = f.fieldIndexOrNewRow(l.Field)
 			if newFieldRow != nil {
-				newFieldRows = append(newFieldRows, newFieldRow)
+				rows = append(rows, newFieldRow)
 			}
 		}
 		tv := NewTermVector(fieldIndex, uint64(l.Position), uint64(l.Start), uint64(l.End), l.ArrayPositions)
 		rv[i] = tv
 	}
 
-	return rv, newFieldRows
+	return rv, rows
 }
 
 func (f *Firestorm) storeField(docID []byte, docNum uint64, field document.Field, fieldIndex uint16) index.IndexRow {

--- a/index/firestorm/analysis.go
+++ b/index/firestorm/analysis.go
@@ -97,19 +97,23 @@ func (f *Firestorm) Analyze(d *document.Document) *index.AnalysisResult {
 func (f *Firestorm) indexField(docID []byte, docNum uint64, includeTermVectors bool, fieldIndex uint16, fieldLength int, tokenFreqs analysis.TokenFrequencies) []index.IndexRow {
 
 	rows := make([]index.IndexRow, 0, len(tokenFreqs))
+	tfrs := make([]TermFreqRow, len(tokenFreqs))
+
 	fieldNorm := float32(1.0 / math.Sqrt(float64(fieldLength)))
 
+	i := 0
 	for _, tf := range tokenFreqs {
 		var termFreqRow *TermFreqRow
 		if includeTermVectors {
 			tv, newFieldRows := f.termVectorsFromTokenFreq(fieldIndex, tf)
 			rows = append(rows, newFieldRows...)
-			termFreqRow = NewTermFreqRow(fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, tv)
+			termFreqRow = InitTermFreqRow(&tfrs[i], fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, tv)
 		} else {
-			termFreqRow = NewTermFreqRow(fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, nil)
+			termFreqRow = InitTermFreqRow(&tfrs[i], fieldIndex, tf.Term, docID, docNum, uint64(tf.Frequency()), fieldNorm, nil)
 		}
 
 		rows = append(rows, termFreqRow)
+		i++
 	}
 
 	return rows

--- a/index/firestorm/analysis.go
+++ b/index/firestorm/analysis.go
@@ -94,7 +94,7 @@ func (f *Firestorm) Analyze(d *document.Document) *index.AnalysisResult {
 
 func (f *Firestorm) indexField(docID string, docNum uint64, includeTermVectors bool, fieldIndex uint16, fieldLength int, tokenFreqs analysis.TokenFrequencies) []index.IndexRow {
 
-	rows := make([]index.IndexRow, 0, 100)
+	rows := make([]index.IndexRow, 0, len(tokenFreqs))
 	fieldNorm := float32(1.0 / math.Sqrt(float64(fieldLength)))
 
 	for _, tf := range tokenFreqs {

--- a/index/firestorm/analysis_test.go
+++ b/index/firestorm/analysis_test.go
@@ -78,8 +78,8 @@ func TestAnalysis(t *testing.T) {
 			r: &index.AnalysisResult{
 				DocID: "a",
 				Rows: []index.IndexRow{
-					NewFieldRow(1, "name"),
 					NewTermFreqRow(0, nil, []byte("a"), 1, 0, 0.0, nil),
+					NewFieldRow(1, "name"),
 					NewStoredRow([]byte("a"), 1, 1, nil, []byte("ttest")),
 					NewTermFreqRow(1, []byte("test"), []byte("a"), 1, 1, 1.0, []*TermVector{NewTermVector(1, 1, 0, 4, nil)}),
 				},

--- a/index/firestorm/comp.go
+++ b/index/firestorm/comp.go
@@ -106,7 +106,7 @@ func (c *Compensator) Migrate(docID []byte, docNum uint64, oldDocNums []uint64) 
 
 	// remove entry from in-flight if it still has same doc num
 	val := c.inFlight.Get(&InFlightItem{docID: docID})
-	if val.(*InFlightItem).docNum == docNum {
+	if val != nil && val.(*InFlightItem).docNum == docNum {
 		c.inFlight = c.inFlight.Delete(&InFlightItem{docID: docID})
 	}
 }

--- a/index/firestorm/dict_updater_test.go
+++ b/index/firestorm/dict_updater_test.go
@@ -10,6 +10,7 @@
 package firestorm
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/blevesearch/bleve/index"
@@ -38,6 +39,9 @@ func TestDictUpdater(t *testing.T) {
 	f.(*Firestorm).dictUpdater.NotifyBatch(dictBatch)
 
 	// invoke updater manually
+	for len(f.(*Firestorm).dictUpdater.incoming) > 0 {
+		runtime.Gosched()
+	}
 	f.(*Firestorm).dictUpdater.update()
 
 	// assert that dictionary rows are correct
@@ -77,6 +81,9 @@ func TestDictUpdater(t *testing.T) {
 	f.(*Firestorm).dictUpdater.NotifyBatch(dictBatch)
 
 	// invoke updater manually
+	for len(f.(*Firestorm).dictUpdater.incoming) > 0 {
+		runtime.Gosched()
+	}
 	f.(*Firestorm).dictUpdater.update()
 
 	// assert that dictionary rows are correct
@@ -116,6 +123,9 @@ func TestDictUpdater(t *testing.T) {
 	f.(*Firestorm).dictUpdater.NotifyBatch(dictBatch)
 
 	// invoke updater manually
+	for len(f.(*Firestorm).dictUpdater.incoming) > 0 {
+		runtime.Gosched()
+	}
 	f.(*Firestorm).dictUpdater.update()
 
 	// assert that dictionary rows are correct

--- a/index/firestorm/firestorm.go
+++ b/index/firestorm/firestorm.go
@@ -144,10 +144,9 @@ func (f *Firestorm) Update(doc *document.Document) (err error) {
 	analysisStart := time.Now()
 	resultChan := make(chan *index.AnalysisResult)
 	aw := index.NewAnalysisWork(f, doc, resultChan)
+
 	// put the work on the queue
-	go func() {
-		f.analysisQueue.Queue(aw)
-	}()
+	go f.analysisQueue.Queue(aw)
 
 	// wait for the result
 	result := <-resultChan

--- a/index/firestorm/firestorm.go
+++ b/index/firestorm/firestorm.go
@@ -218,23 +218,21 @@ func (f *Firestorm) batchRows(writer store.KVWriter, rows []index.IndexRow, dele
 
 				dictionaryDeltas[string(kbuf[0:klen])] += 1
 			}
-
-			kbuf = prepareBuf(kbuf, tfr.KeySize())
-			klen, err := tfr.KeyTo(kbuf)
-			if err != nil {
-				return nil, err
-			}
-
-			vbuf = prepareBuf(vbuf, tfr.ValueSize())
-			vlen, err := tfr.ValueTo(vbuf)
-			if err != nil {
-				return nil, err
-			}
-
-			wb.Set(kbuf[0:klen], vbuf[0:vlen])
-		} else {
-			wb.Set(row.Key(), row.Value())
 		}
+
+		kbuf = prepareBuf(kbuf, row.KeySize())
+		klen, err := row.KeyTo(kbuf)
+		if err != nil {
+			return nil, err
+		}
+
+		vbuf = prepareBuf(vbuf, row.ValueSize())
+		vlen, err := row.ValueTo(vbuf)
+		if err != nil {
+			return nil, err
+		}
+
+		wb.Set(kbuf[0:klen], vbuf[0:vlen])
 	}
 
 	for _, dk := range deleteKeys {

--- a/index/firestorm/lookup_test.go
+++ b/index/firestorm/lookup_test.go
@@ -62,7 +62,7 @@ func TestLookups(t *testing.T) {
 			if val == nil {
 				t.Errorf("expected key: % x to be in the inflight list", tfr.DocID())
 			}
-			f.(*Firestorm).lookuper.lookup(&lookupTask{docID: tfr.DocID(), docNum: tfr.DocNum()})
+			f.(*Firestorm).lookuper.lookup(&InFlightItem{docID: tfr.DocID(), docNum: tfr.DocNum()})
 			// now expect this mutation to NOT be in the in-flight list
 			val = f.(*Firestorm).compensator.inFlight.Get(&InFlightItem{docID: tfr.DocID()})
 			if val != nil {

--- a/index/firestorm/termfreq.go
+++ b/index/firestorm/termfreq.go
@@ -46,18 +46,18 @@ func NewTermVector(field uint16, pos uint64, start uint64, end uint64, arrayPos 
 }
 
 func NewTermFreqRow(field uint16, term []byte, docID []byte, docNum uint64, freq uint64, norm float32, termVectors []*TermVector) *TermFreqRow {
-	rv := TermFreqRow{
-		field:  field,
-		term:   term,
-		docID:  docID,
-		docNum: docNum,
-	}
+	return InitTermFreqRow(&TermFreqRow{}, field, term, docID, docNum, freq, norm, termVectors)
+}
 
-	rv.value.Freq = proto.Uint64(freq)
-	rv.value.Norm = proto.Float32(norm)
-	rv.value.Vectors = termVectors
-
-	return &rv
+func InitTermFreqRow(tfr *TermFreqRow, field uint16, term []byte, docID []byte, docNum uint64, freq uint64, norm float32, termVectors []*TermVector) *TermFreqRow {
+	tfr.field = field
+	tfr.term = term
+	tfr.docID = docID
+	tfr.docNum = docNum
+	tfr.value.Freq = proto.Uint64(freq)
+	tfr.value.Norm = proto.Float32(norm)
+	tfr.value.Vectors = termVectors
+	return tfr
 }
 
 func NewTermFreqRowKV(key, value []byte) (*TermFreqRow, error) {


### PR DESCRIPTION
In contrast to yesterday's pull request (https://github.com/blevesearch/bleve/pull/304), this most recent pull request has two additional changes...

- a firestorm.Batch() improvement to avoid more data copying in append()'s.

- thanks to @nuss-justin, for feedback that led to dropping a change as the go compiler does some smart things when reading a map via this kind of idiom: myMap[string(bytesKey)].  Thanks for helping to make this better and helping to produce negative lines of code!






dropping a change