### PR TITLE
IndexBatcher: wrapper to automatically batch modifications

### DIFF
--- a/index_batcher.go
+++ b/index_batcher.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// NOTE XXX As this approach uses carefully orchestrated interactions
+// between a mutex, channels, and reference swapping, be sure to carefully
+// consider the impact of reordering statements or making changes to the
+// patterns present in the code.
+
 // bleveIndex is an alias that allows the IndexBatcher to embed a Index
 type bleveIndex Index
 
@@ -28,7 +33,7 @@ type IndexBatcher struct {
 	signal chan bool
 }
 
-// rslt is used as a silly double pointer for errors
+// rslt is used as a kind of double pointer for errors
 type rslt struct {
 	err error
 }

--- a/index_batcher.go
+++ b/index_batcher.go
@@ -1,0 +1,159 @@
+package bleve
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// bleveIndex is an alias that allows the IndexBatcher to embed a Index
+type bleveIndex Index
+
+// IndexBatcher can be wrapped around a Index to aggregate operations
+// in a concurrent / parallel context for increased throughput.
+type IndexBatcher struct {
+	bleveIndex
+
+	period time.Duration
+	closer chan bool
+
+	// lock is used to protect applying / resetting the batch, updating /
+	// replacing the result, and signalling / replacing the signal channel from
+	// the batch loop.  Elsewhere it is used for getting a reference to the
+	// current result, getting a reference to the current signal channel,
+	// and adding operations to the batch.
+	lock   sync.Mutex
+	batch  *Batch
+	result *rslt
+	signal chan bool
+}
+
+// rslt is used as a silly double pointer for errors
+type rslt struct {
+	err error
+}
+
+// NewIndexBatcher returns an index that will aggregate and fire modifying
+// requests as a batch every period time. All other Index methods are
+// passed straight through to the underlying index. Period time should be
+// tuned to the underlying KVStore, the concurrent load, latency requirements,
+// and the documents / document mappings being used. Single digit (7~8)
+// milliseconds is a reasonable place to start.
+func NewIndexBatcher(index Index, period time.Duration) Index {
+	ib := &IndexBatcher{
+		bleveIndex: index,
+
+		batch:  index.NewBatch(),
+		period: period,
+		closer: make(chan bool),
+		signal: make(chan bool),
+		result: &rslt{},
+	}
+
+	go ib.batchloop()
+	return ib
+}
+
+// batchloop processes batches every period and implements a clean close
+// operation
+func (ib *IndexBatcher) batchloop() {
+	t := time.NewTicker(ib.period)
+
+BatchLoop:
+	for {
+		select {
+		case <-t.C:
+			ib.lock.Lock()
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						ib.result.err = fmt.Errorf("IndexBatcher caught a panic: %v", r)
+					}
+				}()
+				ib.result.err = ib.Batch(ib.batch)
+			}()
+			ib.batch.Reset()
+			ib.result = &rslt{}
+			close(ib.signal)
+			ib.signal = make(chan bool)
+			ib.lock.Unlock()
+		case <-ib.closer:
+			break BatchLoop
+		}
+	}
+
+	t.Stop()
+	ib.result.err = fmt.Errorf("IndexBatcher has been closed")
+	close(ib.signal)
+}
+
+// Close stops the batcher returning an error to currently waiting operations
+// and closes the underlying Index
+func (ib *IndexBatcher) Close() error {
+	ib.closer <- true
+	return ib.bleveIndex.Close()
+}
+
+// Index the object with the specified identifier. May hold the operation for up
+// to ib.period time before executing in a batch.
+func (ib *IndexBatcher) Index(id string, data interface{}) error {
+	var result *rslt
+	var signal chan bool
+	ib.lock.Lock()
+	result = ib.result
+	signal = ib.signal
+	err := ib.batch.Index(id, data)
+	ib.lock.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	<-signal
+	return result.err
+}
+
+// Delete entries for the specified identifier from the index. May hold the
+// operation for up to ib.period time before executing in a batch.
+func (ib *IndexBatcher) Delete(id string) error {
+	var result *rslt
+	var signal chan bool
+	ib.lock.Lock()
+	result = ib.result
+	signal = ib.signal
+	ib.batch.Delete(id)
+	ib.lock.Unlock()
+
+	<-signal
+	return result.err
+}
+
+// SetInternal mappings directly in the kvstore. May hold the
+// operation for up to ib.period time before executing in a batch.
+func (ib *IndexBatcher) SetInternal(key, val []byte) error {
+	var result *rslt
+	var signal chan bool
+	ib.lock.Lock()
+	result = ib.result
+	signal = ib.signal
+	ib.batch.SetInternal(key, val)
+	ib.lock.Unlock()
+
+	<-signal
+	return result.err
+}
+
+// DeleteInternal mappings directly from the kvstore. May hold the
+// operation for up to ib.period time before executing in a batch.
+func (ib *IndexBatcher) DeleteInternal(key []byte) error {
+	var result *rslt
+	var signal chan bool
+	ib.lock.Lock()
+	result = ib.result
+	signal = ib.signal
+	ib.batch.DeleteInternal(key)
+	ib.lock.Unlock()
+
+	<-signal
+	return result.err
+}

