### PR TITLE
tighter moss KV store iterator handling

### DIFF
--- a/index/store/moss/reader.go
+++ b/index/store/moss/reader.go
@@ -57,7 +57,7 @@ func (r *Reader) PrefixIterator(k []byte) store.KVIterator {
 		end:   kEnd,
 	}
 
-	rv.checkDone()
+	rv.current()
 
 	return rv
 }
@@ -76,7 +76,7 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 		end:   end,
 	}
 
-	rv.checkDone()
+	rv.current()
 
 	return rv
 }


### PR DESCRIPTION
The moss KV store iterator Next() method is invoked in the hot path of search processing, so removing/simplifying some of its code.