### PR TITLE
Store abort close

### DIFF
--- a/index/store/moss/store.go
+++ b/index/store/moss/store.go
@@ -176,8 +176,7 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 
 func (s *Store) Close() error {
 	if v, ok := s.config["mossAbortCloseEnabled"]; ok && v.(bool) == true {
-		msw, ok := s.llstore.(*mossStoreWrapper)
-		if ok {
+		if msw, ok := s.llstore.(*mossStoreWrapper); ok {
 			if s := msw.Actual(); s != nil {
 				s.CloseEx(moss.StoreCloseExOptions{Abort: true})
 			}

--- a/index/store/moss/store.go
+++ b/index/store/moss/store.go
@@ -175,14 +175,15 @@ func New(mo store.MergeOperator, config map[string]interface{}) (
 }
 
 func (s *Store) Close() error {
-	if v, ok := s.config["mossAbortCloseEnabled"]; ok && v.(bool) == true {
-		if msw, ok := s.llstore.(*mossStoreWrapper); ok {
-			if s := msw.Actual(); s != nil {
-				_ = s.CloseEx(moss.StoreCloseExOptions{Abort: true})
+	if val, ok := s.config["mossAbortCloseEnabled"]; ok {
+		if v, ok := val.(bool); ok && v {
+			if msw, ok := s.llstore.(*mossStoreWrapper); ok {
+				if s := msw.Actual(); s != nil {
+					_ = s.CloseEx(moss.StoreCloseExOptions{Abort: true})
+				}
 			}
 		}
 	}
-
 	return s.ms.Close()
 }
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -29,7 +29,7 @@
 			"importpath": "github.com/couchbase/moss",
 			"repository": "https://github.com/couchbase/moss",
 			"vcs": "git",
-			"revision": "564b451e917875e4c580cd4a14a6bbb44a1faf7e",
+			"revision": "fc637b3f82ec5b8139b0d295f6588c6a2bea5a16",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
@mschoch , @steveyen , Attempt to make configurable CloseEx/Abort for mossStore.
[The store level close would happen twice due to the following collection close which is there in the original code. But by adding an extra check at the Store level close, we may avoid code level regressions(nil dereferencing) on it, but not sure whether thats  a hack or a proper way to do it]
Reference: http://review.couchbase.org/#/c/74385/
