### PR TITLE
adding override for "json" in struct tags, tests

### DIFF
--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -160,6 +160,88 @@ func TestMappingStructWithJSONTagsOneDisabled(t *testing.T) {
 	}
 }
 
+func TestMappingStructWithAlternateTags(t *testing.T) {
+
+	mapping := buildMapping()
+	mapping.(*IndexMappingImpl).DefaultMapping.StructTagKey = "bleve"
+
+	x := struct {
+		NoBLEVETag string
+		Name       string `bleve:"name"`
+	}{
+		Name: "marty",
+	}
+
+	doc := document.NewDocument("1")
+	err := mapping.MapDocument(doc, x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundBLEVEName := false
+	foundNoBLEVEName := false
+	count := 0
+	for _, f := range doc.Fields {
+		if f.Name() == "name" {
+			foundBLEVEName = true
+		}
+		if f.Name() == "NoBLEVETag" {
+			foundNoBLEVEName = true
+		}
+		count++
+	}
+	if !foundBLEVEName {
+		t.Errorf("expected to find field named 'name'")
+	}
+	if !foundNoBLEVEName {
+		t.Errorf("expected to find field named 'NoBLEVETag'")
+	}
+	if count != 2 {
+		t.Errorf("expected to find 2 find, found %d", count)
+	}
+}
+
+func TestMappingStructWithAlternateTagsTwoDisabled(t *testing.T) {
+
+	mapping := buildMapping()
+	mapping.(*IndexMappingImpl).DefaultMapping.StructTagKey = "bleve"
+
+	x := struct {
+		Name       string `json:"-"     bleve:"name"`
+		Title      string `json:"-"     bleve:"-"`
+		NoBLEVETag string `json:"-"`
+		Extra      string `json:"extra" bleve:"-"`
+	}{
+		Name: "marty",
+	}
+
+	doc := document.NewDocument("1")
+	err := mapping.MapDocument(doc, x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundBLEVEName := false
+	foundNoBLEVEName := false
+	count := 0
+	for _, f := range doc.Fields {
+		if f.Name() == "name" {
+			foundBLEVEName = true
+		}
+		if f.Name() == "NoBLEVETag" {
+			foundNoBLEVEName = true
+		}
+		count++
+	}
+	if !foundBLEVEName {
+		t.Errorf("expected to find field named 'name'")
+	}
+	if !foundNoBLEVEName {
+		t.Errorf("expected to find field named 'NoBLEVETag'")
+	}
+	if count != 2 {
+		t.Errorf("expected to find 2 find, found %d", count)
+	}
+}
+
 func TestMappingStructWithPointerToString(t *testing.T) {
 
 	mapping := buildMapping()

--- a/mapping/reflect.go
+++ b/mapping/reflect.go
@@ -75,8 +75,8 @@ func mustString(data interface{}) (string, bool) {
 	return "", false
 }
 
-// parseJSONTagName extracts the JSON field name from a struct tag
-func parseJSONTagName(tag string) string {
+// parseTagName extracts the field name from a struct tag
+func parseTagName(tag string) string {
 	if idx := strings.Index(tag, ","); idx != -1 {
 		return tag[:idx]
 	}


### PR DESCRIPTION
This PR adds a field `StructTagKey` to `mapping.DocumentMapping` that allows users to override which key is used when looking for alternate field names / disablement in struct tags during document mapping.  This makes document mapping easier for organizations that want to index existing data structures (including redefining the field names, disabling, etc.) that have explicitly disabled json tags for other reasons.  The change has no effect on existing usage as the default is still "json". Tests have been added (copied and modified really) using "bleve" as an alternate tag.