### PR TITLE
switch collector store impl from slice to heap

### DIFF
--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -41,7 +41,7 @@ type TopNCollector struct {
 	results       search.DocumentMatchCollection
 	facetsBuilder *search.FacetsBuilder
 
-	store *collectStoreSlice
+	store *collectStoreHeap
 
 	needDocIds    bool
 	neededFields  []string
@@ -68,7 +68,7 @@ func NewTopNCollector(size int, skip int, sort search.SortOrder) *TopNCollector 
 		backingSize = PreAllocSizeSkipCap + 1
 	}
 
-	hc.store = newStoreSlice(backingSize, func(i, j *search.DocumentMatch) int {
+	hc.store = newStoreHeap(backingSize, func(i, j *search.DocumentMatch) int {
 		return hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, i, j)
 	})
 


### PR DESCRIPTION
Additional testing has shown that the heap collector performs
significantly better when larger numbers of hits are requested.

The heap is also faster (though very close) when fewer (10) hits
are requested.

Here are the numbers from my laptop:

slice:

```
go test -run=xxx -bench=. -benchmem
BenchmarkTop10of10000Scores-4        	    5000	    396943 ns/op	    2472 B/op	      26 allocs/op
BenchmarkTop100of10000Scores-4       	    2000	    630894 ns/op	   18848 B/op	     116 allocs/op
BenchmarkTop1000of10000Scores-4      	     100	  14996445 ns/op	  176552 B/op	    1016 allocs/op
BenchmarkTop10000of100000Scores-4    	       1	1878796320 ns/op	 1857768 B/op	   19023 allocs/op
BenchmarkTop10of100000Scores-4       	     500	   3858309 ns/op	    2480 B/op	      26 allocs/op
BenchmarkTop100of100000Scores-4      	     300	   4270086 ns/op	   19000 B/op	     116 allocs/op
BenchmarkTop1000of100000Scores-4     	      50	  30163705 ns/op	  178024 B/op	    1016 allocs/op
BenchmarkTop10000of1000000Scores-4   	       1	3429557237 ns/op	 1882008 B/op	   19023 allocs/op
PASS
ok  	github.com/blevesearch/bleve/search/collector	16.316s
```

heap:

```
go test -run=xxx -bench=. -benchmem
BenchmarkTop10of10000Scores-4        	    5000	    341064 ns/op	    2552 B/op	      27 allocs/op
BenchmarkTop100of10000Scores-4       	    3000	    501922 ns/op	   19744 B/op	     117 allocs/op
BenchmarkTop1000of10000Scores-4      	    1000	   1759088 ns/op	  184744 B/op	    1017 allocs/op
BenchmarkTop10000of100000Scores-4    	      50	  25954696 ns/op	 1939608 B/op	   19024 allocs/op
BenchmarkTop10of100000Scores-4       	     500	   3814933 ns/op	    2560 B/op	      27 allocs/op
BenchmarkTop100of100000Scores-4      	     300	   4009369 ns/op	   19896 B/op	     117 allocs/op
BenchmarkTop1000of100000Scores-4     	     200	   6397276 ns/op	  186184 B/op	    1017 allocs/op
BenchmarkTop10000of1000000Scores-4   	      20	  81815315 ns/op	 1963912 B/op	   19024 allocs/op
PASS
ok  	github.com/blevesearch/bleve/search/collector	14.980s
```