### PR TITLE
Preventing panic on ngram initialization, and extending the type conversion

### DIFF
--- a/analysis/token_filters/ngram_filter/ngram_filter.go
+++ b/analysis/token_filters/ngram_filter/ngram_filter.go
@@ -71,20 +71,48 @@ func buildTermFromRunes(runes []rune) []byte {
 }
 
 func NgramFilterConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.TokenFilter, error) {
-	minVal, ok := config["min"].(float64)
+	minVal, ok := config["min"]
 	if !ok {
 		return nil, fmt.Errorf("must specify min")
 	}
-	min := int(minVal)
-	maxVal, ok := config["max"].(float64)
+
+	min, err := convertToInt(minVal)
+	if err != nil {
+		return nil, err
+	}
+
+	maxVal, ok := config["max"]
 	if !ok {
 		return nil, fmt.Errorf("must specify max")
 	}
-	max := int(maxVal)
+
+	max, err := convertToInt(maxVal)
+	if err != nil {
+		return nil, err
+	}
 
 	return NewNgramFilter(min, max), nil
 }
 
 func init() {
 	registry.RegisterTokenFilter(Name, NgramFilterConstructor)
+}
+
+// Expects either an int or a flaot64 value
+func convertToInt(val interface{}) (int, error) {
+	var intVal int
+	var floatVal float64
+	var ok bool
+
+	intVal, ok = val.(int)
+	if ok {
+		return intVal, nil
+	}
+
+	floatVal, ok = val.(float64)
+	if ok {
+		return int(floatVal), nil
+	}
+
+	return 0, fmt.Errorf("failed to convert to int value")
 }

--- a/analysis/token_filters/ngram_filter/ngram_filter_test.go
+++ b/analysis/token_filters/ngram_filter/ngram_filter_test.go
@@ -130,3 +130,58 @@ func TestNgramFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestConversionInt(t *testing.T) {
+	config := map[string]interface{}{
+		"type": Name,
+		"min":  3,
+		"max":  8,
+	}
+
+	f, err := NgramFilterConstructor(config, nil)
+
+	if err != nil {
+		t.Errorf("Failed to construct the ngram filter: %v", err)
+	}
+
+	ngram := f.(*NgramFilter)
+	if ngram.minLength != 3 && ngram.maxLength != 8 {
+		t.Errorf("Failed to construct the bounds. Got %v and %v.", ngram.minLength, ngram.maxLength)
+	}
+}
+
+func TestConversionFloat(t *testing.T) {
+	config := map[string]interface{}{
+		"type": Name,
+		"min":  float64(3),
+		"max":  float64(8),
+	}
+
+	f, err := NgramFilterConstructor(config, nil)
+
+	if err != nil {
+		t.Errorf("Failed to construct the ngram filter: %v", err)
+	}
+
+	ngram := f.(*NgramFilter)
+	if ngram.minLength != 3 && ngram.maxLength != 8 {
+		t.Errorf("Failed to construct the bounds. Got %v and %v.", ngram.minLength, ngram.maxLength)
+	}
+}
+
+func TestBadConversion(t *testing.T) {
+	config := map[string]interface{}{
+		"type": Name,
+		"min":  "3",
+	}
+
+	_, err := NgramFilterConstructor(config, nil)
+
+	if err == nil {
+		t.Errorf("Expected conversion error.")
+	}
+
+	if err.Error() != "failed to convert to int value" {
+		t.Errorf("Wrong error recevied. Got %v.", err)
+	}
+}


### PR DESCRIPTION
This update merely the configuration of the ngram filter more natural.
It achieves the following:
1) Prevents panics is the conf map does not contain float64 as min and max values

2) Extends the type conversion for min/max fields to both float64 and int.
The int is a more natural type for the conf specification since these values are always integers. 