### PR TITLE
skip termFrequencyRow 0xFF scan as term length is already known

### DIFF
--- a/index/upside_down/reader.go
+++ b/index/upside_down/reader.go
@@ -71,7 +71,7 @@ func (r *UpsideDownCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*
 		key, val, valid := r.iterator.Current()
 		if valid {
 			tfr := r.tfrNext
-			err := tfr.parseKDoc(key)
+			err := tfr.parseKDoc(key, r.term)
 			if err != nil {
 				return nil, err
 			}

--- a/index/upside_down/row.go
+++ b/index/upside_down/row.go
@@ -513,13 +513,8 @@ func (tfr *TermFrequencyRow) parseK(key []byte) error {
 	return nil
 }
 
-func (tfr *TermFrequencyRow) parseKDoc(key []byte) error {
-	termEndPos := bytes.IndexByte(key[3:], ByteSeparator)
-	if termEndPos < 0 {
-		return fmt.Errorf("invalid term frequency key, no byte separator terminating term")
-	}
-
-	tfr.doc = key[3+termEndPos+1:]
+func (tfr *TermFrequencyRow) parseKDoc(key []byte, term []byte) error {
+	tfr.doc = key[3+len(term)+1:]
 	if len(tfr.doc) <= 0 {
 		return fmt.Errorf("invalid term frequency key, empty docid")
 	}


### PR DESCRIPTION
This commit modifies the upside_down TermFrequencyRow parseKDoc() to
skip the ByteSeparator (0xFF) scan, as we already know the term's
length in the UpsideDownCouchTermFieldReader.

On my dev box, results from bleve-query test on high frequency terms
went from previous 107qps to 124qps.