### PR TITLE
Skip already lowercased runes on transformation.

### DIFF
--- a/analysis/token/lowercase/lowercase.go
+++ b/analysis/token/lowercase/lowercase.go
@@ -64,8 +64,18 @@ func toLowerDeferredCopy(s []byte) []byte {
 		if r >= utf8.RuneSelf {
 			r, wid = utf8.DecodeRune(s[i:])
 		}
+
 		l := unicode.ToLower(r)
-		lwid := utf8.RuneLen(l)
+
+		// If the rune is already lowercased, just move to the
+		// next rune.
+		if l == r {
+			i += wid
+			j += wid
+			continue
+		}
+
+  		lwid := utf8.RuneLen(l)
 		if lwid > wid {
 			// utf-8 encoded replacement is wider
 			// for now, punt and defer


### PR DESCRIPTION
The LowerCaseFilter works on the original slice to avoid allocations,
so skipping already lowercased runes avoids unnecessary work.

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkLowerCaseFilter-8     1302          815           -37.40%
```