### PR TITLE
analyze locations only if includeTermVectors enabled

### DIFF
--- a/analysis/benchmark_test.go
+++ b/analysis/benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkAnalysis(b *testing.B) {
 		}
 
 		ts := analyzer.Analyze(bleveWikiArticle)
-		freqs := analysis.TokenFrequency(ts, nil)
+		freqs := analysis.TokenFrequency(ts, nil, true)
 		if len(freqs) != 511 {
 			b.Errorf("expected %d freqs, got %d", 511, len(freqs))
 		}

--- a/analysis/freq_test.go
+++ b/analysis/freq_test.go
@@ -44,9 +44,10 @@ func TestTokenFrequency(t *testing.T) {
 					End:      11,
 				},
 			},
+			frequency: 2,
 		},
 	}
-	result := TokenFrequency(tokens, nil)
+	result := TokenFrequency(tokens, nil, true)
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Errorf("expected %#v, got %#v", expectedResult, result)
 	}

--- a/document/field_datetime.go
+++ b/document/field_datetime.go
@@ -75,7 +75,7 @@ func (n *DateTimeField) Analyze() (int, analysis.TokenFrequencies) {
 	}
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions)
+	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_numeric.go
+++ b/document/field_numeric.go
@@ -71,7 +71,7 @@ func (n *NumericField) Analyze() (int, analysis.TokenFrequencies) {
 	}
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions)
+	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_text.go
+++ b/document/field_text.go
@@ -60,7 +60,7 @@ func (t *TextField) Analyze() (int, analysis.TokenFrequencies) {
 		}
 	}
 	fieldLength := len(tokens) // number of tokens in this doc field
-	tokenFreqs := analysis.TokenFrequency(tokens, t.arrayPositions)
+	tokenFreqs := analysis.TokenFrequency(tokens, t.arrayPositions, t.options.IncludeTermVectors())
 	return fieldLength, tokenFreqs
 }
 

--- a/index/firestorm/dict_updater.go
+++ b/index/firestorm/dict_updater.go
@@ -59,7 +59,7 @@ func (d *DictUpdater) NotifyBatch(termUsages map[string]int64) {
 
 func (d *DictUpdater) Start() {
 	d.closeWait.Add(1)
-    go d.runIncoming()
+	go d.runIncoming()
 	go d.run()
 }
 

--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -664,7 +664,7 @@ func decodeFieldType(typ byte, name string, pos []uint64, value []byte) document
 }
 
 func frequencyFromTokenFreq(tf *analysis.TokenFreq) int {
-	return len(tf.Locations)
+	return tf.Frequency()
 }
 
 func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.TokenFreq) ([]*TermVector, []index.IndexRow) {


### PR DESCRIPTION
With this change, TermLocations are computed and maintained only if
includeTermVectors is enabled, for higher performance.