### PR TITLE
Remove DictionaryTerm with count 0 during compact (workaround for #374)

### DIFF
--- a/index/store/goleveldb/store.go
+++ b/index/store/goleveldb/store.go
@@ -10,6 +10,7 @@
 package goleveldb
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/blevesearch/bleve/index/store"
@@ -19,7 +20,10 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
-const Name = "goleveldb"
+const (
+	Name             = "goleveldb"
+	defaultBatchSize = 250
+)
 
 type Store struct {
 	path string
@@ -78,8 +82,57 @@ func (ldbs *Store) Writer() (store.KVWriter, error) {
 	}, nil
 }
 
-func (ldbs *Store) Compact() error {
+// CompactWithBatchSize removes DictionaryTerm entries with a count of zero (in batchSize batches), then
+// compacts the underlying goleveldb store.  Removing entries is a workaround for github issue #374.
+func (ldbs *Store) CompactWithBatchSize(batchSize int) error {
+	// workaround for github issue #374 - remove DictionaryTerm keys with count=0
+	batch := &leveldb.Batch{}
+	for {
+		iter := ldbs.db.NewIterator(util.BytesPrefix([]byte("d")), ldbs.defaultReadOptions)
+		t, err := ldbs.db.OpenTransaction()
+		if err != nil {
+			return err
+		}
+
+		for iter.Next() {
+			if bytes.Equal(iter.Value(), []byte{0}) {
+				k := append([]byte{}, iter.Key()...)
+				batch.Delete(k)
+			}
+			if batch.Len() == batchSize {
+				break
+			}
+		}
+		iter.Release()
+		if iter.Error() != nil {
+			t.Discard()
+			return iter.Error()
+		}
+
+		if batch.Len() > 0 {
+			err := t.Write(batch, ldbs.defaultWriteOptions)
+			if err != nil {
+				t.Discard()
+				return err
+			}
+			err = t.Commit()
+			if err != nil {
+				return err
+			}
+		} else {
+			t.Discard()
+			break
+		}
+		batch.Reset()
+	}
+
 	return ldbs.db.CompactRange(util.Range{nil, nil})
+}
+
+// Compact compacts the underlying goleveldb store.  The current implementation includes a workaround
+// for github issue #374 (see CompactWithBatchSize).
+func (ldbs *Store) Compact() error {
+	return ldbs.CompactWithBatchSize(defaultBatchSize)
 }
 
 func init() {

--- a/index/store/goleveldb/store.go
+++ b/index/store/goleveldb/store.go
@@ -88,11 +88,11 @@ func (ldbs *Store) CompactWithBatchSize(batchSize int) error {
 	// workaround for github issue #374 - remove DictionaryTerm keys with count=0
 	batch := &leveldb.Batch{}
 	for {
-		iter := ldbs.db.NewIterator(util.BytesPrefix([]byte("d")), ldbs.defaultReadOptions)
 		t, err := ldbs.db.OpenTransaction()
 		if err != nil {
 			return err
 		}
+		iter := t.NewIterator(util.BytesPrefix([]byte("d")), ldbs.defaultReadOptions)
 
 		for iter.Next() {
 			if bytes.Equal(iter.Value(), []byte{0}) {


### PR DESCRIPTION
I spent a couple hours on this last night as a workaround for #374.

The implementation removes all DictionaryTerm entries with Count=0 from the index, in configurable batches, within a transaction.  Originally I did this all in one large transaction, but settled on this approach to avoid locking out other writers for an extended period of time.  A batch size of 250 seems like a good default number for a server-based implementation...I'll be using batch sizes of more like 50-100 in my app (running on a single core ARMv7).

I ran this test, that I wrote before submitting #374:

>1.  Create and initialize a new index, take snapshot of size of index folder
>1.  Do the following 5 times:
>    1.  Add 1000 documents to the index
>    1.  Take snapshot of size of index folder
>    1.  Delete all documents from the index
>    1.  Call the new `Compact` method I added in #373 
>    1.  Take snapshot of size of index folder

I verified that there were no dictionary term entries present after the test, and the `.ldb` file contained only the document mapping and fields.

I also ran a variation of the test above to ensure that documents could still be indexed during the execution of `CompactWithBatchSize`.  Just before calling `CompactWithBatchSize`, I started another goroutine to index documents during the compact.  I verified that the documents were indexed, document count after finishing was correct, and there were no dictionary term entries with count 0.
