### PR TITLE
moss lowerLevelUpdate didn't handle batches of size 1

### DIFF
--- a/index/store/moss/store.go
+++ b/index/store/moss/store.go
@@ -82,7 +82,7 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 
 	// --------------------------------------------------
 
-	if options.Log == nil {
+	if options.Log == nil || options.Debug <= 0 {
 		options.Log = func(format string, a ...interface{}) {}
 	}
 


### PR DESCRIPTION
The key was moving the i++ to the right place.

Also, tweaked the logging along the way to tracking this down.
