### PR TITLE
Minor fix to ensure full index path exists

### DIFF
--- a/index_meta.go
+++ b/index_meta.go
@@ -56,7 +56,7 @@ func openIndexMeta(path string) (*indexMeta, error) {
 func (i *indexMeta) Save(path string) (err error) {
 	indexMetaPath := indexMetaPath(path)
 	// ensure any necessary parent directories exist
-	err = os.Mkdir(path, 0700)
+	err = os.MkdirAll(path, 0700)
 	if err != nil {
 		if os.IsExist(err) {
 			return ErrorIndexPathExists


### PR DESCRIPTION
From the comment on the line above, it looks like this was intended to be a call to `os.MkdirAll` instead of `os.Mkdir`.  I caught this because one of my tests is failing to create the test index at a location where the full parent path does not exist.

