### PR TITLE
speed up english possessive filter

### DIFF
--- a/analysis/language/en/possessive_filter_en_test.go
+++ b/analysis/language/en/possessive_filter_en_test.go
@@ -45,6 +45,12 @@ func TestEnglishPossessiveFilter(t *testing.T) {
 				&analysis.Token{
 					Term: []byte("m"),
 				},
+				&analysis.Token{
+					Term: []byte("s"),
+				},
+				&analysis.Token{
+					Term: []byte("'s"),
+				},
 			},
 			output: analysis.TokenStream{
 				&analysis.Token{
@@ -68,6 +74,12 @@ func TestEnglishPossessiveFilter(t *testing.T) {
 				&analysis.Token{
 					Term: []byte("m"),
 				},
+				&analysis.Token{
+					Term: []byte("s"),
+				},
+				&analysis.Token{
+					Term: []byte(""),
+				},
 			},
 		},
 	}
@@ -83,4 +95,43 @@ func TestEnglishPossessiveFilter(t *testing.T) {
 			t.Errorf("expected %s, got %s", test.output, actual)
 		}
 	}
+}
+
+func BenchmarkEnglishPossessiveFilter(b *testing.B) {
+
+	input := analysis.TokenStream{
+		&analysis.Token{
+			Term: []byte("marty's"),
+		},
+		&analysis.Token{
+			Term: []byte("MARTY'S"),
+		},
+		&analysis.Token{
+			Term: []byte("marty’s"),
+		},
+		&analysis.Token{
+			Term: []byte("MARTY’S"),
+		},
+		&analysis.Token{
+			Term: []byte("marty＇s"),
+		},
+		&analysis.Token{
+			Term: []byte("MARTY＇S"),
+		},
+		&analysis.Token{
+			Term: []byte("m"),
+		},
+	}
+
+	cache := registry.NewCache()
+	stemmerFilter, err := cache.TokenFilterNamed(PossessiveName)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stemmerFilter.Filter(input)
+	}
+
 }


### PR DESCRIPTION
previous impl always did full utf8 decode of rune
if we assume most tokens are not possessive this is unnecessary
and even if they are, we only need to chop off last to runes
so, now we only decode last rune of token, and if it looks like
s/S then we proceed to decode second to last rune, and then
only if it looks like any form of apostrophe, do we make any
changes to token, again by just reslicing original to chop
off the possessive extension