### PR TITLE
some optimizations that have API impact

### DIFF
--- a/search/collector/topn_test.go
+++ b/search/collector/topn_test.go
@@ -480,6 +480,18 @@ func BenchmarkTop100of10000Scores(b *testing.B) {
 	}, b)
 }
 
+func BenchmarkTop1000of10000Scores(b *testing.B) {
+	benchHelper(10000, func() search.Collector {
+		return NewTopNCollector(1000, 0, search.SortOrder{&search.SortScore{Desc: true}})
+	}, b)
+}
+
+func BenchmarkTop10000of100000Scores(b *testing.B) {
+	benchHelper(100000, func() search.Collector {
+		return NewTopNCollector(10000, 0, search.SortOrder{&search.SortScore{Desc: true}})
+	}, b)
+}
+
 func BenchmarkTop10of100000Scores(b *testing.B) {
 	benchHelper(100000, func() search.Collector {
 		return NewTopNCollector(10, 0, search.SortOrder{&search.SortScore{Desc: true}})
@@ -489,5 +501,17 @@ func BenchmarkTop10of100000Scores(b *testing.B) {
 func BenchmarkTop100of100000Scores(b *testing.B) {
 	benchHelper(100000, func() search.Collector {
 		return NewTopNCollector(100, 0, search.SortOrder{&search.SortScore{Desc: true}})
+	}, b)
+}
+
+func BenchmarkTop1000of100000Scores(b *testing.B) {
+	benchHelper(100000, func() search.Collector {
+		return NewTopNCollector(1000, 0, search.SortOrder{&search.SortScore{Desc: true}})
+	}, b)
+}
+
+func BenchmarkTop10000of1000000Scores(b *testing.B) {
+	benchHelper(1000000, func() search.Collector {
+		return NewTopNCollector(10000, 0, search.SortOrder{&search.SortScore{Desc: true}})
 	}, b)
 }


### PR DESCRIPTION
These two optimizations have some API impacts...

- one adds more API's to allow advanced apps to prevent more garbage creation by reusing DocumentMatchPool's.

- the other subtly changes creation of SearchResults by possibly returning nil Errors and nil Facets instead of empty map instances.  (An alternative might be to return references to preallocated, global, empty map singletons, but that's also a subtle change in behavior, so I figured nil's might be cleaner and avoid issues of folks inadvertently stuffing entries into supposedly "empty" maps.)

Running a modified bleve-query that uses the above two commits and the new DocumentMatchPool context API's (by adding a sync.Pool to bleve-query)... on a 50K wiki docs index, low frequency term query ("shoch", which returns 5 hits), queries per second goes from 180K qps to 220K qps.

The local modifications I made to bleve-query code are here: https://github.com/steveyen/bleve-bench/commit/ec0a271f97da3de37fba12100ece618066d09835