### PR TITLE
BREAKING CHANGE - removed DumpXXX() methods from bleve.Index

### DIFF
--- a/index.go
+++ b/index.go
@@ -176,24 +176,6 @@ type Index interface {
 	FieldDictRange(field string, startTerm []byte, endTerm []byte) (index.FieldDict, error)
 	FieldDictPrefix(field string, termPrefix []byte) (index.FieldDict, error)
 
-	// DumpAll returns a channel receiving all index rows as
-	// UpsideDownCouchRow, in lexicographic byte order. If the enumeration
-	// fails, an error is sent. The channel is closed once the enumeration
-	// completes or an error is encountered. The caller must consume all
-	// channel entries until the channel is closed to ensure the transaction
-	// and other resources associated with the enumeration are released.
-	//
-	// DumpAll exists for debugging and tooling purpose and may change in the
-	// future.
-	DumpAll() chan interface{}
-
-	// DumpDoc works like DumpAll but returns only StoredRows and
-	// TermFrequencyRows related to a document.
-	DumpDoc(id string) chan interface{}
-
-	// DumpFields works like DumpAll but returns only FieldRows.
-	DumpFields() chan interface{}
-
 	Close() error
 
 	Mapping() *IndexMapping

--- a/index/index.go
+++ b/index/index.go
@@ -24,18 +24,12 @@ type Index interface {
 	Open() error
 	Close() error
 
-	DocCount() (uint64, error)
-
 	Update(doc *document.Document) error
 	Delete(id string) error
 	Batch(batch *Batch) error
 
 	SetInternal(key, val []byte) error
 	DeleteInternal(key []byte) error
-
-	DumpAll() chan interface{}
-	DumpDoc(id string) chan interface{}
-	DumpFields() chan interface{}
 
 	// Reader returns a low-level accessor on the index data. Close it to
 	// release associated resources.
@@ -71,10 +65,14 @@ type IndexReader interface {
 
 	GetInternal(key []byte) ([]byte, error)
 
-	DocCount() uint64
+	DocCount() (uint64, error)
 
 	ExternalID(id IndexInternalID) (string, error)
 	InternalID(id string) (IndexInternalID, error)
+
+	DumpAll() chan interface{}
+	DumpDoc(id string) chan interface{}
+	DumpFields() chan interface{}
 
 	Close() error
 }

--- a/index/smolder/dump.go
+++ b/index/smolder/dump.go
@@ -22,7 +22,7 @@ import (
 // if your application relies on them, you're doing something wrong
 // they may change or be removed at any time
 
-func (udc *SmolderingCouch) dumpPrefix(kvreader store.KVReader, rv chan interface{}, prefix []byte) {
+func dumpPrefix(kvreader store.KVReader, rv chan interface{}, prefix []byte) {
 	start := prefix
 	if start == nil {
 		start = []byte{0}
@@ -52,7 +52,7 @@ func (udc *SmolderingCouch) dumpPrefix(kvreader store.KVReader, rv chan interfac
 	}
 }
 
-func (udc *SmolderingCouch) dumpRange(kvreader store.KVReader, rv chan interface{}, start, end []byte) {
+func dumpRange(kvreader store.KVReader, rv chan interface{}, start, end []byte) {
 	it := kvreader.RangeIterator(start, end)
 	defer func() {
 		cerr := it.Close()
@@ -78,48 +78,20 @@ func (udc *SmolderingCouch) dumpRange(kvreader store.KVReader, rv chan interface
 	}
 }
 
-func (udc *SmolderingCouch) DumpAll() chan interface{} {
+func (i *IndexReader) DumpAll() chan interface{} {
 	rv := make(chan interface{})
 	go func() {
 		defer close(rv)
-
-		// start an isolated reader for use during the dump
-		kvreader, err := udc.store.Reader()
-		if err != nil {
-			rv <- err
-			return
-		}
-		defer func() {
-			cerr := kvreader.Close()
-			if cerr != nil {
-				rv <- cerr
-			}
-		}()
-
-		udc.dumpRange(kvreader, rv, nil, nil)
+		dumpRange(i.kvreader, rv, nil, nil)
 	}()
 	return rv
 }
 
-func (udc *SmolderingCouch) DumpFields() chan interface{} {
+func (i *IndexReader) DumpFields() chan interface{} {
 	rv := make(chan interface{})
 	go func() {
 		defer close(rv)
-
-		// start an isolated reader for use during the dump
-		kvreader, err := udc.store.Reader()
-		if err != nil {
-			rv <- err
-			return
-		}
-		defer func() {
-			cerr := kvreader.Close()
-			if cerr != nil {
-				rv <- cerr
-			}
-		}()
-
-		udc.dumpPrefix(kvreader, rv, []byte{'f'})
+		dumpPrefix(i.kvreader, rv, []byte{'f'})
 	}()
 	return rv
 }
@@ -131,26 +103,13 @@ func (k keyset) Swap(i, j int)      { k[i], k[j] = k[j], k[i] }
 func (k keyset) Less(i, j int) bool { return bytes.Compare(k[i], k[j]) < 0 }
 
 // DumpDoc returns all rows in the index related to this doc id
-func (udc *SmolderingCouch) DumpDoc(id string) chan interface{} {
+func (i *IndexReader) DumpDoc(id string) chan interface{} {
 	rv := make(chan interface{})
 
 	go func() {
 		defer close(rv)
 
-		indexReader, err := udc.Reader()
-		if err != nil {
-			rv <- err
-			return
-		}
-
-		defer func() {
-			cerr := indexReader.Close()
-			if cerr != nil {
-				rv <- cerr
-			}
-		}()
-
-		back, err := udc.backIndexRowForDoc(indexReader, nil, id)
+		back, err := i.backIndexRowForDoc(nil, id)
 		if err != nil {
 			rv <- err
 			return
@@ -171,16 +130,13 @@ func (udc *SmolderingCouch) DumpDoc(id string) chan interface{} {
 		}
 		sort.Sort(keys)
 
-		// start an isolated reader for use during the dump
-		kvreader := indexReader.(*IndexReader).kvreader
-
 		// first add all the stored rows
 		storedRowPrefix := NewStoredRowDocBytes(back.docNumber, 0, []uint64{}, 'x', []byte{}).ScanPrefixForDoc()
-		udc.dumpPrefix(kvreader, rv, storedRowPrefix)
+		dumpPrefix(i.kvreader, rv, storedRowPrefix)
 
 		// now walk term keys in order and add them as well
 		if len(keys) > 0 {
-			it := kvreader.RangeIterator(keys[0], nil)
+			it := i.kvreader.RangeIterator(keys[0], nil)
 			defer func() {
 				cerr := it.Close()
 				if cerr != nil {

--- a/index/smolder/dump_test.go
+++ b/index/smolder/dump_test.go
@@ -44,12 +44,20 @@ func TestDump(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -79,7 +87,11 @@ func TestDump(t *testing.T) {
 	}
 
 	fieldsCount := 0
-	fieldsRows := idx.DumpFields()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fieldsRows := reader.DumpFields()
 	for range fieldsRows {
 		fieldsCount++
 	}
@@ -95,7 +107,7 @@ func TestDump(t *testing.T) {
 	// 1 id stored row
 	expectedDocRowCount := int(1+(2*(64/document.DefaultPrecisionStep))+3) + 1 + 1
 	docRowCount := 0
-	docRows := idx.DumpDoc("1")
+	docRows := reader.DumpDoc("1")
 	for range docRows {
 		docRowCount++
 	}
@@ -104,7 +116,7 @@ func TestDump(t *testing.T) {
 	}
 
 	docRowCount = 0
-	docRows = idx.DumpDoc("2")
+	docRows = reader.DumpDoc("2")
 	for range docRows {
 		docRowCount++
 	}
@@ -121,11 +133,16 @@ func TestDump(t *testing.T) {
 	// 16 date term row counts (shared for both docs, same date value)
 	expectedAllRowCount := int(1 + fieldsCount + (2 * expectedDocRowCount) + 2 + 4 + int((2 * (64 / document.DefaultPrecisionStep))))
 	allRowCount := 0
-	allRows := idx.DumpAll()
+	allRows := reader.DumpAll()
 	for range allRows {
 		allRowCount++
 	}
 	if allRowCount != expectedAllRowCount {
 		t.Errorf("expected %d rows for all, got %d", expectedAllRowCount, allRowCount)
+	}
+
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/index/smolder/smoldering_test.go
+++ b/index/smolder/smoldering_test.go
@@ -51,12 +51,20 @@ func TestIndexOpenReopen(t *testing.T) {
 	}
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// opening the database should have inserted a version and _id field
@@ -116,12 +124,20 @@ func TestIndexInsert(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -132,12 +148,20 @@ func TestIndexInsert(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 4 rows (1 for version, 1 for schema field, and 1 for single term, and 1 for the term count, and 1 for the back index entry)
@@ -181,12 +205,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -207,12 +239,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	expectedCount++
 	expectedRows += 4 // 2 dictionary 2 terms
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = idx.Delete("1")
@@ -222,12 +262,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	expectedCount--
 	expectedRows -= 2 //2 terms
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = idx.Delete("2")
@@ -237,12 +285,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	expectedCount--
 	expectedRows -= 2 //2 terms
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 2 rows (1 for version, 2 for schema field, 3 for dictionary row garbage)
@@ -303,9 +359,17 @@ func TestIndexInsertThenUpdate(t *testing.T) {
 	}
 	if rowCount != expectedLength {
 		t.Errorf("expected %d rows, got: %d", expectedLength, rowCount)
-		allRows := idx.DumpAll()
+		reader, err := idx.Reader()
+		if err != nil {
+			t.Fatal(err)
+		}
+		allRows := reader.DumpAll()
 		for ar := range allRows {
 			t.Logf("%v", ar)
+		}
+		err = reader.Close()
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 
@@ -325,9 +389,16 @@ func TestIndexInsertThenUpdate(t *testing.T) {
 	}
 	if rowCount != expectedLength {
 		t.Errorf("expected %d rows, got: %d", expectedLength, rowCount)
-		allRows := idx.DumpAll()
+		reader, err := idx.Reader()
+		if err != nil {
+			t.Fatal(err)
+		}
+		allRows := reader.DumpAll()
 		for ar := range allRows {
 			t.Logf("%v", ar)
+		}
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }
@@ -407,12 +478,20 @@ func TestIndexInsertMultiple(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
-		t.Errorf("expected doc count: %d, got %d", expectedCount, docCount)
+		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -441,12 +520,20 @@ func TestIndexInsertWithStore(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -457,12 +544,20 @@ func TestIndexInsertWithStore(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 6 rows (1 for version, 2 for schema field, and 2 for terms, and 2 for the stored field and 2 for the term counts, and 1 for the back index entry)
@@ -675,7 +770,10 @@ func TestIndexBatch(t *testing.T) {
 		}
 	}()
 
-	docCount := indexReader.DocCount()
+	docCount, err := indexReader.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
 	}
@@ -702,9 +800,17 @@ func TestIndexBatch(t *testing.T) {
 	expectedDocIDs := []string{"2", "3"}
 	if !reflect.DeepEqual(docIDs, expectedDocIDs) {
 		t.Errorf("expected ids: %v, got ids: %v", expectedDocIDs, docIDs)
-		allRows := idx.DumpAll()
+		reader, err := idx.Reader()
+		if err != nil {
+			t.Fatal(err)
+		}
+		allRows := reader.DumpAll()
 		for ar := range allRows {
 			t.Logf("%v", ar)
+		}
+		err = reader.Close()
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }
@@ -734,12 +840,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -756,12 +870,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 78 rows
@@ -861,7 +983,10 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}
 
 	// expected doc count shouldn't have changed
-	docCount = indexReader2.DocCount()
+	docCount, err = indexReader2.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
 	}
@@ -911,12 +1036,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	expectedCount--
 
 	// expected doc count shouldn't have changed
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -1365,7 +1498,7 @@ func TestLargeField(t *testing.T) {
 		}
 	}()
 
-	largeFieldValue := make([]byte, 0)
+	var largeFieldValue []byte
 	for len(largeFieldValue) < RowBufferSize {
 		largeFieldValue = append(largeFieldValue, bleveWikiArticle1K...)
 	}

--- a/index/upside_down/dump_test.go
+++ b/index/upside_down/dump_test.go
@@ -44,12 +44,20 @@ func TestDump(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -79,7 +87,11 @@ func TestDump(t *testing.T) {
 	}
 
 	fieldsCount := 0
-	fieldsRows := idx.DumpFields()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fieldsRows := reader.DumpFields()
 	for range fieldsRows {
 		fieldsCount++
 	}
@@ -93,7 +105,7 @@ func TestDump(t *testing.T) {
 	// 3 stored fields
 	expectedDocRowCount := int(1 + (2 * (64 / document.DefaultPrecisionStep)) + 3)
 	docRowCount := 0
-	docRows := idx.DumpDoc("1")
+	docRows := reader.DumpDoc("1")
 	for range docRows {
 		docRowCount++
 	}
@@ -102,7 +114,7 @@ func TestDump(t *testing.T) {
 	}
 
 	docRowCount = 0
-	docRows = idx.DumpDoc("2")
+	docRows = reader.DumpDoc("2")
 	for range docRows {
 		docRowCount++
 	}
@@ -119,11 +131,16 @@ func TestDump(t *testing.T) {
 	// 16 date term row counts (shared for both docs, same date value)
 	expectedAllRowCount := int(1 + fieldsCount + (2 * expectedDocRowCount) + 2 + 2 + int((2 * (64 / document.DefaultPrecisionStep))))
 	allRowCount := 0
-	allRows := idx.DumpAll()
+	allRows := reader.DumpAll()
 	for range allRows {
 		allRowCount++
 	}
 	if allRowCount != expectedAllRowCount {
 		t.Errorf("expected %d rows for all, got %d", expectedAllRowCount, allRowCount)
+	}
+
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/index/upside_down/index_reader.go
+++ b/index/upside_down/index_reader.go
@@ -56,7 +56,7 @@ func (i *IndexReader) DocIDReaderOnly(ids []string) (index.DocIDReader, error) {
 func (i *IndexReader) Document(id string) (doc *document.Document, err error) {
 	// first hit the back index to confirm doc exists
 	var backIndexRow *BackIndexRow
-	backIndexRow, err = i.index.backIndexRowForDoc(i.kvreader, []byte(id))
+	backIndexRow, err = backIndexRowForDoc(i.kvreader, []byte(id))
 	if err != nil {
 		return
 	}
@@ -97,7 +97,7 @@ func (i *IndexReader) Document(id string) (doc *document.Document, err error) {
 }
 
 func (i *IndexReader) DocumentFieldTerms(id index.IndexInternalID, fields []string) (index.FieldTerms, error) {
-	back, err := i.index.backIndexRowForDoc(i.kvreader, id)
+	back, err := backIndexRowForDoc(i.kvreader, id)
 	if err != nil {
 		return nil, err
 	}
@@ -156,8 +156,8 @@ func (i *IndexReader) GetInternal(key []byte) ([]byte, error) {
 	return i.kvreader.Get(internalRow.Key())
 }
 
-func (i *IndexReader) DocCount() uint64 {
-	return i.docCount
+func (i *IndexReader) DocCount() (uint64, error) {
+	return i.docCount, nil
 }
 
 func (i *IndexReader) Close() error {

--- a/index/upside_down/upside_down_test.go
+++ b/index/upside_down/upside_down_test.go
@@ -51,12 +51,20 @@ func TestIndexOpenReopen(t *testing.T) {
 	}
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// opening the database should have inserted a version
@@ -116,12 +124,20 @@ func TestIndexInsert(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -132,12 +148,20 @@ func TestIndexInsert(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 4 rows (1 for version, 1 for schema field, and 1 for single term, and 1 for the term count, and 1 for the back index entry)
@@ -176,12 +200,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -200,12 +232,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = idx.Delete("1")
@@ -214,12 +254,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	}
 	expectedCount--
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = idx.Delete("2")
@@ -228,12 +276,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 	}
 	expectedCount--
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 2 rows (1 for version, 1 for schema field, 1 for dictionary row garbage)
@@ -390,12 +446,20 @@ func TestIndexInsertMultiple(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
-		t.Errorf("expected doc count: %d, got %d", expectedCount, docCount)
+		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -424,12 +488,20 @@ func TestIndexInsertWithStore(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -440,12 +512,20 @@ func TestIndexInsertWithStore(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 6 rows (1 for version, 1 for schema field, and 1 for single term, and 1 for the stored field and 1 for the term count, and 1 for the back index entry)
@@ -654,7 +734,10 @@ func TestIndexBatch(t *testing.T) {
 		}
 	}()
 
-	docCount := indexReader.DocCount()
+	docCount, err := indexReader.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
 	}
@@ -663,7 +746,7 @@ func TestIndexBatch(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	docIds := make([]index.IndexInternalID, 0)
+	var docIds []index.IndexInternalID
 	docID, err := docIDReader.Next()
 	for docID != nil && err == nil {
 		docIds = append(docIds, docID)
@@ -703,12 +786,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}()
 
 	var expectedCount uint64
-	docCount, err := idx.DocCount()
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err := reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	doc := document.NewDocument("1")
@@ -725,12 +816,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}
 	expectedCount++
 
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// should have 72 rows
@@ -818,7 +917,10 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}
 
 	// expected doc count shouldn't have changed
-	docCount = indexReader2.DocCount()
+	docCount, err = indexReader2.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
 	}
@@ -862,12 +964,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	expectedCount--
 
 	// expected doc count shouldn't have changed
-	docCount, err = idx.DocCount()
+	reader, err = idx.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	docCount, err = reader.DocCount()
 	if err != nil {
 		t.Error(err)
 	}
 	if docCount != expectedCount {
 		t.Errorf("Expected document count to be %d got %d", expectedCount, docCount)
+	}
+	err = reader.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -1308,7 +1418,7 @@ func TestLargeField(t *testing.T) {
 		}
 	}()
 
-	largeFieldValue := make([]byte, 0)
+	var largeFieldValue []byte
 	for len(largeFieldValue) < RowBufferSize {
 		largeFieldValue = append(largeFieldValue, bleveWikiArticle1K...)
 	}

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -251,54 +251,6 @@ func (i *indexAliasImpl) FieldDictPrefix(field string, termPrefix []byte) (index
 	}, nil
 }
 
-func (i *indexAliasImpl) DumpAll() chan interface{} {
-	i.mutex.RLock()
-	defer i.mutex.RUnlock()
-
-	if !i.open {
-		return nil
-	}
-
-	err := i.isAliasToSingleIndex()
-	if err != nil {
-		return nil
-	}
-
-	return i.indexes[0].DumpAll()
-}
-
-func (i *indexAliasImpl) DumpDoc(id string) chan interface{} {
-	i.mutex.RLock()
-	defer i.mutex.RUnlock()
-
-	if !i.open {
-		return nil
-	}
-
-	err := i.isAliasToSingleIndex()
-	if err != nil {
-		return nil
-	}
-
-	return i.indexes[0].DumpDoc(id)
-}
-
-func (i *indexAliasImpl) DumpFields() chan interface{} {
-	i.mutex.RLock()
-	defer i.mutex.RUnlock()
-
-	if !i.open {
-		return nil
-	}
-
-	err := i.isAliasToSingleIndex()
-	if err != nil {
-		return nil
-	}
-
-	return i.indexes[0].DumpFields()
-}
-
 func (i *indexAliasImpl) Close() error {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -64,29 +64,14 @@ func TestIndexAliasSingle(t *testing.T) {
 		t.Errorf("expected %v, got %v", expectedError, err)
 	}
 
-	res := alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping := alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat := alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -153,29 +138,14 @@ func TestIndexAliasSingle(t *testing.T) {
 		t.Errorf("expected %v, got %v", expectedError2, err)
 	}
 
-	res = alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping = alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat = alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -240,29 +210,14 @@ func TestIndexAliasSingle(t *testing.T) {
 		t.Errorf("expected %v, got %v", expectedError3, err)
 	}
 
-	res = alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping = alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat = alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -328,29 +283,14 @@ func TestIndexAliasClosed(t *testing.T) {
 		t.Errorf("expected %v, got %v", ErrorIndexClosed, err)
 	}
 
-	res := alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping := alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat := alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -410,29 +350,14 @@ func TestIndexAliasEmpty(t *testing.T) {
 		t.Errorf("expected %v, got %v", ErrorAliasEmpty, err)
 	}
 
-	res := alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping := alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat := alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -538,29 +463,14 @@ func TestIndexAliasMulti(t *testing.T) {
 		t.Errorf("expected %v, got %v", ErrorAliasMulti, err)
 	}
 
-	res := alias.DumpAll()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpDoc("a")
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
-	res = alias.DumpFields()
-	if res != nil {
-		t.Errorf("expected nil, got %v", res)
-	}
-
 	mapping := alias.Mapping()
 	if mapping != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", mapping)
 	}
 
 	indexStat := alias.Stats()
 	if indexStat != nil {
-		t.Errorf("expected nil, got %v", res)
+		t.Errorf("expected nil, got %v", indexStat)
 	}
 
 	// now a few things that should work
@@ -1353,18 +1263,6 @@ func (i *stubIndex) FieldDictRange(field string, startTerm []byte, endTerm []byt
 
 func (i *stubIndex) FieldDictPrefix(field string, termPrefix []byte) (index.FieldDict, error) {
 	return nil, i.err
-}
-
-func (i *stubIndex) DumpAll() chan interface{} {
-	return nil
-}
-
-func (i *stubIndex) DumpDoc(id string) chan interface{} {
-	return nil
-}
-
-func (i *stubIndex) DumpFields() chan interface{} {
-	return nil
 }
 
 func (i *stubIndex) Close() error {

--- a/search/collectors/search_test.go
+++ b/search/collectors/search_test.go
@@ -111,8 +111,8 @@ func (sr *stubReader) GetInternal(key []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func (sr *stubReader) DocCount() uint64 {
-	return 0
+func (sr *stubReader) DocCount() (uint64, error) {
+	return 0, nil
 }
 
 func (sr *stubReader) ExternalID(id index.IndexInternalID) (string, error) {
@@ -121,6 +121,18 @@ func (sr *stubReader) ExternalID(id index.IndexInternalID) (string, error) {
 
 func (sr *stubReader) InternalID(id string) (index.IndexInternalID, error) {
 	return []byte(id), nil
+}
+
+func (sr *stubReader) DumpAll() chan interface{} {
+	return nil
+}
+
+func (sr *stubReader) DumpDoc(id string) chan interface{} {
+	return nil
+}
+
+func (sr *stubReader) DumpFields() chan interface{} {
+	return nil
 }
 
 func (sr *stubReader) Close() error {

--- a/search/searchers/search_match_all.go
+++ b/search/searchers/search_match_all.go
@@ -19,10 +19,15 @@ type MatchAllSearcher struct {
 	indexReader index.IndexReader
 	reader      index.DocIDReader
 	scorer      *scorers.ConstantScorer
+	count       uint64
 }
 
 func NewMatchAllSearcher(indexReader index.IndexReader, boost float64, explain bool) (*MatchAllSearcher, error) {
 	reader, err := indexReader.DocIDReaderAll()
+	if err != nil {
+		return nil, err
+	}
+	count, err := indexReader.DocCount()
 	if err != nil {
 		return nil, err
 	}
@@ -31,11 +36,12 @@ func NewMatchAllSearcher(indexReader index.IndexReader, boost float64, explain b
 		indexReader: indexReader,
 		reader:      reader,
 		scorer:      scorer,
+		count:       count,
 	}, nil
 }
 
 func (s *MatchAllSearcher) Count() uint64 {
-	return s.indexReader.DocCount()
+	return s.count
 }
 
 func (s *MatchAllSearcher) Weight() float64 {

--- a/search/searchers/search_term.go
+++ b/search/searchers/search_term.go
@@ -30,7 +30,11 @@ func NewTermSearcher(indexReader index.IndexReader, term string, field string, b
 	if err != nil {
 		return nil, err
 	}
-	scorer := scorers.NewTermQueryScorer(term, field, boost, indexReader.DocCount(), reader.Count(), explain)
+	count, err := indexReader.DocCount()
+	if err != nil {
+		return nil, err
+	}
+	scorer := scorers.NewTermQueryScorer(term, field, boost, count, reader.Count(), explain)
 	return &TermSearcher{
 		indexReader: indexReader,
 		term:        term,

--- a/search/searchers/search_term_test.go
+++ b/search/searchers/search_term_test.go
@@ -150,7 +150,7 @@ func TestTermSearcher(t *testing.T) {
 	}()
 
 	searcher.SetQueryNorm(2.0)
-	docCount, err := i.DocCount()
+	docCount, err := indexReader.DocCount()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/bleve_dump/main.go
+++ b/utils/bleve_dump/main.go
@@ -81,19 +81,27 @@ index specified by -index.
 		return
 	}
 
+	internalIndex, _, err := index.Advanced()
+	if err != nil {
+		log.Fatal(err)
+	}
+	internalIndexReader, err := internalIndex.Reader()
+	if err != nil {
+		log.Fatal(err)
+	}
 	var dumpChan chan interface{}
 	if *docID != "" {
 		if *fieldsOnly {
 			log.Fatal("-docID cannot be used with -fields")
 		}
-		dumpChan = index.DumpDoc(*docID)
+		dumpChan = internalIndexReader.DumpDoc(*docID)
 	} else if *fieldsOnly {
-		dumpChan = index.DumpFields()
+		dumpChan = internalIndexReader.DumpFields()
 	} else if *dictionary != "" {
 		dumpDictionary(index, *dictionary)
 		return
 	} else {
-		dumpChan = index.DumpAll()
+		dumpChan = internalIndexReader.DumpAll()
 	}
 
 	for rowOrErr := range dumpChan {
@@ -104,6 +112,10 @@ index specified by -index.
 			fmt.Printf("%v\n", rowOrErr)
 			fmt.Printf("Key:   % -100x\nValue: % -100x\n\n", rowOrErr.Key(), rowOrErr.Value())
 		}
+	}
+	err = internalIndexReader.Close()
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
The DumpXXX() methods were always documented as internal and
unsupported.  However, now they are being removed from the
public top-level API.  They are still available on the internal
IndexReader, which can be accessed using the Advanced() method.

The DocCount() and DumpXXX() methods on the internal index
have moved to the internal index reader, since they logically
operate on a snapshot of an index.