### PR TITLE
optimization for single term, non-faceted, score-based searches

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -142,10 +142,17 @@ func (tfd *TermFieldDoc) Reset() *TermFieldDoc {
 // containing a given term in a given field. Documents are returned in byte
 // lexicographic order over their identifiers.
 type TermFieldReader interface {
-	// Next returns the next document containing the term in this field, or nil
-	// when it reaches the end of the enumeration.  The preAlloced TermFieldDoc
-	// is optional, and when non-nil, will be used instead of allocating memory.
-	Next(preAlloced *TermFieldDoc) (*TermFieldDoc, error)
+	// Next returns the next document containing the term in this
+	// field, or nil when it reaches the end of the enumeration.
+	//
+	// The preAlloced TermFieldDoc is optional, and when non-nil, will
+	// be used instead of allocating memory.
+	//
+	// The filter is optional optimization, and allows the caller to
+	// filter the candidate TermFieldDoc's sooner by their freq and
+	// norm.  Since it is just an optimization, implementations of the
+	// Next() method are allowed to ignore the optional filter.
+	Next(preAlloced *TermFieldDoc, filter FreqNormFilter) (*TermFieldDoc, error)
 
 	// Advance resets the enumeration at specified document or its immediate
 	// follower.
@@ -155,6 +162,10 @@ type TermFieldReader interface {
 	Count() uint64
 	Close() error
 }
+
+// A FreqNormFilter returns true if a match can be skipped during
+// TermFieldReader.Next() iteration based on its freq/norm score.
+type FreqNormFilter func(freq uint64, norm float64) bool
 
 type DictEntry struct {
 	Term  string

--- a/index/smolder/index_reader.go
+++ b/index/smolder/index_reader.go
@@ -183,7 +183,7 @@ func (i *IndexReader) InternalID(id string) (index.IndexInternalID, error) {
 		return nil, nil
 	}
 	pre := index.TermFieldDoc{}
-	tfd, err := tfr.Next(&pre)
+	tfd, err := tfr.Next(&pre, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/index/smolder/reader.go
+++ b/index/smolder/reader.go
@@ -64,7 +64,8 @@ func (r *SmolderingCouchTermFieldReader) Count() uint64 {
 	return r.count
 }
 
-func (r *SmolderingCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*index.TermFieldDoc, error) {
+func (r *SmolderingCouchTermFieldReader) Next(preAlloced *index.TermFieldDoc,
+	filter index.FreqNormFilter) (*index.TermFieldDoc, error) {
 	if r.iterator != nil {
 		key, val, valid := r.iterator.Current()
 		if valid {

--- a/index/smolder/reader_test.go
+++ b/index/smolder/reader_test.go
@@ -98,9 +98,9 @@ func TestIndexReader(t *testing.T) {
 
 	var match *index.TermFieldDoc
 	var actualCount uint64
-	match, err = reader.Next(nil)
+	match, err = reader.Next(nil, nil)
 	for err == nil && match != nil {
-		match, err = reader.Next(nil)
+		match, err = reader.Next(nil, nil)
 		if err != nil {
 			t.Errorf("unexpected error reading next")
 		}
@@ -127,7 +127,7 @@ func TestIndexReader(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	match, err = tfr.Next(nil)
+	match, err = tfr.Next(nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestIndexReader(t *testing.T) {
 	if count != 0 {
 		t.Errorf("expected count 0 for reader of non-existant field")
 	}
-	match, err = reader.Next(nil)
+	match, err = reader.Next(nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/index/smolder/smoldering_test.go
+++ b/index/smolder/smoldering_test.go
@@ -1313,12 +1313,12 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 		t.Error(err)
 	}
 
-	tfd, err := termFieldReader.Next(nil)
+	tfd, err := termFieldReader.Next(nil, nil)
 	for tfd != nil && err == nil {
 		if !tfd.ID.Equals(EncodeUvarintAscending(nil, 1)) {
 			t.Errorf("expected to find document id 1")
 		}
-		tfd, err = termFieldReader.Next(nil)
+		tfd, err = termFieldReader.Next(nil, nil)
 	}
 	if err != nil {
 		t.Error(err)

--- a/index/upside_down/reader_test.go
+++ b/index/upside_down/reader_test.go
@@ -98,9 +98,9 @@ func TestIndexReader(t *testing.T) {
 
 	var match *index.TermFieldDoc
 	var actualCount uint64
-	match, err = reader.Next(nil)
+	match, err = reader.Next(nil, nil)
 	for err == nil && match != nil {
-		match, err = reader.Next(nil)
+		match, err = reader.Next(nil, nil)
 		if err != nil {
 			t.Errorf("unexpected error reading next")
 		}
@@ -127,7 +127,7 @@ func TestIndexReader(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	match, err = tfr.Next(nil)
+	match, err = tfr.Next(nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestIndexReader(t *testing.T) {
 	if count != 0 {
 		t.Errorf("expected count 0 for reader of non-existant field")
 	}
-	match, err = reader.Next(nil)
+	match, err = reader.Next(nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/index/upside_down/upside_down_test.go
+++ b/index/upside_down/upside_down_test.go
@@ -1234,12 +1234,12 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 		t.Error(err)
 	}
 
-	tfd, err := termFieldReader.Next(nil)
+	tfd, err := termFieldReader.Next(nil, nil)
 	for tfd != nil && err == nil {
 		if !tfd.ID.Equals(index.IndexInternalID("1")) {
 			t.Errorf("expected to find document id 1")
 		}
-		tfd, err = termFieldReader.Next(nil)
+		tfd, err = termFieldReader.Next(nil, nil)
 	}
 	if err != nil {
 		t.Error(err)

--- a/search/search.go
+++ b/search/search.go
@@ -144,4 +144,14 @@ type Searcher interface {
 // SearchContext represents the context around a single search
 type SearchContext struct {
 	DocumentMatchPool *DocumentMatchPool
+
+	// A LowScoreFilter is an optional score provided by the
+	// collector, allowing searchers to potentially optimize by
+	// performing early filtering of doc matches with low score.
+	LowScoreFilter float64
+
+	// A count of the matches which were filtered out due to a low
+	// score w.r.t. the LowScoreFilter.  These need to be counted
+	// into the search result's total hits.
+	LowScoreNumMatches uint64
 }

--- a/search/searchers/search_boolean.go
+++ b/search/searchers/search_boolean.go
@@ -166,6 +166,7 @@ func (s *BooleanSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *BooleanSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
 
 	if !s.initialized {
 		err := s.initSearchers(ctx)

--- a/search/searchers/search_conjunction.go
+++ b/search/searchers/search_conjunction.go
@@ -103,6 +103,8 @@ func (s *ConjunctionSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *ConjunctionSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {

--- a/search/searchers/search_disjunction.go
+++ b/search/searchers/search_disjunction.go
@@ -130,6 +130,8 @@ func (s *DisjunctionSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *DisjunctionSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {

--- a/search/searchers/search_docid.go
+++ b/search/searchers/search_docid.go
@@ -50,6 +50,8 @@ func (s *DocIDSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *DocIDSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	docidMatch, err := s.reader.Next()
 	if err != nil {
 		return nil, err

--- a/search/searchers/search_fuzzy.go
+++ b/search/searchers/search_fuzzy.go
@@ -108,6 +108,8 @@ func (s *FuzzySearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *FuzzySearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	return s.searcher.Next(ctx)
 
 }

--- a/search/searchers/search_match_all.go
+++ b/search/searchers/search_match_all.go
@@ -53,6 +53,8 @@ func (s *MatchAllSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *MatchAllSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	id, err := s.reader.Next()
 	if err != nil {
 		return nil, err

--- a/search/searchers/search_match_none.go
+++ b/search/searchers/search_match_none.go
@@ -37,6 +37,8 @@ func (s *MatchNoneSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *MatchNoneSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	return nil, nil
 }
 

--- a/search/searchers/search_numeric_range.go
+++ b/search/searchers/search_numeric_range.go
@@ -97,6 +97,8 @@ func (s *NumericRangeSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *NumericRangeSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	return s.searcher.Next(ctx)
 }
 

--- a/search/searchers/search_phrase.go
+++ b/search/searchers/search_phrase.go
@@ -91,6 +91,8 @@ func (s *PhraseSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *PhraseSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {

--- a/search/searchers/search_regexp.go
+++ b/search/searchers/search_regexp.go
@@ -107,6 +107,8 @@ func (s *RegexpSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *RegexpSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	return s.searcher.Next(ctx)
 
 }

--- a/search/searchers/search_term_prefix.go
+++ b/search/searchers/search_term_prefix.go
@@ -71,6 +71,8 @@ func (s *TermPrefixSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *TermPrefixSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	ctx.LowScoreFilter = 0
+
 	return s.searcher.Next(ctx)
 
 }


### PR DESCRIPTION
This optimization handles a very narrow case: single term searches, no
facets, default sort-by-score.  The main optimization, in this
specialized, limited situation, is to skip over as many term matches,
as early as possible, whose scores are too low.

The optimization tightens the critical filtering loop to just within
the upside_down term field reader Next() method, and tries to avoid
even docId parsing/copying within that hot loop.  Instead, with this
change, that critical loop only performs freq/norm parsing.

Local dev box bleve-query benchmark throughput of high-frequency term
searches hits over 250qps, up from 127qps from before this change.