### PR TITLE
Revert "optimize when disjunction query has only a single child"

### DIFF
--- a/query_disjunction.go
+++ b/query_disjunction.go
@@ -66,10 +66,6 @@ func (q *disjunctionQuery) SetMin(m float64) Query {
 }
 
 func (q *disjunctionQuery) Searcher(i index.IndexReader, m *IndexMapping, explain bool) (search.Searcher, error) {
-	if len(q.Disjuncts) == 1 {
-		return q.Disjuncts[0].Searcher(i, m, explain)
-	}
-
 	ss := make([]search.Searcher, len(q.Disjuncts))
 	for in, disjunct := range q.Disjuncts {
 		var err error


### PR DESCRIPTION
See also: https://issues.couchbase.com/browse/MB-21046

This reverts commit 6d6fae289509c9deb27710e6f28d56b1ae587c06.

It turns out that boolean searcher was depending on its 'should'
constituent (a disjunction query) and its min state changes, so a
rewrite wasn't safe/correct given this situation.