### PR TITLE
optimize upside_down reader Next() when 0-length term field vectors

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -100,7 +100,7 @@ type TermFieldVector struct {
 
 type TermFieldDoc struct {
 	Term    string
-	ID      string
+	ID      []byte
 	Freq    uint64
 	Norm    float64
 	Vectors []*TermFieldVector

--- a/index/index.go
+++ b/index/index.go
@@ -111,8 +111,9 @@ type TermFieldDoc struct {
 // lexicographic order over their identifiers.
 type TermFieldReader interface {
 	// Next returns the next document containing the term in this field, or nil
-	// when it reaches the end of the enumeration.
-	Next() (*TermFieldDoc, error)
+	// when it reaches the end of the enumeration.  The preAlloced TermFieldDoc
+	// is optional, and when non-nil, will be used instead of allocating memory.
+	Next(preAlloced *TermFieldDoc) (*TermFieldDoc, error)
 
 	// Advance resets the enumeration at specified document or its immediate
 	// follower.
@@ -198,4 +199,9 @@ func (b *Batch) String() string {
 func (b *Batch) Reset() {
 	b.IndexOps = make(map[string]*document.Document)
 	b.InternalOps = make(map[string][]byte)
+}
+
+func (tfd *TermFieldDoc) Reset() *TermFieldDoc {
+	*tfd = TermFieldDoc{}
+	return tfd
 }

--- a/index/store/moss/iterator.go
+++ b/index/store/moss/iterator.go
@@ -115,16 +115,11 @@ func (x *Iterator) Close() error {
 }
 
 func (x *Iterator) checkDone() {
-	x.done = true
-	x.k = nil
-	x.v = nil
-
 	k, v, err := x.iter.Current()
-	if err != nil {
-		return
-	}
-
-	if x.prefix != nil && !bytes.HasPrefix(k, x.prefix) {
+	if err != nil || (x.prefix != nil && !bytes.HasPrefix(k, x.prefix)) {
+		x.done = true
+		x.k = nil
+		x.v = nil
 		return
 	}
 

--- a/index/store/moss/iterator.go
+++ b/index/store/moss/iterator.go
@@ -60,12 +60,11 @@ func (x *Iterator) Next() {
 		return
 	}
 
-	x.done = true
-	x.k = nil
-	x.v = nil
-
 	err := x.iter.Next()
 	if err != nil {
+		x.done = true
+		x.k = nil
+		x.v = nil
 		return
 	}
 

--- a/index/store/moss/iterator.go
+++ b/index/store/moss/iterator.go
@@ -18,15 +18,14 @@ import (
 )
 
 type Iterator struct {
-	store  *Store
-	ss     moss.Snapshot
-	iter   moss.Iterator
-	prefix []byte
-	start  []byte
-	end    []byte
-	done   bool
-	k      []byte
-	v      []byte
+	store *Store
+	ss    moss.Snapshot
+	iter  moss.Iterator
+	start []byte
+	end   []byte
+	done  bool
+	k     []byte
+	v     []byte
 }
 
 func (x *Iterator) Seek(seekToKey []byte) {
@@ -105,7 +104,6 @@ func (x *Iterator) Close() error {
 		x.iter = nil
 	}
 
-	x.prefix = nil
 	x.done = true
 	x.k = nil
 	x.v = nil
@@ -115,7 +113,7 @@ func (x *Iterator) Close() error {
 
 func (x *Iterator) checkDone() {
 	k, v, err := x.iter.Current()
-	if err != nil || (x.prefix != nil && !bytes.HasPrefix(k, x.prefix)) {
+	if err != nil {
 		x.done = true
 		x.k = nil
 		x.v = nil

--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -22,6 +22,7 @@ type UpsideDownCouchTermFieldReader struct {
 	count       uint64
 	term        []byte
 	field       uint16
+	tfrNext     TermFrequencyRow
 }
 
 func newUpsideDownCouchTermFieldReader(indexReader *IndexReader, term []byte, field uint16) (*UpsideDownCouchTermFieldReader, error) {
@@ -65,7 +66,12 @@ func (r *UpsideDownCouchTermFieldReader) Next() (*index.TermFieldDoc, error) {
 	if r.iterator != nil {
 		key, val, valid := r.iterator.Current()
 		if valid {
-			tfr, err := NewTermFrequencyRowKV(key, val)
+			tfr := r.tfrNext
+			err := tfr.parseK(key)
+			if err != nil {
+				return nil, err
+			}
+			err = tfr.parseV(val)
 			if err != nil {
 				return nil, err
 			}

--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -62,7 +62,7 @@ func (r *UpsideDownCouchTermFieldReader) Count() uint64 {
 	return r.count
 }
 
-func (r *UpsideDownCouchTermFieldReader) Next() (*index.TermFieldDoc, error) {
+func (r *UpsideDownCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*index.TermFieldDoc, error) {
 	if r.iterator != nil {
 		key, val, valid := r.iterator.Current()
 		if valid {
@@ -75,14 +75,16 @@ func (r *UpsideDownCouchTermFieldReader) Next() (*index.TermFieldDoc, error) {
 			if err != nil {
 				return nil, err
 			}
-			rv := index.TermFieldDoc{
-				ID:      string(tfr.doc),
-				Freq:    tfr.freq,
-				Norm:    float64(tfr.norm),
-				Vectors: r.indexReader.index.termFieldVectorsFromTermVectors(tfr.vectors),
+			rv := preAlloced
+			if rv == nil {
+				rv = &index.TermFieldDoc{}
 			}
+			rv.ID = string(tfr.doc)
+			rv.Freq = tfr.freq
+			rv.Norm = float64(tfr.norm)
+			rv.Vectors = r.indexReader.index.termFieldVectorsFromTermVectors(tfr.vectors)
 			r.iterator.Next()
-			return &rv, nil
+			return rv, nil
 		}
 	}
 	return nil, nil

--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -66,7 +66,7 @@ func (r *UpsideDownCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*
 	if r.iterator != nil {
 		key, val, valid := r.iterator.Current()
 		if valid {
-			tfr := r.tfrNext
+			tfr := &r.tfrNext
 			err := tfr.parseK(key)
 			if err != nil {
 				return nil, err

--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -81,7 +81,7 @@ func (r *UpsideDownCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*
 			if rv == nil {
 				rv = &index.TermFieldDoc{}
 			}
-			rv.ID = string(tfr.doc)
+			rv.ID = tfr.doc
 			rv.Freq = tfr.freq
 			rv.Norm = float64(tfr.norm)
 			if tfr.vectors != nil {
@@ -105,7 +105,7 @@ func (r *UpsideDownCouchTermFieldReader) Advance(docID string) (*index.TermField
 				return nil, err
 			}
 			rv := index.TermFieldDoc{
-				ID:      string(tfr.doc),
+				ID:      tfr.doc,
 				Freq:    tfr.freq,
 				Norm:    float64(tfr.norm),
 				Vectors: r.indexReader.index.termFieldVectorsFromTermVectors(tfr.vectors),

--- a/index/upside_down/reader_test.go
+++ b/index/upside_down/reader_test.go
@@ -111,7 +111,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	expectedMatch := &index.TermFieldDoc{
-		ID:   "2",
+		ID:   []byte("2"),
 		Freq: 1,
 		Norm: 0.5773502588272095,
 		Vectors: []*index.TermFieldVector{
@@ -152,7 +152,7 @@ func TestIndexReader(t *testing.T) {
 	if match == nil {
 		t.Fatalf("Expected match, got nil")
 	}
-	if match.ID != "2" {
+	if string(match.ID) != "2" {
 		t.Errorf("Expected ID '2', got '%s'", match.ID)
 	}
 	match, err = reader.Advance("3")

--- a/index/upside_down/reader_test.go
+++ b/index/upside_down/reader_test.go
@@ -98,9 +98,9 @@ func TestIndexReader(t *testing.T) {
 
 	var match *index.TermFieldDoc
 	var actualCount uint64
-	match, err = reader.Next()
+	match, err = reader.Next(nil)
 	for err == nil && match != nil {
-		match, err = reader.Next()
+		match, err = reader.Next(nil)
 		if err != nil {
 			t.Errorf("unexpected error reading next")
 		}
@@ -127,7 +127,7 @@ func TestIndexReader(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	match, err = tfr.Next()
+	match, err = tfr.Next(nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestIndexReader(t *testing.T) {
 	if count != 0 {
 		t.Errorf("expected count 0 for reader of non-existant field")
 	}
-	match, err = reader.Next()
+	match, err = reader.Next(nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/index/upside_down/row.go
+++ b/index/upside_down/row.go
@@ -483,26 +483,34 @@ func NewTermFrequencyRowWithTermVectors(term []byte, field uint16, docID []byte,
 }
 
 func NewTermFrequencyRowK(key []byte) (*TermFrequencyRow, error) {
-	rv := TermFrequencyRow{}
+	rv := &TermFrequencyRow{}
+	err := rv.parseK(key)
+	if err != nil {
+		return nil, err
+	}
+	return rv, nil
+}
+
+func (tfr *TermFrequencyRow) parseK(key []byte) error {
 	keyLen := len(key)
 	if keyLen < 3 {
-		return nil, fmt.Errorf("invalid term frequency key, no valid field")
+		return fmt.Errorf("invalid term frequency key, no valid field")
 	}
-	rv.field = binary.LittleEndian.Uint16(key[1:3])
+	tfr.field = binary.LittleEndian.Uint16(key[1:3])
 
 	termEndPos := bytes.IndexByte(key[3:], ByteSeparator)
 	if termEndPos < 0 {
-		return nil, fmt.Errorf("invalid term frequency key, no byte separator terminating term")
+		return fmt.Errorf("invalid term frequency key, no byte separator terminating term")
 	}
-	rv.term = key[3 : 3+termEndPos]
+	tfr.term = key[3 : 3+termEndPos]
 
 	docLen := len(key) - (3 + termEndPos + 1)
 	if docLen < 1 {
-		return nil, fmt.Errorf("invalid term frequency key, empty docid")
+		return fmt.Errorf("invalid term frequency key, empty docid")
 	}
-	rv.doc = key[3+termEndPos+1:]
+	tfr.doc = key[3+termEndPos+1:]
 
-	return &rv, nil
+	return nil
 }
 
 func (tfr *TermFrequencyRow) parseV(value []byte) error {

--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -769,11 +769,9 @@ func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.
 	return rv, rows
 }
 
-var emptyTermFieldVectors = []*index.TermFieldVector{}
-
 func (udc *UpsideDownCouch) termFieldVectorsFromTermVectors(in []*TermVector) []*index.TermFieldVector {
 	if len(in) <= 0 {
-		return emptyTermFieldVectors
+		return nil
 	}
 
 	rv := make([]*index.TermFieldVector, len(in))

--- a/index/upside_down/upside_down.go
+++ b/index/upside_down/upside_down.go
@@ -769,7 +769,13 @@ func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.
 	return rv, rows
 }
 
+var emptyTermFieldVectors = []*index.TermFieldVector{}
+
 func (udc *UpsideDownCouch) termFieldVectorsFromTermVectors(in []*TermVector) []*index.TermFieldVector {
+	if len(in) <= 0 {
+		return emptyTermFieldVectors
+	}
+
 	rv := make([]*index.TermFieldVector, len(in))
 
 	for i, tv := range in {

--- a/index/upside_down/upside_down_test.go
+++ b/index/upside_down/upside_down_test.go
@@ -1126,7 +1126,7 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 
 	tfd, err := termFieldReader.Next(nil)
 	for tfd != nil && err == nil {
-		if tfd.ID != "1" {
+		if string(tfd.ID) != "1" {
 			t.Errorf("expected to find document id 1")
 		}
 		tfd, err = termFieldReader.Next(nil)

--- a/index/upside_down/upside_down_test.go
+++ b/index/upside_down/upside_down_test.go
@@ -1124,12 +1124,12 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 		t.Error(err)
 	}
 
-	tfd, err := termFieldReader.Next()
+	tfd, err := termFieldReader.Next(nil)
 	for tfd != nil && err == nil {
 		if tfd.ID != "1" {
 			t.Errorf("expected to find document id 1")
 		}
-		tfd, err = termFieldReader.Next()
+		tfd, err = termFieldReader.Next(nil)
 	}
 	if err != nil {
 		t.Error(err)

--- a/search/collectors/collector_top_score.go
+++ b/search/collectors/collector_top_score.go
@@ -60,7 +60,7 @@ func (tksc *TopScoreCollector) Took() time.Duration {
 func (tksc *TopScoreCollector) Collect(ctx context.Context, searcher search.Searcher) error {
 	startTime := time.Now()
 	var err error
-	var pre search.DocumentMatch // Pre-alloc'ed instance.
+	var pre search.DocumentMatch // A single pre-alloc'ed, reused instance.
 	var next *search.DocumentMatch
 	select {
 	case <-ctx.Done():
@@ -104,6 +104,9 @@ func (tksc *TopScoreCollector) collectSingle(dmIn *search.DocumentMatch) {
 		return
 	}
 
+	// Because the dmIn will be the single, pre-allocated, reused
+	// instance, we need to copy the dmIn into a new, standalone
+	// instance before inserting into our candidate results list.
 	dm := &search.DocumentMatch{}
 	*dm = *dmIn
 

--- a/search/collectors/collector_top_score.go
+++ b/search/collectors/collector_top_score.go
@@ -146,6 +146,7 @@ func (tksc *TopScoreCollector) Results() search.DocumentMatchCollection {
 				continue
 			}
 			rv[i] = e.Value.(*search.DocumentMatch)
+			rv[i].ArrangeID()
 			i++
 		}
 		return rv

--- a/search/collectors/collector_top_score_test.go
+++ b/search/collectors/collector_top_score_test.go
@@ -105,8 +105,8 @@ func TestTop10Scores(t *testing.T) {
 		t.Fatalf("expected 10 results, got %d", len(results))
 	}
 
-	if results[0].ID != "l" {
-		t.Errorf("expected first result to have ID 'l', got %s", results[0].ID)
+	if results[0].ArrangeID() != "l" {
+		t.Errorf("expected first result to have ID 'l', got %s", results[0].ArrangeID())
 	}
 
 	if results[0].Score != 99.0 {
@@ -213,8 +213,8 @@ func TestTop10ScoresSkip10(t *testing.T) {
 		t.Fatalf("expected 4 results, got %d", len(results))
 	}
 
-	if results[0].ID != "b" {
-		t.Errorf("expected first result to have ID 'b', got %s", results[0].ID)
+	if results[0].ArrangeID() != "b" {
+		t.Errorf("expected first result to have ID 'b', got %s", results[0].ArrangeID())
 	}
 
 	if results[0].Score != 9.5 {
@@ -307,7 +307,7 @@ func TestPaginationSameScores(t *testing.T) {
 
 	firstResults := make(map[string]struct{})
 	for _, hit := range results {
-		firstResults[hit.ID] = struct{}{}
+		firstResults[hit.ArrangeID()] = struct{}{}
 	}
 
 	// a stub search with more than 10 matches
@@ -393,8 +393,8 @@ func TestPaginationSameScores(t *testing.T) {
 
 	// make sure that none of these hits repeat ones we saw in the top 5
 	for _, hit := range results {
-		if _, ok := firstResults[hit.ID]; ok {
-			t.Errorf("doc ID %s is in top 5 and next 5 result sets", hit.ID)
+		if _, ok := firstResults[hit.ArrangeID()]; ok {
+			t.Errorf("doc ID %s is in top 5 and next 5 result sets", hit.ArrangeID())
 		}
 	}
 

--- a/search/collectors/search_test.go
+++ b/search/collectors/search_test.go
@@ -29,7 +29,7 @@ func (ss *stubSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docume
 
 func (ss *stubSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 
-	for ss.index < len(ss.matches) && ss.matches[ss.index].ID < ID {
+	for ss.index < len(ss.matches) && ss.matches[ss.index].ArrangeID() < ID {
 		ss.index++
 	}
 	if ss.index < len(ss.matches) {

--- a/search/collectors/search_test.go
+++ b/search/collectors/search_test.go
@@ -18,7 +18,7 @@ type stubSearcher struct {
 	matches search.DocumentMatchCollection
 }
 
-func (ss *stubSearcher) Next() (*search.DocumentMatch, error) {
+func (ss *stubSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	if ss.index < len(ss.matches) {
 		rv := ss.matches[ss.index]
 		ss.index++

--- a/search/facets_builder.go
+++ b/search/facets_builder.go
@@ -42,7 +42,7 @@ func (fb *FacetsBuilder) Update(docMatch *DocumentMatch) error {
 	for _, facetBuilder := range fb.facets {
 		fields = append(fields, facetBuilder.Field())
 	}
-	fieldTerms, err := fb.indexReader.DocumentFieldTermsForFields(docMatch.ID, fields)
+	fieldTerms, err := fb.indexReader.DocumentFieldTermsForFields(docMatch.ArrangeID(), fields)
 	if err != nil {
 		return err
 	}

--- a/search/scorers/scorer_conjunction.go
+++ b/search/scorers/scorer_conjunction.go
@@ -25,7 +25,7 @@ func NewConjunctionQueryScorer(explain bool) *ConjunctionQueryScorer {
 
 func (s *ConjunctionQueryScorer) Score(constituents []*search.DocumentMatch) *search.DocumentMatch {
 	rv := search.DocumentMatch{
-		ID: constituents[0].ID,
+		ID: constituents[0].ArrangeID(),
 	}
 
 	var sum float64

--- a/search/scorers/scorer_constant_test.go
+++ b/search/scorers/scorer_constant_test.go
@@ -28,7 +28,7 @@ func TestConstantScorer(t *testing.T) {
 		// test some simple math
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 				Vectors: []*index.TermFieldVector{
@@ -52,7 +52,7 @@ func TestConstantScorer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch.ID)
+		actual := scorer.Score(string(test.termMatch.ID))
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)
@@ -72,7 +72,7 @@ func TestConstantScorerWithQueryNorm(t *testing.T) {
 	}{
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -108,7 +108,7 @@ func TestConstantScorerWithQueryNorm(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch.ID)
+		actual := scorer.Score(string(test.termMatch.ID))
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)

--- a/search/scorers/scorer_disjunction.go
+++ b/search/scorers/scorer_disjunction.go
@@ -27,7 +27,7 @@ func NewDisjunctionQueryScorer(explain bool) *DisjunctionQueryScorer {
 
 func (s *DisjunctionQueryScorer) Score(constituents []*search.DocumentMatch, countMatch, countTotal int) *search.DocumentMatch {
 	rv := search.DocumentMatch{
-		ID: constituents[0].ID,
+		ID: constituents[0].ArrangeID(),
 	}
 
 	var sum float64

--- a/search/scorers/scorer_term.go
+++ b/search/scorers/scorer_term.go
@@ -132,8 +132,9 @@ func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc, preAllocated *sea
 	if rv == nil {
 		rv = &search.DocumentMatch{}
 	}
-	rv.ID = termMatch.ID
+	rv.SetIDBytes(termMatch.ID)
 	rv.Score = score
+
 	if s.explain {
 		rv.Expl = scoreExplanation
 	}

--- a/search/scorers/scorer_term.go
+++ b/search/scorers/scorer_term.go
@@ -83,7 +83,7 @@ func (s *TermQueryScorer) SetQueryNorm(qnorm float64) {
 	}
 }
 
-func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc) *search.DocumentMatch {
+func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc, preAllocated *search.DocumentMatch) *search.DocumentMatch {
 	var scoreExplanation *search.Explanation
 
 	// need to compute score
@@ -128,10 +128,12 @@ func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc) *search.DocumentM
 		}
 	}
 
-	rv := search.DocumentMatch{
-		ID:    termMatch.ID,
-		Score: score,
+	rv := preAllocated
+	if rv == nil {
+		rv = &search.DocumentMatch{}
 	}
+	rv.ID = termMatch.ID
+	rv.Score = score
 	if s.explain {
 		rv.Expl = scoreExplanation
 	}
@@ -172,5 +174,5 @@ func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc) *search.DocumentM
 
 	}
 
-	return &rv
+	return rv
 }

--- a/search/scorers/scorer_term_test.go
+++ b/search/scorers/scorer_term_test.go
@@ -144,7 +144,7 @@ func TestTermScorer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch)
+		actual := scorer.Score(test.termMatch, nil)
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)
@@ -231,7 +231,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch)
+		actual := scorer.Score(test.termMatch, nil)
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)

--- a/search/scorers/scorer_term_test.go
+++ b/search/scorers/scorer_term_test.go
@@ -35,7 +35,7 @@ func TestTermScorer(t *testing.T) {
 		// test some simple math
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 				Vectors: []*index.TermFieldVector{
@@ -84,7 +84,7 @@ func TestTermScorer(t *testing.T) {
 		// test the same thing again (score should be cached this time)
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -114,7 +114,7 @@ func TestTermScorer(t *testing.T) {
 		// test a case where the sqrt isn't precalculated
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 65,
 				Norm: 1.0,
 			},
@@ -145,6 +145,7 @@ func TestTermScorer(t *testing.T) {
 
 	for _, test := range tests {
 		actual := scorer.Score(test.termMatch, nil)
+		actual.ArrangeID()
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)
@@ -177,7 +178,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 	}{
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -232,6 +233,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 
 	for _, test := range tests {
 		actual := scorer.Score(test.termMatch, nil)
+		actual.ArrangeID()
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)

--- a/search/scorers/sqrt_cache.go
+++ b/search/scorers/sqrt_cache.go
@@ -13,12 +13,12 @@ import (
 	"math"
 )
 
-var SqrtCache map[int]float64
+var SqrtCache []float64
 
 const MaxSqrtCache = 64
 
 func init() {
-	SqrtCache = make(map[int]float64, MaxSqrtCache)
+	SqrtCache = make([]float64, MaxSqrtCache)
 	for i := 0; i < MaxSqrtCache; i++ {
 		SqrtCache[i] = math.Sqrt(float64(i))
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -85,6 +85,11 @@ func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
 	dm.Fields[name] = valSlice
 }
 
+func (dm *DocumentMatch) Reset() *DocumentMatch {
+	*dm = DocumentMatch{}
+	return dm
+}
+
 type DocumentMatchCollection []*DocumentMatch
 
 func (c DocumentMatchCollection) Len() int           { return len(c) }
@@ -92,7 +97,7 @@ func (c DocumentMatchCollection) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c DocumentMatchCollection) Less(i, j int) bool { return c[i].Score > c[j].Score }
 
 type Searcher interface {
-	Next() (*DocumentMatch, error)
+	Next(preAllocated *DocumentMatch) (*DocumentMatch, error)
 	Advance(ID string) (*DocumentMatch, error)
 	Close() error
 	Weight() float64

--- a/search/search.go
+++ b/search/search.go
@@ -62,6 +62,8 @@ type DocumentMatch struct {
 	// SearchRequest.Fields. Text fields are returned as strings, numeric
 	// fields as float64s and date fields as time.RFC3339 formatted strings.
 	Fields map[string]interface{} `json:"fields,omitempty"`
+
+	idBytes []byte // Helps avoid string conversion until last moment.
 }
 
 func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
@@ -88,6 +90,23 @@ func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
 func (dm *DocumentMatch) Reset() *DocumentMatch {
 	*dm = DocumentMatch{}
 	return dm
+}
+
+// ArrangeID converts the idBytes to an ID string, which allows us to
+// delay conversion work for performance.  Of note, we need to be
+// careful to ArrangeID() before returning or exposing a DocumentMatch
+// to the user's application.
+func (dm *DocumentMatch) ArrangeID() string {
+	if dm.ID == "" && dm.idBytes != nil {
+		dm.ID = string(dm.idBytes)
+		dm.idBytes = nil
+	}
+	return dm.ID
+}
+
+func (dm *DocumentMatch) SetIDBytes(v []byte) {
+	dm.idBytes = v
+	dm.ID = ""
 }
 
 type DocumentMatchCollection []*DocumentMatch

--- a/search/searchers/search_boolean.go
+++ b/search/searchers/search_boolean.go
@@ -70,21 +70,21 @@ func (s *BooleanSearcher) initSearchers() error {
 	var err error
 	// get all searchers pointing at their first match
 	if s.mustSearcher != nil {
-		s.currMust, err = s.mustSearcher.Next()
+		s.currMust, err = s.mustSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
 	}
 
 	if s.shouldSearcher != nil {
-		s.currShould, err = s.shouldSearcher.Next()
+		s.currShould, err = s.shouldSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
 	}
 
 	if s.mustNotSearcher != nil {
-		s.currMustNot, err = s.mustNotSearcher.Next()
+		s.currMustNot, err = s.mustNotSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -106,12 +106,12 @@ func (s *BooleanSearcher) advanceNextMust() error {
 	var err error
 
 	if s.mustSearcher != nil {
-		s.currMust, err = s.mustSearcher.Next()
+		s.currMust, err = s.mustSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
 	} else if s.mustSearcher == nil {
-		s.currShould, err = s.shouldSearcher.Next()
+		s.currShould, err = s.shouldSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func (s *BooleanSearcher) SetQueryNorm(qnorm float64) {
 	}
 }
 
-func (s *BooleanSearcher) Next() (*search.DocumentMatch, error) {
+func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 
 	if !s.initialized {
 		err := s.initSearchers()
@@ -292,7 +292,7 @@ func (s *BooleanSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 		s.currentID = ""
 	}
 
-	return s.Next()
+	return s.Next(nil)
 }
 
 func (s *BooleanSearcher) Count() uint64 {

--- a/search/searchers/search_boolean.go
+++ b/search/searchers/search_boolean.go
@@ -91,9 +91,9 @@ func (s *BooleanSearcher) initSearchers() error {
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}
@@ -118,9 +118,9 @@ func (s *BooleanSearcher) advanceNextMust() error {
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}
@@ -161,13 +161,13 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 	var rv *search.DocumentMatch
 
 	for s.currentID != "" {
-		if s.currMustNot != nil && s.currMustNot.ID < s.currentID {
+		if s.currMustNot != nil && s.currMustNot.ArrangeID() < s.currentID {
 			// advance must not searcher to our candidate entry
 			s.currMustNot, err = s.mustNotSearcher.Advance(s.currentID)
 			if err != nil {
 				return nil, err
 			}
-			if s.currMustNot != nil && s.currMustNot.ID == s.currentID {
+			if s.currMustNot != nil && s.currMustNot.ArrangeID() == s.currentID {
 				// the candidate is excluded
 				err = s.advanceNextMust()
 				if err != nil {
@@ -175,7 +175,7 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 				}
 				continue
 			}
-		} else if s.currMustNot != nil && s.currMustNot.ID == s.currentID {
+		} else if s.currMustNot != nil && s.currMustNot.ArrangeID() == s.currentID {
 			// the candidate is excluded
 			err = s.advanceNextMust()
 			if err != nil {
@@ -184,13 +184,13 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 			continue
 		}
 
-		if s.currShould != nil && s.currShould.ID < s.currentID {
+		if s.currShould != nil && s.currShould.ArrangeID() < s.currentID {
 			// advance should searcher to our candidate entry
 			s.currShould, err = s.shouldSearcher.Advance(s.currentID)
 			if err != nil {
 				return nil, err
 			}
-			if s.currShould != nil && s.currShould.ID == s.currentID {
+			if s.currShould != nil && s.currShould.ArrangeID() == s.currentID {
 				// score bonus matches should
 				var cons []*search.DocumentMatch
 				if s.currMust != nil {
@@ -218,7 +218,7 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 				}
 				break
 			}
-		} else if s.currShould != nil && s.currShould.ID == s.currentID {
+		} else if s.currShould != nil && s.currShould.ArrangeID() == s.currentID {
 			// score bonus matches should
 			var cons []*search.DocumentMatch
 			if s.currMust != nil {
@@ -285,9 +285,9 @@ func (s *BooleanSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}

--- a/search/searchers/search_boolean_test.go
+++ b/search/searchers/search_boolean_test.go
@@ -342,7 +342,7 @@ func TestBooleanSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -354,7 +354,7 @@ func TestBooleanSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_boolean_test.go
+++ b/search/searchers/search_boolean_test.go
@@ -346,8 +346,8 @@ func TestBooleanSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_conjunction.go
+++ b/search/searchers/search_conjunction.go
@@ -75,7 +75,7 @@ func (s *ConjunctionSearcher) initSearchers() error {
 
 	if len(s.currs) > 0 {
 		if s.currs[0] != nil {
-			s.currentID = s.currs[0].ID
+			s.currentID = s.currs[0].ArrangeID()
 		} else {
 			s.currentID = ""
 		}
@@ -111,9 +111,9 @@ func (s *ConjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 OUTER:
 	for s.currentID != "" {
 		for i, termSearcher := range s.searchers {
-			if s.currs[i] != nil && s.currs[i].ID != s.currentID {
-				if s.currentID < s.currs[i].ID {
-					s.currentID = s.currs[i].ID
+			if s.currs[i] != nil && s.currs[i].ArrangeID() != s.currentID {
+				if s.currentID < s.currs[i].ArrangeID() {
+					s.currentID = s.currs[i].ArrangeID()
 					continue OUTER
 				}
 				// this reader doesn't have the currentID, try to advance
@@ -125,10 +125,10 @@ OUTER:
 					s.currentID = ""
 					continue OUTER
 				}
-				if s.currs[i].ID != s.currentID {
+				if s.currs[i].ArrangeID() != s.currentID {
 					// we just advanced, so it doesn't match, it must be greater
 					// no need to call next
-					s.currentID = s.currs[i].ID
+					s.currentID = s.currs[i].ArrangeID()
 					continue OUTER
 				}
 			} else if s.currs[i] == nil {
@@ -147,7 +147,7 @@ OUTER:
 		if s.currs[0] == nil {
 			s.currentID = ""
 		} else {
-			s.currentID = s.currs[0].ID
+			s.currentID = s.currs[0].ArrangeID()
 		}
 		// don't continue now, wait for the next call to Next()
 		break

--- a/search/searchers/search_conjunction.go
+++ b/search/searchers/search_conjunction.go
@@ -67,7 +67,7 @@ func (s *ConjunctionSearcher) initSearchers() error {
 	var err error
 	// get all searchers pointing at their first match
 	for i, termSearcher := range s.searchers {
-		s.currs[i], err = termSearcher.Next()
+		s.currs[i], err = termSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func (s *ConjunctionSearcher) SetQueryNorm(qnorm float64) {
 	}
 }
 
-func (s *ConjunctionSearcher) Next() (*search.DocumentMatch, error) {
+func (s *ConjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers()
 		if err != nil {
@@ -140,7 +140,7 @@ OUTER:
 		rv = s.scorer.Score(s.currs)
 
 		// prepare for next entry
-		s.currs[0], err = s.searchers[0].Next()
+		s.currs[0], err = s.searchers[0].Next(nil)
 		if err != nil {
 			return nil, err
 		}
@@ -170,7 +170,7 @@ func (s *ConjunctionSearcher) Advance(ID string) (*search.DocumentMatch, error) 
 		}
 	}
 	s.currentID = ID
-	return s.Next()
+	return s.Next(nil)
 }
 
 func (s *ConjunctionSearcher) Count() uint64 {

--- a/search/searchers/search_conjunction_test.go
+++ b/search/searchers/search_conjunction_test.go
@@ -187,7 +187,7 @@ func TestConjunctionSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -199,7 +199,7 @@ func TestConjunctionSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_conjunction_test.go
+++ b/search/searchers/search_conjunction_test.go
@@ -191,8 +191,8 @@ func TestConjunctionSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_disjunction.go
+++ b/search/searchers/search_disjunction.go
@@ -101,8 +101,8 @@ func (s *DisjunctionSearcher) initSearchers() error {
 func (s *DisjunctionSearcher) nextSmallestID() string {
 	rv := ""
 	for _, curr := range s.currs {
-		if curr != nil && (curr.ID < rv || rv == "") {
-			rv = curr.ID
+		if curr != nil && (curr.ArrangeID() < rv || rv == "") {
+			rv = curr.ArrangeID()
 		}
 	}
 	return rv
@@ -136,7 +136,7 @@ func (s *DisjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 	found := false
 	for !found && s.currentID != "" {
 		for _, curr := range s.currs {
-			if curr != nil && curr.ID == s.currentID {
+			if curr != nil && curr.ArrangeID() == s.currentID {
 				matching = append(matching, curr)
 			}
 		}
@@ -151,7 +151,7 @@ func (s *DisjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 		matching = make([]*search.DocumentMatch, 0)
 		// invoke next on all the matching searchers
 		for i, curr := range s.currs {
-			if curr != nil && curr.ID == s.currentID {
+			if curr != nil && curr.ArrangeID() == s.currentID {
 				searcher := s.searchers[i]
 				s.currs[i], err = searcher.Next(nil)
 				if err != nil {

--- a/search/searchers/search_disjunction.go
+++ b/search/searchers/search_disjunction.go
@@ -87,7 +87,7 @@ func (s *DisjunctionSearcher) initSearchers() error {
 	var err error
 	// get all searchers pointing at their first match
 	for i, termSearcher := range s.searchers {
-		s.currs[i], err = termSearcher.Next()
+		s.currs[i], err = termSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ func (s *DisjunctionSearcher) SetQueryNorm(qnorm float64) {
 	}
 }
 
-func (s *DisjunctionSearcher) Next() (*search.DocumentMatch, error) {
+func (s *DisjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers()
 		if err != nil {
@@ -153,7 +153,7 @@ func (s *DisjunctionSearcher) Next() (*search.DocumentMatch, error) {
 		for i, curr := range s.currs {
 			if curr != nil && curr.ID == s.currentID {
 				searcher := s.searchers[i]
-				s.currs[i], err = searcher.Next()
+				s.currs[i], err = searcher.Next(nil)
 				if err != nil {
 					return nil, err
 				}
@@ -182,7 +182,7 @@ func (s *DisjunctionSearcher) Advance(ID string) (*search.DocumentMatch, error) 
 
 	s.currentID = s.nextSmallestID()
 
-	return s.Next()
+	return s.Next(nil)
 }
 
 func (s *DisjunctionSearcher) Count() uint64 {

--- a/search/searchers/search_disjunction_test.go
+++ b/search/searchers/search_disjunction_test.go
@@ -108,7 +108,7 @@ func TestDisjunctionSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -120,7 +120,7 @@ func TestDisjunctionSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_disjunction_test.go
+++ b/search/searchers/search_disjunction_test.go
@@ -112,8 +112,8 @@ func TestDisjunctionSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_docid.go
+++ b/search/searchers/search_docid.go
@@ -77,7 +77,7 @@ func (s *DocIDSearcher) SetQueryNorm(qnorm float64) {
 	s.scorer.SetQueryNorm(qnorm)
 }
 
-func (s *DocIDSearcher) Next() (*search.DocumentMatch, error) {
+func (s *DocIDSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	if s.current >= len(s.ids) {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func (s *DocIDSearcher) Next() (*search.DocumentMatch, error) {
 
 func (s *DocIDSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 	s.current = sort.SearchStrings(s.ids, ID)
-	return s.Next()
+	return s.Next(nil)
 }
 
 func (s *DocIDSearcher) Close() error {

--- a/search/searchers/search_docid_test.go
+++ b/search/searchers/search_docid_test.go
@@ -72,8 +72,8 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if id != m.ID {
-			t.Fatalf("expected %v at position %v, got %v", id, i, m.ID)
+		if id != m.ArrangeID() {
+			t.Fatalf("expected %v at position %v, got %v", id, i, m.ArrangeID())
 		}
 	}
 	m, err := searcher.Next(nil)
@@ -81,7 +81,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 		t.Fatal(err)
 	}
 	if m != nil {
-		t.Fatalf("expected nil past the end of the sequence, got %v", m.ID)
+		t.Fatalf("expected nil past the end of the sequence, got %v", m.ArrangeID())
 	}
 
 	// Check seeking
@@ -95,7 +95,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if m == nil || m.ID != id {
+			if m == nil || m.ArrangeID() != id {
 				t.Fatalf("advancing to %v returned %v instead of %v", before, m, id)
 			}
 		}

--- a/search/searchers/search_docid_test.go
+++ b/search/searchers/search_docid_test.go
@@ -68,7 +68,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 
 	// Check the sequence
 	for i, id := range wanted {
-		m, err := searcher.Next()
+		m, err := searcher.Next(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,7 +76,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 			t.Fatalf("expected %v at position %v, got %v", id, i, m.ID)
 		}
 	}
-	m, err := searcher.Next()
+	m, err := searcher.Next(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/searchers/search_fuzzy.go
+++ b/search/searchers/search_fuzzy.go
@@ -107,8 +107,8 @@ func (s *FuzzySearcher) SetQueryNorm(qnorm float64) {
 	s.searcher.SetQueryNorm(qnorm)
 }
 
-func (s *FuzzySearcher) Next() (*search.DocumentMatch, error) {
-	return s.searcher.Next()
+func (s *FuzzySearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
+	return s.searcher.Next(preAllocated)
 
 }
 

--- a/search/searchers/search_fuzzy_test.go
+++ b/search/searchers/search_fuzzy_test.go
@@ -105,7 +105,7 @@ func TestFuzzySearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -117,7 +117,7 @@ func TestFuzzySearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_fuzzy_test.go
+++ b/search/searchers/search_fuzzy_test.go
@@ -109,8 +109,8 @@ func TestFuzzySearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_match_all.go
+++ b/search/searchers/search_match_all.go
@@ -46,7 +46,7 @@ func (s *MatchAllSearcher) SetQueryNorm(qnorm float64) {
 	s.scorer.SetQueryNorm(qnorm)
 }
 
-func (s *MatchAllSearcher) Next() (*search.DocumentMatch, error) {
+func (s *MatchAllSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	id, err := s.reader.Next()
 	if err != nil {
 		return nil, err

--- a/search/searchers/search_match_all_test.go
+++ b/search/searchers/search_match_all_test.go
@@ -109,7 +109,7 @@ func TestMatchAllSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -121,7 +121,7 @@ func TestMatchAllSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_match_all_test.go
+++ b/search/searchers/search_match_all_test.go
@@ -113,8 +113,8 @@ func TestMatchAllSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_match_none.go
+++ b/search/searchers/search_match_none.go
@@ -36,7 +36,7 @@ func (s *MatchNoneSearcher) SetQueryNorm(qnorm float64) {
 
 }
 
-func (s *MatchNoneSearcher) Next() (*search.DocumentMatch, error) {
+func (s *MatchNoneSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	return nil, nil
 }
 

--- a/search/searchers/search_match_none_test.go
+++ b/search/searchers/search_match_none_test.go
@@ -55,8 +55,8 @@ func TestMatchNoneSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_match_none_test.go
+++ b/search/searchers/search_match_none_test.go
@@ -51,7 +51,7 @@ func TestMatchNoneSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -63,7 +63,7 @@ func TestMatchNoneSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_numeric_range.go
+++ b/search/searchers/search_numeric_range.go
@@ -96,8 +96,8 @@ func (s *NumericRangeSearcher) SetQueryNorm(qnorm float64) {
 	s.searcher.SetQueryNorm(qnorm)
 }
 
-func (s *NumericRangeSearcher) Next() (*search.DocumentMatch, error) {
-	return s.searcher.Next()
+func (s *NumericRangeSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
+	return s.searcher.Next(preAllocated)
 }
 
 func (s *NumericRangeSearcher) Advance(ID string) (*search.DocumentMatch, error) {

--- a/search/searchers/search_phrase.go
+++ b/search/searchers/search_phrase.go
@@ -56,7 +56,7 @@ func (s *PhraseSearcher) initSearchers() error {
 	var err error
 	// get all searchers pointing at their first match
 	if s.mustSearcher != nil {
-		s.currMust, err = s.mustSearcher.Next()
+		s.currMust, err = s.mustSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -70,7 +70,7 @@ func (s *PhraseSearcher) advanceNextMust() error {
 	var err error
 
 	if s.mustSearcher != nil {
-		s.currMust, err = s.mustSearcher.Next()
+		s.currMust, err = s.mustSearcher.Next(nil)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (s *PhraseSearcher) SetQueryNorm(qnorm float64) {
 	s.mustSearcher.SetQueryNorm(qnorm)
 }
 
-func (s *PhraseSearcher) Next() (*search.DocumentMatch, error) {
+func (s *PhraseSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers()
 		if err != nil {
@@ -172,7 +172,7 @@ func (s *PhraseSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.Next()
+	return s.Next(nil)
 }
 
 func (s *PhraseSearcher) Count() uint64 {

--- a/search/searchers/search_phrase_test.go
+++ b/search/searchers/search_phrase_test.go
@@ -68,7 +68,7 @@ func TestPhraseSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -80,7 +80,7 @@ func TestPhraseSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_phrase_test.go
+++ b/search/searchers/search_phrase_test.go
@@ -72,8 +72,8 @@ func TestPhraseSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_regexp.go
+++ b/search/searchers/search_regexp.go
@@ -106,8 +106,8 @@ func (s *RegexpSearcher) SetQueryNorm(qnorm float64) {
 	s.searcher.SetQueryNorm(qnorm)
 }
 
-func (s *RegexpSearcher) Next() (*search.DocumentMatch, error) {
-	return s.searcher.Next()
+func (s *RegexpSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
+	return s.searcher.Next(preAllocated)
 
 }
 

--- a/search/searchers/search_regexp_test.go
+++ b/search/searchers/search_regexp_test.go
@@ -89,8 +89,8 @@ func TestRegexpSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_regexp_test.go
+++ b/search/searchers/search_regexp_test.go
@@ -85,7 +85,7 @@ func TestRegexpSearch(t *testing.T) {
 			}
 		}()
 
-		next, err := test.searcher.Next()
+		next, err := test.searcher.Next(nil)
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
@@ -97,7 +97,7 @@ func TestRegexpSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Expl)
 				}
 			}
-			next, err = test.searcher.Next()
+			next, err = test.searcher.Next(nil)
 			i++
 		}
 		if err != nil {

--- a/search/searchers/search_term.go
+++ b/search/searchers/search_term.go
@@ -22,6 +22,7 @@ type TermSearcher struct {
 	explain     bool
 	reader      index.TermFieldReader
 	scorer      *scorers.TermQueryScorer
+	tfd         index.TermFieldDoc
 }
 
 func NewTermSearcher(indexReader index.IndexReader, term string, field string, boost float64, explain bool) (*TermSearcher, error) {
@@ -53,7 +54,7 @@ func (s *TermSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *TermSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
-	termMatch, err := s.reader.Next()
+	termMatch, err := s.reader.Next(s.tfd.Reset())
 	if err != nil {
 		return nil, err
 	}

--- a/search/searchers/search_term.go
+++ b/search/searchers/search_term.go
@@ -19,10 +19,10 @@ type TermSearcher struct {
 	indexReader index.IndexReader
 	term        string
 	field       string
-	explain     bool
 	reader      index.TermFieldReader
 	scorer      *scorers.TermQueryScorer
 	tfd         index.TermFieldDoc
+	explain     bool
 }
 
 func NewTermSearcher(indexReader index.IndexReader, term string, field string, boost float64, explain bool) (*TermSearcher, error) {

--- a/search/searchers/search_term.go
+++ b/search/searchers/search_term.go
@@ -52,7 +52,7 @@ func (s *TermSearcher) SetQueryNorm(qnorm float64) {
 	s.scorer.SetQueryNorm(qnorm)
 }
 
-func (s *TermSearcher) Next() (*search.DocumentMatch, error) {
+func (s *TermSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 	termMatch, err := s.reader.Next()
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (s *TermSearcher) Next() (*search.DocumentMatch, error) {
 	}
 
 	// score match
-	docMatch := s.scorer.Score(termMatch)
+	docMatch := s.scorer.Score(termMatch, preAllocated)
 	// return doc match
 	return docMatch, nil
 
@@ -80,7 +80,7 @@ func (s *TermSearcher) Advance(ID string) (*search.DocumentMatch, error) {
 	}
 
 	// score match
-	docMatch := s.scorer.Score(termMatch)
+	docMatch := s.scorer.Score(termMatch, nil)
 
 	// return doc match
 	return docMatch, nil

--- a/search/searchers/search_term_prefix.go
+++ b/search/searchers/search_term_prefix.go
@@ -70,8 +70,8 @@ func (s *TermPrefixSearcher) SetQueryNorm(qnorm float64) {
 	s.searcher.SetQueryNorm(qnorm)
 }
 
-func (s *TermPrefixSearcher) Next() (*search.DocumentMatch, error) {
-	return s.searcher.Next()
+func (s *TermPrefixSearcher) Next(preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
+	return s.searcher.Next(preAllocated)
 
 }
 

--- a/search/searchers/search_term_test.go
+++ b/search/searchers/search_term_test.go
@@ -167,15 +167,15 @@ func TestTermSearcher(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
 	}
-	if docMatch.ID != "a" {
-		t.Errorf("expected result ID to be 'a', got '%s", docMatch.ID)
+	if docMatch.ArrangeID() != "a" {
+		t.Errorf("expected result ID to be 'a', got '%s", docMatch.ArrangeID())
 	}
 	docMatch, err = searcher.Advance("c")
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
 	}
-	if docMatch.ID != "c" {
-		t.Errorf("expected result ID to be 'c' got '%s'", docMatch.ID)
+	if docMatch.ArrangeID() != "c" {
+		t.Errorf("expected result ID to be 'c' got '%s'", docMatch.ArrangeID())
 	}
 
 	// try advancing past end

--- a/search/searchers/search_term_test.go
+++ b/search/searchers/search_term_test.go
@@ -163,7 +163,7 @@ func TestTermSearcher(t *testing.T) {
 		t.Errorf("expected count of 9, got %d", searcher.Count())
 	}
 
-	docMatch, err := searcher.Next()
+	docMatch, err := searcher.Next(nil)
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
 	}
@@ -188,7 +188,7 @@ func TestTermSearcher(t *testing.T) {
 	}
 
 	// try pushing next past end
-	docMatch, err = searcher.Next()
+	docMatch, err = searcher.Next(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
From some bleve-query perf profiling, term field vectors appeared to
be alloc'ed, which was unnecessary as term field vectors are disabled
in the bleve-blast/bleve-query tests.

From some bleve-query tests, 200K wikipedia docs, high-freq terms,
OSX dev laptop, this change brought 31 qps to 34 qps.