### PR TITLE
introduce ability for searches to timeout or be cancelled

### DIFF
--- a/index.go
+++ b/index.go
@@ -13,6 +13,7 @@ import (
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store"
+	"golang.org/x/net/context"
 )
 
 // A Batch groups together multiple Index and Delete
@@ -167,6 +168,7 @@ type Index interface {
 	DocCount() (uint64, error)
 
 	Search(req *SearchRequest) (*SearchResult, error)
+	SearchInContext(ctx context.Context, req *SearchRequest) (*SearchResult, error)
 
 	Fields() ([]string, error)
 

--- a/index_impl.go
+++ b/index_impl.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store"
@@ -364,6 +366,12 @@ func (i *indexImpl) DocCount() (uint64, error) {
 // Search executes a search request operation.
 // Returns a SearchResult object or an error.
 func (i *indexImpl) Search(req *SearchRequest) (sr *SearchResult, err error) {
+	return i.SearchInContext(context.Background(), req)
+}
+
+// SearchInContext executes a search request operation within the provided
+// Context.  Returns a SearchResult object or an error.
+func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr *SearchResult, err error) {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()
 
@@ -424,7 +432,7 @@ func (i *indexImpl) Search(req *SearchRequest) (sr *SearchResult, err error) {
 		collector.SetFacetsBuilder(facetsBuilder)
 	}
 
-	err = collector.Collect(searcher)
+	err = collector.Collect(ctx, searcher)
 	if err != nil {
 		return nil, err
 	}

--- a/search/collector.go
+++ b/search/collector.go
@@ -11,10 +11,12 @@ package search
 
 import (
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 type Collector interface {
-	Collect(searcher Searcher) error
+	Collect(ctx context.Context, searcher Searcher) error
 	Results() DocumentMatchCollection
 	Total() uint64
 	MaxScore() float64

--- a/search/collectors/collector_top_score_test.go
+++ b/search/collectors/collector_top_score_test.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/blevesearch/bleve/search"
 )
 
@@ -84,7 +86,7 @@ func TestTop10Scores(t *testing.T) {
 	}
 
 	collector := NewTopScorerCollector(10)
-	err := collector.Collect(searcher)
+	err := collector.Collect(context.Background(), searcher)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +194,7 @@ func TestTop10ScoresSkip10(t *testing.T) {
 	}
 
 	collector := NewTopScorerSkipCollector(10, 10)
-	err := collector.Collect(searcher)
+	err := collector.Collect(context.Background(), searcher)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +240,7 @@ func BenchmarkTop10of100000Scores(b *testing.B) {
 	collector := NewTopScorerCollector(10)
 	b.ResetTimer()
 
-	err := collector.Collect(searcher)
+	err := collector.Collect(context.Background(), searcher)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
our implementation uses: golang.org/x/net/context

New method SearchInContext() allows the user to run a search
in the provided context.  If that context is cancelled or
exceeds its deadline Bleve will attempt to stop and return
as soon as possible.  This is a *best effort* attempt at this
time and may *not* be in a timely manner.  If the caller must
return very near the timeout, the call should also be wrapped
in a goroutine.

The IndexAlias ipmlementation is affected in a slightly more
complex way.  In order to return partial results when a timeout
occurs on some indexes, the timeout is strictly enforced, and
at the moment this does introduce an additional goroutine.

The Bleve implementation honoring the context is currently
very course-grained.  Specifically we check the Done() channel
between each DocumentMatch produced during the search.  In the
future we will propogate the context deeper into the internals
of Bleve, and this will allow finer-grained timeout behavior.