### PR TITLE
add build tag protecting merge-coverprofile

### DIFF
--- a/docs/merge-coverprofile.go
+++ b/docs/merge-coverprofile.go
@@ -1,3 +1,19 @@
+// Copyright © 2016 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
 package main
 
 import (


### PR DESCRIPTION
this should prevent people that run:
go get github.com/blevesearch/bleve/...
from getting a useless "docs" program in their bin/ dir