--- a/index_batcher.go
+++ b/index_batcher.go
@@ -32,8 +32,8 @@ import (
 // routine for the batching, and doesn't require tracking the number of
 // operations waiting on a response or looping to notify each waiting operation.
 
-// bleveIndex is an alias for Index used by the IndexBatcher to avoid a between
-// the embedded Index field and the overrideen Index method
+// bleveIndex is an alias for Index used by the IndexBatcher to avoid a conflict
+// between the embedded Index field and the overridden Index method
 type bleveIndex Index
 
 // IndexBatcher can be wrapped around a Index to aggregate operations

--- a/index_batcher.go
+++ b/index_batcher.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// NOTE XXX As this approach uses carefully orchestrated interactions
+// NOTE As this approach uses carefully orchestrated interactions
 // between a mutex, channels, and reference swapping, be sure to carefully
 // consider the impact of reordering statements or making changes to the
 // patterns present in the code. Specifically, individual operations follow the

--- a/index_batcher_test.go
+++ b/index_batcher_test.go
@@ -1,0 +1,252 @@
+package bleve
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIndexBatcherConcurrentCrud(t *testing.T) {
+	defer func() {
+		err := os.RemoveAll("testidx")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	index, err := New("testidx", NewIndexMapping())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	index = NewIndexBatcher(index, 2*time.Millisecond)
+
+	{
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			doca := map[string]interface{}{
+				"name": "marty",
+				"desc": "gophercon india",
+			}
+			err = index.Index("a", doca)
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			docy := map[string]interface{}{
+				"name": "jasper",
+				"desc": "clojure",
+			}
+			err = index.Index("y", docy)
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			docy := map[string]interface{}{
+				"name": "jasper2",
+				"desc": "clojure2",
+			}
+			err = index.Index("y2", docy)
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.SetInternal([]byte("status2"), []byte("pending"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			docx := map[string]interface{}{
+				"name": "rose",
+				"desc": "googler",
+			}
+			err = index.Index("x", docx)
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.SetInternal([]byte("status"), []byte("pending"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+
+	val, err := index.GetInternal([]byte("status2"))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(val) != "pending" {
+		t.Errorf("expected pending, got '%s'", val)
+	}
+
+	{
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			err = index.Delete("y")
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.Delete("y2")
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.DeleteInternal([]byte("status2"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.SetInternal([]byte("status"), []byte("ready"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+
+	val, err = index.GetInternal([]byte("status2"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got '%s'", val)
+	}
+
+	docb := map[string]interface{}{
+		"name": "steve",
+		"desc": "cbft master",
+	}
+	batch := index.NewBatch()
+	err = batch.Index("b", docb)
+	if err != nil {
+		t.Error(err)
+	}
+	batch.Delete("x")
+	batch.SetInternal([]byte("batchi"), []byte("batchv"))
+	batch.DeleteInternal([]byte("status"))
+	err = index.Batch(batch)
+	if err != nil {
+		t.Error(err)
+	}
+	val, err = index.GetInternal([]byte("batchi"))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(val) != "batchv" {
+		t.Errorf("expected 'batchv', got '%s'", val)
+	}
+	val, err = index.GetInternal([]byte("status"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got '%s'", val)
+	}
+
+	{
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			err = index.SetInternal([]byte("seqno"), []byte("7"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			err = index.DeleteInternal([]byte("status"))
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+	val, err = index.GetInternal([]byte("status"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got '%s'", val)
+	}
+
+	val, err = index.GetInternal([]byte("seqno"))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(val) != "7" {
+		t.Errorf("expected '7', got '%s'", val)
+	}
+
+	count, err := index.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("expected doc count 2, got %d", count)
+	}
+
+	doc, err := index.Document("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc == nil {
+		t.Errorf("expected doc not nil, got nil")
+	}
+
+	doc, err = index.Document("y2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc != nil {
+		t.Errorf("expected doc nil, got not nil")
+	}
+}


### PR DESCRIPTION
IndexBatcher aggregates modifications (Index(), Delete(), SetInternal(), DeleteInternal()) that occur within close proximity into a batch execution for increased throughput at the cost of an amortized period / 2 latency increase.  It is a fairly transparent wrapper around the Index interface that is itself an Index.  The period is adjustable.  When experimenting with Cassandra as a backend, I ran into throughput bottlenecks as a result of the number of keys being inserted at the KVStore layer.  Guiding individual insertions into batches via this layer nearly doubled throughput.
