### PR TITLE
optimize DocumentMatch ID string conversion with ArrangeID()

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -100,7 +100,7 @@ type TermFieldVector struct {
 
 type TermFieldDoc struct {
 	Term    string
-	ID      string
+	ID      []byte
 	Freq    uint64
 	Norm    float64
 	Vectors []*TermFieldVector

--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -81,7 +81,7 @@ func (r *UpsideDownCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*
 			if rv == nil {
 				rv = &index.TermFieldDoc{}
 			}
-			rv.ID = string(tfr.doc)
+			rv.ID = tfr.doc
 			rv.Freq = tfr.freq
 			rv.Norm = float64(tfr.norm)
 			if tfr.vectors != nil {
@@ -108,7 +108,7 @@ func (r *UpsideDownCouchTermFieldReader) Advance(docID string, preAlloced *index
 			if rv == nil {
 				rv = &index.TermFieldDoc{}
 			}
-			rv.ID = string(tfr.doc)
+			rv.ID = tfr.doc
 			rv.Freq = tfr.freq
 			rv.Norm = float64(tfr.norm)
 			if tfr.vectors != nil {

--- a/index/upside_down/reader_test.go
+++ b/index/upside_down/reader_test.go
@@ -111,7 +111,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	expectedMatch := &index.TermFieldDoc{
-		ID:   "2",
+		ID:   []byte("2"),
 		Freq: 1,
 		Norm: 0.5773502588272095,
 		Vectors: []*index.TermFieldVector{
@@ -152,7 +152,7 @@ func TestIndexReader(t *testing.T) {
 	if match == nil {
 		t.Fatalf("Expected match, got nil")
 	}
-	if match.ID != "2" {
+	if string(match.ID) != "2" {
 		t.Errorf("Expected ID '2', got '%s'", match.ID)
 	}
 	match, err = reader.Advance("3", nil)

--- a/index/upside_down/upside_down_test.go
+++ b/index/upside_down/upside_down_test.go
@@ -1126,7 +1126,7 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 
 	tfd, err := termFieldReader.Next(nil)
 	for tfd != nil && err == nil {
-		if tfd.ID != "1" {
+		if string(tfd.ID) != "1" {
 			t.Errorf("expected to find document id 1")
 		}
 		tfd, err = termFieldReader.Next(nil)

--- a/search/collectors/collector_top_score.go
+++ b/search/collectors/collector_top_score.go
@@ -146,6 +146,7 @@ func (tksc *TopScoreCollector) Results() search.DocumentMatchCollection {
 				continue
 			}
 			rv[i] = e.Value.(*search.DocumentMatch)
+			rv[i].ArrangeID()
 			i++
 		}
 		return rv

--- a/search/collectors/collector_top_score_test.go
+++ b/search/collectors/collector_top_score_test.go
@@ -105,8 +105,8 @@ func TestTop10Scores(t *testing.T) {
 		t.Fatalf("expected 10 results, got %d", len(results))
 	}
 
-	if results[0].ID != "l" {
-		t.Errorf("expected first result to have ID 'l', got %s", results[0].ID)
+	if results[0].ArrangeID() != "l" {
+		t.Errorf("expected first result to have ID 'l', got %s", results[0].ArrangeID())
 	}
 
 	if results[0].Score != 99.0 {
@@ -213,8 +213,8 @@ func TestTop10ScoresSkip10(t *testing.T) {
 		t.Fatalf("expected 4 results, got %d", len(results))
 	}
 
-	if results[0].ID != "b" {
-		t.Errorf("expected first result to have ID 'b', got %s", results[0].ID)
+	if results[0].ArrangeID() != "b" {
+		t.Errorf("expected first result to have ID 'b', got %s", results[0].ArrangeID())
 	}
 
 	if results[0].Score != 9.5 {
@@ -307,7 +307,7 @@ func TestPaginationSameScores(t *testing.T) {
 
 	firstResults := make(map[string]struct{})
 	for _, hit := range results {
-		firstResults[hit.ID] = struct{}{}
+		firstResults[hit.ArrangeID()] = struct{}{}
 	}
 
 	// a stub search with more than 10 matches
@@ -393,8 +393,8 @@ func TestPaginationSameScores(t *testing.T) {
 
 	// make sure that none of these hits repeat ones we saw in the top 5
 	for _, hit := range results {
-		if _, ok := firstResults[hit.ID]; ok {
-			t.Errorf("doc ID %s is in top 5 and next 5 result sets", hit.ID)
+		if _, ok := firstResults[hit.ArrangeID()]; ok {
+			t.Errorf("doc ID %s is in top 5 and next 5 result sets", hit.ArrangeID())
 		}
 	}
 

--- a/search/collectors/search_test.go
+++ b/search/collectors/search_test.go
@@ -29,7 +29,7 @@ func (ss *stubSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docume
 
 func (ss *stubSearcher) Advance(ID string, preAllocated *search.DocumentMatch) (*search.DocumentMatch, error) {
 
-	for ss.index < len(ss.matches) && ss.matches[ss.index].ID < ID {
+	for ss.index < len(ss.matches) && ss.matches[ss.index].ArrangeID() < ID {
 		ss.index++
 	}
 	if ss.index < len(ss.matches) {

--- a/search/facets_builder.go
+++ b/search/facets_builder.go
@@ -42,7 +42,7 @@ func (fb *FacetsBuilder) Update(docMatch *DocumentMatch) error {
 	for _, facetBuilder := range fb.facets {
 		fields = append(fields, facetBuilder.Field())
 	}
-	fieldTerms, err := fb.indexReader.DocumentFieldTermsForFields(docMatch.ID, fields)
+	fieldTerms, err := fb.indexReader.DocumentFieldTermsForFields(docMatch.ArrangeID(), fields)
 	if err != nil {
 		return err
 	}

--- a/search/scorers/scorer_conjunction.go
+++ b/search/scorers/scorer_conjunction.go
@@ -25,7 +25,7 @@ func NewConjunctionQueryScorer(explain bool) *ConjunctionQueryScorer {
 
 func (s *ConjunctionQueryScorer) Score(constituents []*search.DocumentMatch) *search.DocumentMatch {
 	rv := search.DocumentMatch{
-		ID: constituents[0].ID,
+		ID: constituents[0].ArrangeID(),
 	}
 
 	var sum float64

--- a/search/scorers/scorer_constant_test.go
+++ b/search/scorers/scorer_constant_test.go
@@ -28,7 +28,7 @@ func TestConstantScorer(t *testing.T) {
 		// test some simple math
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 				Vectors: []*index.TermFieldVector{
@@ -52,7 +52,7 @@ func TestConstantScorer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch.ID)
+		actual := scorer.Score(string(test.termMatch.ID))
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)
@@ -72,7 +72,7 @@ func TestConstantScorerWithQueryNorm(t *testing.T) {
 	}{
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -108,7 +108,7 @@ func TestConstantScorerWithQueryNorm(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := scorer.Score(test.termMatch.ID)
+		actual := scorer.Score(string(test.termMatch.ID))
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)

--- a/search/scorers/scorer_disjunction.go
+++ b/search/scorers/scorer_disjunction.go
@@ -27,7 +27,7 @@ func NewDisjunctionQueryScorer(explain bool) *DisjunctionQueryScorer {
 
 func (s *DisjunctionQueryScorer) Score(constituents []*search.DocumentMatch, countMatch, countTotal int) *search.DocumentMatch {
 	rv := search.DocumentMatch{
-		ID: constituents[0].ID,
+		ID: constituents[0].ArrangeID(),
 	}
 
 	var sum float64

--- a/search/scorers/scorer_term.go
+++ b/search/scorers/scorer_term.go
@@ -132,8 +132,9 @@ func (s *TermQueryScorer) Score(termMatch *index.TermFieldDoc, preAllocated *sea
 	if rv == nil {
 		rv = &search.DocumentMatch{}
 	}
-	rv.ID = termMatch.ID
+	rv.SetIDBytes(termMatch.ID)
 	rv.Score = score
+
 	if s.explain {
 		rv.Expl = scoreExplanation
 	}

--- a/search/scorers/scorer_term_test.go
+++ b/search/scorers/scorer_term_test.go
@@ -35,7 +35,7 @@ func TestTermScorer(t *testing.T) {
 		// test some simple math
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 				Vectors: []*index.TermFieldVector{
@@ -84,7 +84,7 @@ func TestTermScorer(t *testing.T) {
 		// test the same thing again (score should be cached this time)
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -114,7 +114,7 @@ func TestTermScorer(t *testing.T) {
 		// test a case where the sqrt isn't precalculated
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 65,
 				Norm: 1.0,
 			},
@@ -145,6 +145,7 @@ func TestTermScorer(t *testing.T) {
 
 	for _, test := range tests {
 		actual := scorer.Score(test.termMatch, nil)
+		actual.ArrangeID()
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)
@@ -177,7 +178,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 	}{
 		{
 			termMatch: &index.TermFieldDoc{
-				ID:   "one",
+				ID:   []byte("one"),
 				Freq: 1,
 				Norm: 1.0,
 			},
@@ -232,6 +233,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 
 	for _, test := range tests {
 		actual := scorer.Score(test.termMatch, nil)
+		actual.ArrangeID()
 
 		if !reflect.DeepEqual(actual, test.result) {
 			t.Errorf("expected %#v got %#v for %#v", test.result, actual, test.termMatch)

--- a/search/search.go
+++ b/search/search.go
@@ -62,6 +62,8 @@ type DocumentMatch struct {
 	// SearchRequest.Fields. Text fields are returned as strings, numeric
 	// fields as float64s and date fields as time.RFC3339 formatted strings.
 	Fields map[string]interface{} `json:"fields,omitempty"`
+
+	idBytes []byte // Helps avoid string conversion until last moment.
 }
 
 func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
@@ -88,6 +90,23 @@ func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
 func (dm *DocumentMatch) Reset() *DocumentMatch {
 	*dm = DocumentMatch{}
 	return dm
+}
+
+// ArrangeID converts the idBytes to an ID string, which allows us to
+// delay conversion work for performance.  Of note, we need to be
+// careful to ArrangeID() before returning or exposing a DocumentMatch
+// to the user's application.
+func (dm *DocumentMatch) ArrangeID() string {
+	if dm.ID == "" && dm.idBytes != nil {
+		dm.ID = string(dm.idBytes)
+		dm.idBytes = nil
+	}
+	return dm.ID
+}
+
+func (dm *DocumentMatch) SetIDBytes(v []byte) {
+	dm.idBytes = v
+	dm.ID = ""
 }
 
 type DocumentMatchCollection []*DocumentMatch

--- a/search/searchers/search_boolean.go
+++ b/search/searchers/search_boolean.go
@@ -91,9 +91,9 @@ func (s *BooleanSearcher) initSearchers() error {
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}
@@ -118,9 +118,9 @@ func (s *BooleanSearcher) advanceNextMust() error {
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}
@@ -161,13 +161,13 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 	var rv *search.DocumentMatch
 
 	for s.currentID != "" {
-		if s.currMustNot != nil && s.currMustNot.ID < s.currentID {
+		if s.currMustNot != nil && s.currMustNot.ArrangeID() < s.currentID {
 			// advance must not searcher to our candidate entry
 			s.currMustNot, err = s.mustNotSearcher.Advance(s.currentID, nil)
 			if err != nil {
 				return nil, err
 			}
-			if s.currMustNot != nil && s.currMustNot.ID == s.currentID {
+			if s.currMustNot != nil && s.currMustNot.ArrangeID() == s.currentID {
 				// the candidate is excluded
 				err = s.advanceNextMust()
 				if err != nil {
@@ -175,7 +175,7 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 				}
 				continue
 			}
-		} else if s.currMustNot != nil && s.currMustNot.ID == s.currentID {
+		} else if s.currMustNot != nil && s.currMustNot.ArrangeID() == s.currentID {
 			// the candidate is excluded
 			err = s.advanceNextMust()
 			if err != nil {
@@ -184,13 +184,13 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 			continue
 		}
 
-		if s.currShould != nil && s.currShould.ID < s.currentID {
+		if s.currShould != nil && s.currShould.ArrangeID() < s.currentID {
 			// advance should searcher to our candidate entry
 			s.currShould, err = s.shouldSearcher.Advance(s.currentID, nil)
 			if err != nil {
 				return nil, err
 			}
-			if s.currShould != nil && s.currShould.ID == s.currentID {
+			if s.currShould != nil && s.currShould.ArrangeID() == s.currentID {
 				// score bonus matches should
 				var cons []*search.DocumentMatch
 				if s.currMust != nil {
@@ -218,7 +218,7 @@ func (s *BooleanSearcher) Next(preAllocated *search.DocumentMatch) (*search.Docu
 				}
 				break
 			}
-		} else if s.currShould != nil && s.currShould.ID == s.currentID {
+		} else if s.currShould != nil && s.currShould.ArrangeID() == s.currentID {
 			// score bonus matches should
 			var cons []*search.DocumentMatch
 			if s.currMust != nil {
@@ -285,9 +285,9 @@ func (s *BooleanSearcher) Advance(ID string, preAllocated *search.DocumentMatch)
 	}
 
 	if s.mustSearcher != nil && s.currMust != nil {
-		s.currentID = s.currMust.ID
+		s.currentID = s.currMust.ArrangeID()
 	} else if s.mustSearcher == nil && s.currShould != nil {
-		s.currentID = s.currShould.ID
+		s.currentID = s.currShould.ArrangeID()
 	} else {
 		s.currentID = ""
 	}

--- a/search/searchers/search_boolean_test.go
+++ b/search/searchers/search_boolean_test.go
@@ -346,8 +346,8 @@ func TestBooleanSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_conjunction.go
+++ b/search/searchers/search_conjunction.go
@@ -75,7 +75,7 @@ func (s *ConjunctionSearcher) initSearchers() error {
 
 	if len(s.currs) > 0 {
 		if s.currs[0] != nil {
-			s.currentID = s.currs[0].ID
+			s.currentID = s.currs[0].ArrangeID()
 		} else {
 			s.currentID = ""
 		}
@@ -111,9 +111,9 @@ func (s *ConjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 OUTER:
 	for s.currentID != "" {
 		for i, termSearcher := range s.searchers {
-			if s.currs[i] != nil && s.currs[i].ID != s.currentID {
-				if s.currentID < s.currs[i].ID {
-					s.currentID = s.currs[i].ID
+			if s.currs[i] != nil && s.currs[i].ArrangeID() != s.currentID {
+				if s.currentID < s.currs[i].ArrangeID() {
+					s.currentID = s.currs[i].ArrangeID()
 					continue OUTER
 				}
 				// this reader doesn't have the currentID, try to advance
@@ -125,10 +125,10 @@ OUTER:
 					s.currentID = ""
 					continue OUTER
 				}
-				if s.currs[i].ID != s.currentID {
+				if s.currs[i].ArrangeID() != s.currentID {
 					// we just advanced, so it doesn't match, it must be greater
 					// no need to call next
-					s.currentID = s.currs[i].ID
+					s.currentID = s.currs[i].ArrangeID()
 					continue OUTER
 				}
 			} else if s.currs[i] == nil {
@@ -147,7 +147,7 @@ OUTER:
 		if s.currs[0] == nil {
 			s.currentID = ""
 		} else {
-			s.currentID = s.currs[0].ID
+			s.currentID = s.currs[0].ArrangeID()
 		}
 		// don't continue now, wait for the next call to Next()
 		break

--- a/search/searchers/search_conjunction_test.go
+++ b/search/searchers/search_conjunction_test.go
@@ -191,8 +191,8 @@ func TestConjunctionSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_disjunction.go
+++ b/search/searchers/search_disjunction.go
@@ -101,8 +101,8 @@ func (s *DisjunctionSearcher) initSearchers() error {
 func (s *DisjunctionSearcher) nextSmallestID() string {
 	rv := ""
 	for _, curr := range s.currs {
-		if curr != nil && (curr.ID < rv || rv == "") {
-			rv = curr.ID
+		if curr != nil && (curr.ArrangeID() < rv || rv == "") {
+			rv = curr.ArrangeID()
 		}
 	}
 	return rv
@@ -136,7 +136,7 @@ func (s *DisjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 	found := false
 	for !found && s.currentID != "" {
 		for _, curr := range s.currs {
-			if curr != nil && curr.ID == s.currentID {
+			if curr != nil && curr.ArrangeID() == s.currentID {
 				matching = append(matching, curr)
 			}
 		}
@@ -151,7 +151,7 @@ func (s *DisjunctionSearcher) Next(preAllocated *search.DocumentMatch) (*search.
 		matching = make([]*search.DocumentMatch, 0)
 		// invoke next on all the matching searchers
 		for i, curr := range s.currs {
-			if curr != nil && curr.ID == s.currentID {
+			if curr != nil && curr.ArrangeID() == s.currentID {
 				searcher := s.searchers[i]
 				s.currs[i], err = searcher.Next(nil)
 				if err != nil {

--- a/search/searchers/search_disjunction_test.go
+++ b/search/searchers/search_disjunction_test.go
@@ -112,8 +112,8 @@ func TestDisjunctionSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_docid_test.go
+++ b/search/searchers/search_docid_test.go
@@ -72,8 +72,8 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if id != m.ID {
-			t.Fatalf("expected %v at position %v, got %v", id, i, m.ID)
+		if id != m.ArrangeID() {
+			t.Fatalf("expected %v at position %v, got %v", id, i, m.ArrangeID())
 		}
 	}
 	m, err := searcher.Next(nil)
@@ -81,7 +81,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 		t.Fatal(err)
 	}
 	if m != nil {
-		t.Fatalf("expected nil past the end of the sequence, got %v", m.ID)
+		t.Fatalf("expected nil past the end of the sequence, got %v", m.ArrangeID())
 	}
 
 	// Check seeking
@@ -95,7 +95,7 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if m == nil || m.ID != id {
+			if m == nil || m.ArrangeID() != id {
 				t.Fatalf("advancing to %v returned %v instead of %v", before, m, id)
 			}
 		}

--- a/search/searchers/search_fuzzy_test.go
+++ b/search/searchers/search_fuzzy_test.go
@@ -109,8 +109,8 @@ func TestFuzzySearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_match_all_test.go
+++ b/search/searchers/search_match_all_test.go
@@ -113,8 +113,8 @@ func TestMatchAllSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_match_none_test.go
+++ b/search/searchers/search_match_none_test.go
@@ -55,8 +55,8 @@ func TestMatchNoneSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if !scoresCloseEnough(next.Score, test.results[i].Score) {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_phrase_test.go
+++ b/search/searchers/search_phrase_test.go
@@ -72,8 +72,8 @@ func TestPhraseSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_regexp_test.go
+++ b/search/searchers/search_regexp_test.go
@@ -89,8 +89,8 @@ func TestRegexpSearch(t *testing.T) {
 		i := 0
 		for err == nil && next != nil {
 			if i < len(test.results) {
-				if next.ID != test.results[i].ID {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ID, next.ID, testIndex)
+				if next.ArrangeID() != test.results[i].ArrangeID() {
+					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].ArrangeID(), next.ArrangeID(), testIndex)
 				}
 				if next.Score != test.results[i].Score {
 					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)

--- a/search/searchers/search_term_test.go
+++ b/search/searchers/search_term_test.go
@@ -167,15 +167,15 @@ func TestTermSearcher(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
 	}
-	if docMatch.ID != "a" {
-		t.Errorf("expected result ID to be 'a', got '%s", docMatch.ID)
+	if docMatch.ArrangeID() != "a" {
+		t.Errorf("expected result ID to be 'a', got '%s", docMatch.ArrangeID())
 	}
 	docMatch, err = searcher.Advance("c", nil)
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
 	}
-	if docMatch.ID != "c" {
-		t.Errorf("expected result ID to be 'c' got '%s'", docMatch.ID)
+	if docMatch.ArrangeID() != "c" {
+		t.Errorf("expected result ID to be 'c' got '%s'", docMatch.ArrangeID())
 	}
 
 	// try advancing past end


### PR DESCRIPTION
This change adds a private idBytes field to the DocumentMatch struct,
to allow us to avoid converting the id bytes to an ID string for most
of the matches would be filtered away by LIMIT params.