### PR TITLE
avoid allocation in stop token filter

### DIFF
--- a/analysis/token_filters/stop_tokens_filter/stop_tokens_filter.go
+++ b/analysis/token_filters/stop_tokens_filter/stop_tokens_filter.go
@@ -36,16 +36,16 @@ func NewStopTokensFilter(stopTokens analysis.TokenMap) *StopTokensFilter {
 }
 
 func (f *StopTokensFilter) Filter(input analysis.TokenStream) analysis.TokenStream {
-	rv := make(analysis.TokenStream, 0, len(input))
-
+	j := 0
 	for _, token := range input {
 		_, isStopToken := f.stopTokens[string(token.Term)]
 		if !isStopToken {
-			rv = append(rv, token)
+			input[j] = token
+			j++
 		}
 	}
 
-	return rv
+	return input[:j]
 }
 
 func StopTokensFilterConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.TokenFilter, error) {


### PR DESCRIPTION
the token stream resulting from the removal of stop words must
be shorter or the same length as the original, so we just
reuse it and truncate it at the end.