### PR TITLE
Add bucket fillPercent option for boltdb

### DIFF
--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -33,11 +33,12 @@ const (
 )
 
 type Store struct {
-	path   string
-	bucket string
-	db     *bolt.DB
-	noSync bool
-	mo     store.MergeOperator
+	path        string
+	bucket      string
+	db          *bolt.DB
+	noSync      bool
+	fillPercent float64
+	mo          store.MergeOperator
 }
 
 func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, error) {
@@ -52,6 +53,11 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 	}
 
 	noSync, _ := config["nosync"].(bool)
+
+	fillPercent, ok := config["fillPercent"].(float64)
+	if !ok {
+		fillPercent = bolt.DefaultFillPercent
+	}
 
 	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
@@ -69,11 +75,12 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 	}
 
 	rv := Store{
-		path:   path,
-		bucket: bucket,
-		db:     db,
-		mo:     mo,
-		noSync: noSync,
+		path:        path,
+		bucket:      bucket,
+		db:          db,
+		mo:          mo,
+		noSync:      noSync,
+		fillPercent: fillPercent,
 	}
 	return &rv, nil
 }

--- a/index/store/boltdb/writer.go
+++ b/index/store/boltdb/writer.go
@@ -40,6 +40,7 @@ func (w *Writer) ExecuteBatch(batch store.KVBatch) error {
 	}
 
 	bucket := tx.Bucket([]byte(w.store.bucket))
+	bucket.FillPercent = w.store.fillPercent
 
 	for k, mergeOps := range emulatedBatch.Merger.Merges {
 		kb := []byte(k)


### PR DESCRIPTION
Hi again,

I couldn't resist experimenting with this setting when I saw it in the boltdb `Bucket` documentation:

```go
    // Sets the threshold for filling nodes when they split. By default,
    // the bucket will fill to 50% but it can be useful to increase this
    // amount if you know that your write workloads are mostly append-only.
    //
    // This is non-persisted across transactions so it must be set in every Tx.
    FillPercent float64
```

Documents in our IoT "device reports" index are immutable for as long as they're retained.  I found that page utilization on this index is very much improved with higher `FillPercent` values.  For example, using a value of `0.8` (instead of the default `0.5`), we're able to index 20-25% more reports within a given index file size.

This PR adds `fillPercent` as an option when using the boltdb store.
