### PR TITLE
reuse incrementBytes() in moss KV store integration

### DIFF
--- a/analysis/token/lowercase/lowercase.go
+++ b/analysis/token/lowercase/lowercase.go
@@ -78,11 +78,11 @@ func toLowerDeferredCopy(s []byte) []byte {
 		// Handles the Unicode edge-case where the last
 		// rune in a word on the greek Σ needs to be converted
 		// differently.
-		if l == 'σ' && i + 2 == len(s) {
+		if l == 'σ' && i+2 == len(s) {
 			l = 'ς'
 		}
 
-  		lwid := utf8.RuneLen(l)
+		lwid := utf8.RuneLen(l)
 		if lwid > wid {
 			// utf-8 encoded replacement is wider
 			// for now, punt and defer

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -127,7 +127,7 @@ func (s *DisjunctionSearcher) updateMatches() error {
 				return err
 			}
 
-			last := len(s.searchers)-1
+			last := len(s.searchers) - 1
 			s.searchers[i] = s.searchers[last]
 			s.searchers = s.searchers[0:last]
 			s.currs[i] = s.currs[last]


### PR DESCRIPTION
In this commit, I saw that there was a simple incrementBytes()
implementation elsewhere in bleve that seemed simpler than using the
big int package.