### PR TITLE
configurable mossStoreOptions and DeferredSort defaults to true

### DIFF
--- a/index/store/moss/store.go
+++ b/index/store/moss/store.go
@@ -65,6 +65,9 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 		}
 	}
 
+	options.MergeOperator = mo
+	options.DeferredSort = true
+
 	v, ok = config["mossCollectionOptions"]
 	if ok {
 		b, err := json.Marshal(v) // Convert from map[string]interface{}.
@@ -125,11 +128,11 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 		}
 
 		lowerLevelInit, lowerLevelUpdate, lowerLevelStore, err :=
-			initLowerLevelStore(mo, config,
+			initLowerLevelStore(config,
 				mossLowerLevelStoreName,
 				mossLowerLevelStoreConfig,
 				mossLowerLevelMaxBatchSize,
-				options.Log)
+				options)
 		if err != nil {
 			return nil, err
 		}
@@ -140,8 +143,6 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 	}
 
 	// --------------------------------------------------
-
-	options.MergeOperator = mo
 
 	ms, err := moss.NewCollection(options)
 	if err != nil {


### PR DESCRIPTION
Due to some local bleve-blast performance runs on my OSX dev box, I saw that the deferred sorting option in moss seemed to help a little with throughput.  So, this change flips on DeferredSort to true by default.

Also, I added an optional "mossStoreOptions" to the map[string]interface{} config, for more configurability.  For example, we should be able to turn that new DeferredSort to false via this new "mossStoreOptions".

Finally, I also tried to simplify the InitMossStore() parameters list by passing along the full options struct.
