### PR TITLE
Add http endpoint for batch import.

### DIFF
--- a/http/batch_index.go
+++ b/http/batch_index.go
@@ -1,0 +1,114 @@
+//  Copyright (c) 2016 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/blevesearch/bleve"
+	"io"
+	"net/http"
+)
+
+type MetaData struct {
+	Action string `json:"action"`
+	Index  string `json:"index"`
+	Id     string `json:"id"`
+}
+
+type BatchIndexHandler struct {
+}
+
+func NewBatchIndexHandler() *BatchIndexHandler {
+	return &BatchIndexHandler{}
+}
+
+func (h *BatchIndexHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	openBatches := map[string]*bleve.Batch{}
+
+	dec := json.NewDecoder(req.Body)
+	isMeta := true
+	var currentMeta MetaData
+
+	for {
+		if isMeta {
+			var meta MetaData
+			if err := dec.Decode(&meta); err == io.EOF {
+				break
+			} else if err != nil {
+				showError(w, req, fmt.Sprintf("error parsing meta JSON: %v", err), 400)
+				return
+			}
+			currentMeta = meta
+
+			batch, present := openBatches[currentMeta.Index]
+
+			if !present {
+				index := IndexByName(currentMeta.Index)
+				if index == nil {
+					showError(w, req, fmt.Sprintf("no such  index '%s'", currentMeta.Index), 404)
+					return
+				}
+				batch = index.NewBatch()
+				openBatches[currentMeta.Index] = batch
+			}
+
+			switch currentMeta.Action {
+			case "index":
+				isMeta = false
+			case "delete":
+				batch.Delete(currentMeta.Id)
+			default:
+				showError(w, req, fmt.Sprintf("unknown action: %v", currentMeta.Action), 400)
+				return
+			}
+
+		} else {
+			var doc interface{}
+			if err := dec.Decode(&doc); err == io.EOF {
+				break
+			} else if err != nil {
+				showError(w, req, fmt.Sprintf("error parsing document JSON: %v", err), 400)
+				return
+			}
+
+			batch, _ := openBatches[currentMeta.Index]
+
+			switch currentMeta.Action {
+			case "index":
+				err := batch.Index(currentMeta.Id, doc)
+				if err != nil {
+					showError(w, req, fmt.Sprintf("error indexing document in batch '%s': %v", currentMeta.Id, err), 500)
+					return
+				}
+			default:
+				showError(w, req, fmt.Sprintf("unknown action: %v", currentMeta.Action), 400)
+				return
+			}
+			isMeta = true
+		}
+
+	}
+
+	for idx, batch := range openBatches {
+		index := IndexByName(idx)
+		err := index.Batch(batch)
+		if err != nil {
+			showError(w, req, fmt.Sprintf("error while storing batch: %v", err), 400)
+			return
+		}
+	}
+
+	rv := struct {
+		Status string `json:"status"`
+	}{
+		Status: "ok",
+	}
+	mustEncode(w, rv)
+}


### PR DESCRIPTION
This is a work in progress of adding batch import support as a HTTP endpoint based on the current functionality.

The proposed format is line delimited first a meta json with a defined format and then optionally a document block (depending on the type).

Proposed meta:

``` json
{"index": "<indexname>", "id": "<docid>", "action": "<index or delete>"}
```

So for example:

A file with

``` json
{"index": "foo", "id": "airline_10", "action": "index"}
{"type": "airline","name": "40-Mile Air","iata": "Q5","icao": "MLA","callsign": "MILE-AIR","country": "United States"}
{"index": "foo", "id": "enoent", "action": "delete"}
{"index": "foo", "id": "airline_10123", "action": "index"}
{"type": "airline","name": "Texas Wings","iata": "TQ","icao": "TXW","callsign": "TXW","country": "United States" }
{"index": "foo", "id": "airline_10226", "action": "index"}
{"type": "airline","name": "Texas Wings","iata": "TQ","icao": "TXW","callsign": "TXW","country": "United States" }
{"index": "foo", "id": "airline_10226", "action": "delete"}
```

will end up with 2 docs stored, the first delete will be ignored (enoent) and the second delete will remove one of the docs. 

I tested with a simple server

``` go
package main

import(
    "github.com/gorilla/mux"
    bleveHttp "github.com/blevesearch/bleve/http"
    "net/http"
    "log"
    "flag"
    "github.com/blevesearch/bleve"
    "fmt"
)

var bindAddr = flag.String("addr", ":8095", "http listen address")

func main() {
    router := mux.NewRouter()

    mapping := bleve.NewIndexMapping()
    index, err := bleve.New("foo.bleve", mapping)

    fmt.Println("ERROR!!", err)

    bleveHttp.RegisterIndexName("foo", index)

    bulkIndexHandler := bleveHttp.NewBatchIndexHandler()
    router.Handle("/_bulk", bulkIndexHandler).Methods("POST")

    http.Handle("/", router)
    log.Printf("Listening on %v", *bindAddr)
    log.Fatal(http.ListenAndServe(*bindAddr, nil))
}
```

and storing the file shown above with `curl -vv -XPOST http://localhost:8095/_bulk --data-binary "@requests"`.

`bleve_dump` shows me I think it did the right thing. 

So:
- functionality/semantics wise is there anything I missed?
- there is lots of duplication in there, and any goisms I didn't follow please let me know and I'll clean it up.
- where is the best place to add tests?
- any other things I missed?

Once this one is sane I'll make an independent PR to the bleve-explorer to take advantage of it.

fixes #171
