### PR TITLE
Compact for boltdb (workaround for #374)

### DIFF
--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	Name             = "boltdb"
-	defaultBatchSize = 100
+	Name                    = "boltdb"
+	defaultCompactBatchSize = 100
 )
 
 type Store struct {
@@ -143,7 +143,7 @@ func (bs *Store) CompactWithBatchSize(batchSize int) error {
 // Compact calls CompactWithBatchSize with a default batch size of 100.  This is a workaround
 // for github issue #374.
 func (bs *Store) Compact() error {
-	return bs.CompactWithBatchSize(defaultBatchSize)
+	return bs.CompactWithBatchSize(defaultCompactBatchSize)
 }
 
 func init() {

--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -106,8 +106,8 @@ func (bs *Store) Stats() json.Marshaler {
 	}
 }
 
-// CompactWithBatchSize removes DictionaryTerm entries with a count of zero (in batchSize batches), then
-// compacts the underlying boltdb store.  Removing entries is a workaround for github issue #374.
+// CompactWithBatchSize removes DictionaryTerm entries with a count of zero (in batchSize batches)
+// Removing entries is a workaround for github issue #374.
 func (bs *Store) CompactWithBatchSize(batchSize int) error {
 	for {
 		cnt := 0
@@ -140,8 +140,8 @@ func (bs *Store) CompactWithBatchSize(batchSize int) error {
 	return nil
 }
 
-// Compact compacts the underlying boltdb store.  The current implementation includes a workaround
-// for github issue #374 (see CompactWithBatchSize).
+// Compact calls CompactWithBatchSize with a default batch size of 100.  This is a workaround
+// for github issue #374.
 func (bs *Store) Compact() error {
 	return bs.CompactWithBatchSize(defaultBatchSize)
 }

--- a/index/store/goleveldb/store.go
+++ b/index/store/goleveldb/store.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	Name             = "goleveldb"
-	defaultBatchSize = 250
+	Name                    = "goleveldb"
+	defaultCompactBatchSize = 250
 )
 
 type Store struct {
@@ -132,7 +132,7 @@ func (ldbs *Store) CompactWithBatchSize(batchSize int) error {
 // Compact compacts the underlying goleveldb store.  The current implementation includes a workaround
 // for github issue #374 (see CompactWithBatchSize).
 func (ldbs *Store) Compact() error {
-	return ldbs.CompactWithBatchSize(defaultBatchSize)
+	return ldbs.CompactWithBatchSize(defaultCompactBatchSize)
 }
 
 func init() {


### PR DESCRIPTION
This is similar to PR #376 (workaround for issue #374), except for boltdb.  

Sorry I didn't reach this conclusion sooner, but it looks like goleveldb won't work for our application even with the new compact logic.  In continued stress testing on a gateway device (128MB RAM, ~100MB available flash), we saw the following:

1.  Within `Compact`, can successfully remove unused `DictionaryTerm` entries.
1.  Application crashes (out of memory) during call to `ldbs.db.CompactRange(util.Range{nil, nil})`.  Apparently `CompactRange` uses a lot of extra memory to remap the file.

I swapped out goleveldb for boltdb and tried all of this again.  With boltdb, we can do the following to manage our filesystem resources without crashing:

1.  Calculate the maximum size we can allow the DB file to reach based on partition free space
1.  When the DB reaches maximum allowable size, begin monitoring the size of the free page list
1.  When the free page list reaches a threshold (prior to where boltdb would try to grow the file):
    1.  Purge oldest documents to free up space
    1.  Call this `Compact` to free up unused `DictionaryTerm` entries

Again, the code from both of these PRs can be removed once #374 is solved.