### PR TITLE
DocumentMatch.Sort field not json marshaled

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -70,7 +70,7 @@ type DocumentMatch struct {
 	Expl            *Explanation          `json:"explanation,omitempty"`
 	Locations       FieldTermLocationMap  `json:"locations,omitempty"`
 	Fragments       FieldFragmentMap      `json:"fragments,omitempty"`
-	Sort            []string              `json:"sort,omitempty"`
+	Sort            []string              `json:"-"`
 
 	// Fields contains the values for document fields listed in
 	// SearchRequest.Fields. Text fields are returned as strings, numeric


### PR DESCRIPTION
Previous to this commit, a search result would have the sort
information marshaled for every hit, like...
 ```
 {
  ...
  "request": {
    "query": { ... },
    ...
    "sort": [ "-_score" ]
  },
  "hits": [
    {
      "index": "beers_73aeae08ca311a30_d8c75a95",
      "id": "lang_creek_brewry",
      "score": 1.9991049606044637,
      "sort": [ "-_score" ]
    },
    {
      "index": "beers_73aeae08ca311a30_54127e67",
      "id": "tempo-goldstar",
      "score": 1.6043732680203666,
      "sort": [ "-_score" ]
    },
    ...
  }
```

This change removes the sort information from each hit, resulting in a
smaller response JSON.  The sort information is still part of the
request part of the response.