### PR TITLE
revert optimization that trims search-disjunction child searchers

### DIFF
--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -122,19 +122,6 @@ func (s *DisjunctionSearcher) updateMatches() error {
 	for i := 0; i < len(s.currs); i++ {
 		curr := s.currs[i]
 		if curr == nil {
-			err := s.searchers[i].Close()
-			if err != nil {
-				return err
-			}
-
-			last := len(s.searchers) - 1
-			s.searchers[i] = s.searchers[last]
-			s.searchers = s.searchers[0:last]
-			s.currs[i] = s.currs[last]
-			s.currs = s.currs[0:last]
-
-			i-- // To keep i the same for the next iteration.
-
 			continue
 		}
 


### PR DESCRIPTION
This commit reverts a previous optimization attempt 3f588cd4a that
tried to trim or shrink the array of child searchers in a
search-disjunction.

I've been looking at this code all day so far, with lots of printf's,
but still don't have a solid theory as to why this optimization
introduces a functionality regression.

But, the regression is indisputable.  Removing the code that trims
the child-searchers-array seems to correctly restore correct behavior.