### PR TITLE
Fix masking of error when creating index (minor error reporting fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .#*
 .project
 .settings
+**/.idea/
+**/*.iml
 .DS_Store
 /analysis/token_filters/cld2/cld2-read-only
 /analysis/token_filters/cld2/libcld2_full.a

--- a/index_meta.go
+++ b/index_meta.go
@@ -58,7 +58,10 @@ func (i *indexMeta) Save(path string) (err error) {
 	// ensure any necessary parent directories exist
 	err = os.Mkdir(path, 0700)
 	if err != nil {
-		return ErrorIndexPathExists
+		if os.IsExist(err) {
+			return ErrorIndexPathExists
+		}
+		return err
 	}
 	metaBytes, err := json.Marshal(i)
 	if err != nil {


### PR DESCRIPTION
Our continuous integration tests are failing with `cannot create new index, path already exists` when creating a test index.  I can't reproduce this error on my laptop (macbook pro) -- it only happens in CI (shippable.com, ubuntu in a Docker container).  I added a line to explicitly remove the path before creating the index, and am seeing the same failure.  I think the code I changed was masking the actual error by always returning the "path already exists" error without first checking the error type.
