### PR TITLE
add support for parsing BoolFieldQuery from JSON

### DIFF
--- a/search/query/query.go
+++ b/search/query/query.go
@@ -226,6 +226,15 @@ func ParseQuery(input []byte) (Query, error) {
 		}
 		return &rv, nil
 	}
+	_, hasBool := tmp["bool"]
+	if hasBool {
+		var rv BoolFieldQuery
+		err := json.Unmarshal(input, &rv)
+		if err != nil {
+			return nil, err
+		}
+		return &rv, nil
+	}
 	return nil, fmt.Errorf("unknown query type")
 }
 

--- a/search/query/query_test.go
+++ b/search/query/query_test.go
@@ -171,6 +171,10 @@ func TestParseQuery(t *testing.T) {
 			output: NewDocIDQuery([]string{"a", "b", "c"}),
 		},
 		{
+			input:  []byte(`{"bool": true}`),
+			output: NewBoolFieldQuery(true),
+		},
+		{
 			input:  []byte(`{"madeitup":"queryhere"}`),
 			output: nil,
 			err:    true,


### PR DESCRIPTION
presence of the "bool" key triggers parsing as a BoolFieldQuery
fixes #498