### PR TITLE
Added match query operator

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -416,6 +416,19 @@ func ExampleNewConjunctionQuery() {
 	// document id 2
 }
 
+func ExampleNewMatchQueryOperator() {
+	query := NewMatchQueryOperator("great one", MatchQueryOperatorAnd)
+	searchRequest := NewSearchRequest(query)
+	searchResults, err := example_index.Search(searchRequest)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(searchResults.Hits[0].ID)
+	// Output:
+	// document id 2
+}
+
 func ExampleNewDisjunctionQuery() {
 	disjuncts := make([]Query, 2)
 	disjuncts[0] = NewMatchQuery("great")

--- a/query_test.go
+++ b/query_test.go
@@ -35,6 +35,23 @@ func TestParseQuery(t *testing.T) {
 			output: NewMatchQuery("beer").SetField("desc"),
 		},
 		{
+			input:  []byte(`{"match":"beer","field":"desc","operator":"or"}`),
+			output: NewMatchQuery("beer").SetField("desc"),
+		},
+		{
+			input:  []byte(`{"match":"beer","field":"desc","operator":"and"}`),
+			output: NewMatchQueryOperator("beer", MatchQueryOperatorAnd).SetField("desc"),
+		},
+		{
+			input:  []byte(`{"match":"beer","field":"desc","operator":"or"}`),
+			output: NewMatchQueryOperator("beer", MatchQueryOperatorOr).SetField("desc"),
+		},
+		{
+			input:  []byte(`{"match":"beer","field":"desc","operator":"does not exist"}`),
+			output: nil,
+			err:    matchQueryOperatorUnmarshalError("does not exist"),
+		},
+		{
 			input:  []byte(`{"match_phrase":"light beer","field":"desc"}`),
 			output: NewMatchPhraseQuery("light beer").SetField("desc"),
 		},


### PR DESCRIPTION
Match query operator, either `or` (default), or `and` controls whether analyzed terms construct disjunction, or conjunction query.