### PR TITLE
log slow queries only when Config.SlowSearchLogThreshold > 0

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -497,7 +497,8 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	searchDuration := time.Since(searchStart)
 	atomic.AddUint64(&i.stats.searchTime, uint64(searchDuration))
 
-	if searchDuration > Config.SlowSearchLogThreshold {
+	if Config.SlowSearchLogThreshold > 0 &&
+		searchDuration > Config.SlowSearchLogThreshold {
 		logger.Printf("slow search took %s - %v", searchDuration, req)
 	}
 


### PR DESCRIPTION
From some profiling, I saw that there was some logging "work" performed on every search.

(By default, the logging was being io.Discard'ed, so nothing showed up in the actual logs to see this earlier.)