### PR TITLE
Metrics Work

### DIFF
--- a/index/store/metrics/batch.go
+++ b/index/store/metrics/batch.go
@@ -16,7 +16,7 @@ func (b *Batch) Delete(key []byte) {
 }
 
 func (b *Batch) Merge(key, val []byte) {
-	b.s.TimerBatchMerge.Time(func() {
+	b.s.timerBatchMerge.Time(func() {
 		b.o.Merge(key, val)
 	})
 }

--- a/index/store/metrics/iterator.go
+++ b/index/store/metrics/iterator.go
@@ -8,13 +8,13 @@ type Iterator struct {
 }
 
 func (i *Iterator) Seek(x []byte) {
-	i.s.TimerIteratorSeek.Time(func() {
+	i.s.timerIteratorSeek.Time(func() {
 		i.o.Seek(x)
 	})
 }
 
 func (i *Iterator) Next() {
-	i.s.TimerIteratorNext.Time(func() {
+	i.s.timerIteratorNext.Time(func() {
 		i.o.Next()
 	})
 }

--- a/index/store/metrics/reader.go
+++ b/index/store/metrics/reader.go
@@ -8,7 +8,7 @@ type Reader struct {
 }
 
 func (r *Reader) Get(key []byte) (v []byte, err error) {
-	r.s.TimerReaderGet.Time(func() {
+	r.s.timerReaderGet.Time(func() {
 		v, err = r.o.Get(key)
 		if err != nil {
 			r.s.AddError("Reader.Get", err, key)
@@ -18,7 +18,7 @@ func (r *Reader) Get(key []byte) (v []byte, err error) {
 }
 
 func (r *Reader) MultiGet(keys [][]byte) (vals [][]byte, err error) {
-	r.s.TimerReaderMultiGet.Time(func() {
+	r.s.timerReaderMultiGet.Time(func() {
 		vals, err = r.o.MultiGet(keys)
 		if err != nil {
 			r.s.AddError("Reader.MultiGet", err, nil)
@@ -28,14 +28,14 @@ func (r *Reader) MultiGet(keys [][]byte) (vals [][]byte, err error) {
 }
 
 func (r *Reader) PrefixIterator(prefix []byte) (i store.KVIterator) {
-	r.s.TimerReaderPrefixIterator.Time(func() {
+	r.s.timerReaderPrefixIterator.Time(func() {
 		i = &Iterator{s: r.s, o: r.o.PrefixIterator(prefix)}
 	})
 	return
 }
 
 func (r *Reader) RangeIterator(start, end []byte) (i store.KVIterator) {
-	r.s.TimerReaderRangeIterator.Time(func() {
+	r.s.timerReaderRangeIterator.Time(func() {
 		i = &Iterator{s: r.s, o: r.o.RangeIterator(start, end)}
 	})
 	return

--- a/index/store/metrics/stats.go
+++ b/index/store/metrics/stats.go
@@ -23,14 +23,14 @@ func (s *stats) statsMap() map[string]interface{} {
 	ms := map[string]interface{}{}
 
 	ms["metrics"] = map[string]interface{}{
-		"reader_get":             TimerMap(s.s.TimerReaderGet),
-		"reader_multi_get":       TimerMap(s.s.TimerReaderMultiGet),
-		"reader_prefix_iterator": TimerMap(s.s.TimerReaderPrefixIterator),
-		"reader_range_iterator":  TimerMap(s.s.TimerReaderRangeIterator),
-		"writer_execute_batch":   TimerMap(s.s.TimerWriterExecuteBatch),
-		"iterator_seek":          TimerMap(s.s.TimerIteratorSeek),
-		"iterator_next":          TimerMap(s.s.TimerIteratorNext),
-		"batch_merge":            TimerMap(s.s.TimerBatchMerge),
+		"reader_get":             TimerMap(s.s.timerReaderGet),
+		"reader_multi_get":       TimerMap(s.s.timerReaderMultiGet),
+		"reader_prefix_iterator": TimerMap(s.s.timerReaderPrefixIterator),
+		"reader_range_iterator":  TimerMap(s.s.timerReaderRangeIterator),
+		"writer_execute_batch":   TimerMap(s.s.timerWriterExecuteBatch),
+		"iterator_seek":          TimerMap(s.s.timerIteratorSeek),
+		"iterator_next":          TimerMap(s.s.timerIteratorNext),
+		"batch_merge":            TimerMap(s.s.timerBatchMerge),
 	}
 
 	if o, ok := s.s.o.(store.KVStoreStats); ok {

--- a/index/store/metrics/store.go
+++ b/index/store/metrics/store.go
@@ -32,14 +32,14 @@ const Name = "metrics"
 type Store struct {
 	o store.KVStore
 
-	TimerReaderGet            metrics.Timer
-	TimerReaderMultiGet       metrics.Timer
-	TimerReaderPrefixIterator metrics.Timer
-	TimerReaderRangeIterator  metrics.Timer
-	TimerWriterExecuteBatch   metrics.Timer
-	TimerIteratorSeek         metrics.Timer
-	TimerIteratorNext         metrics.Timer
-	TimerBatchMerge           metrics.Timer
+	timerReaderGet            metrics.Timer
+	timerReaderMultiGet       metrics.Timer
+	timerReaderPrefixIterator metrics.Timer
+	timerReaderRangeIterator  metrics.Timer
+	timerWriterExecuteBatch   metrics.Timer
+	timerIteratorSeek         metrics.Timer
+	timerIteratorNext         metrics.Timer
+	timerBatchMerge           metrics.Timer
 
 	m      sync.Mutex // Protects the fields that follow.
 	errors *list.List // Capped list of StoreError's.
@@ -73,14 +73,14 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 	rv := &Store{
 		o: kvs,
 
-		TimerReaderGet:            metrics.NewTimer(),
-		TimerReaderMultiGet:       metrics.NewTimer(),
-		TimerReaderPrefixIterator: metrics.NewTimer(),
-		TimerReaderRangeIterator:  metrics.NewTimer(),
-		TimerWriterExecuteBatch:   metrics.NewTimer(),
-		TimerIteratorSeek:         metrics.NewTimer(),
-		TimerIteratorNext:         metrics.NewTimer(),
-		TimerBatchMerge:           metrics.NewTimer(),
+		timerReaderGet:            metrics.NewTimer(),
+		timerReaderMultiGet:       metrics.NewTimer(),
+		timerReaderPrefixIterator: metrics.NewTimer(),
+		timerReaderRangeIterator:  metrics.NewTimer(),
+		timerWriterExecuteBatch:   metrics.NewTimer(),
+		timerIteratorSeek:         metrics.NewTimer(),
+		timerIteratorNext:         metrics.NewTimer(),
+		timerBatchMerge:           metrics.NewTimer(),
 
 		errors: list.New(),
 	}
@@ -148,42 +148,42 @@ func (s *Store) WriteJSON(w io.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerReaderGet)
+	WriteTimerJSON(w, s.timerReaderGet)
 	_, err = w.Write([]byte(`,"TimerReaderMultiGet":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerReaderMultiGet)
+	WriteTimerJSON(w, s.timerReaderMultiGet)
 	_, err = w.Write([]byte(`,"TimerReaderPrefixIterator":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerReaderPrefixIterator)
+	WriteTimerJSON(w, s.timerReaderPrefixIterator)
 	_, err = w.Write([]byte(`,"TimerReaderRangeIterator":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerReaderRangeIterator)
+	WriteTimerJSON(w, s.timerReaderRangeIterator)
 	_, err = w.Write([]byte(`,"TimerWriterExecuteBatch":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerWriterExecuteBatch)
+	WriteTimerJSON(w, s.timerWriterExecuteBatch)
 	_, err = w.Write([]byte(`,"TimerIteratorSeek":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerIteratorSeek)
+	WriteTimerJSON(w, s.timerIteratorSeek)
 	_, err = w.Write([]byte(`,"TimerIteratorNext":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerIteratorNext)
+	WriteTimerJSON(w, s.timerIteratorNext)
 	_, err = w.Write([]byte(`,"TimerBatchMerge":`))
 	if err != nil {
 		return
 	}
-	WriteTimerJSON(w, s.TimerBatchMerge)
+	WriteTimerJSON(w, s.timerBatchMerge)
 
 	_, err = w.Write([]byte(`,"Errors":[`))
 	if err != nil {
@@ -252,13 +252,13 @@ func (s *Store) WriteCSVHeader(w io.Writer) {
 }
 
 func (s *Store) WriteCSV(w io.Writer) {
-	WriteTimerCSV(w, s.TimerReaderGet)
-	WriteTimerCSV(w, s.TimerReaderPrefixIterator)
-	WriteTimerCSV(w, s.TimerReaderRangeIterator)
-	WriteTimerCSV(w, s.TimerWriterExecuteBatch)
-	WriteTimerCSV(w, s.TimerIteratorSeek)
-	WriteTimerCSV(w, s.TimerIteratorNext)
-	WriteTimerCSV(w, s.TimerBatchMerge)
+	WriteTimerCSV(w, s.timerReaderGet)
+	WriteTimerCSV(w, s.timerReaderPrefixIterator)
+	WriteTimerCSV(w, s.timerReaderRangeIterator)
+	WriteTimerCSV(w, s.timerWriterExecuteBatch)
+	WriteTimerCSV(w, s.timerIteratorSeek)
+	WriteTimerCSV(w, s.timerIteratorNext)
+	WriteTimerCSV(w, s.timerBatchMerge)
 }
 
 func (s *Store) Stats() json.Marshaler {

--- a/index/store/metrics/writer.go
+++ b/index/store/metrics/writer.go
@@ -36,7 +36,7 @@ func (w *Writer) ExecuteBatch(b store.KVBatch) (err error) {
 	if !ok {
 		return fmt.Errorf("wrong type of batch")
 	}
-	w.s.TimerWriterExecuteBatch.Time(func() {
+	w.s.timerWriterExecuteBatch.Time(func() {
 		err = w.o.ExecuteBatch(batch.o)
 		if err != nil {
 			w.s.AddError("Writer.ExecuteBatch", err, nil)


### PR DESCRIPTION
First, we no longer export the internal metrics timers (opens door for vendoring go-metrics in the future)

~~Second, we aggregate stats on an iterator, the record those numbers on Close() of the iterator.  Internally, the metrics library maintains a mutex on the stat, which must be acquired/released, so we want avoid that in the hottest paths.~~