### PR TITLE
MB-20101 - moss KV fix Get() of 0-length vals

### DIFF
--- a/index/store/moss/reader.go
+++ b/index/store/moss/reader.go
@@ -28,7 +28,7 @@ func (r *Reader) Get(k []byte) (v []byte, err error) {
 		return nil, err
 	}
 	if v != nil {
-		return append([]byte(nil), v...), nil
+		return append(make([]byte, 0, len(v)), v...), nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
The moss KV store adapter's Get() implementation was incorrectly
transforming a 0-length val (e.g., []byte{}) into a nil val.