### PR TITLE
Refactor PhraseSearcher

### DIFF
--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -102,11 +102,13 @@ func (s *PhraseSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch,
 		freq := 0
 		firstTerm := s.terms[0]
 		for field, termLocMap := range s.currMust.Locations {
-			rvtlm := make(search.TermLocationMap, 0)
 			locations, ok := termLocMap[firstTerm]
 			if !ok {
 				continue
 			}
+
+			rvtlm := make(search.TermLocationMap, 0)
+
 		OUTER:
 			for _, location := range locations {
 				crvtlm := make(search.TermLocationMap, 0)

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -110,8 +110,9 @@ func (s *PhraseSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch,
 		OUTER:
 			for _, location := range locations {
 				crvtlm := make(search.TermLocationMap, 0)
+				crvtlm.AddLocation(firstTerm, location)
 			INNER:
-				for i := 0; i < len(s.terms); i++ {
+				for i := 1; i < len(s.terms); i++ {
 					nextTerm := s.terms[i]
 					if nextTerm == "" {
 						continue


### PR DESCRIPTION
In the first patch we use early continues to reduce the level of nesting. The following two patches fix some minor issues in the code and in the last patch we add checking of the DocumentMatch.Location values to the phrase searcher test.

If you prefer to have some of the patches squashed, just let me know.
