### PR TITLE
optimmize heap collector Final() for large counts

### DIFF
--- a/search/collector/heap.go
+++ b/search/collector/heap.go
@@ -49,17 +49,12 @@ func (c *collectStoreHeap) Final(skip int, fixup collectorFixup) (search.Documen
 		return make(search.DocumentMatchCollection, 0), nil
 	}
 	rv := make(search.DocumentMatchCollection, size)
-	for count > 0 {
-		count--
-
-		if count >= skip {
-			size--
-			doc := heap.Pop(c).(*search.DocumentMatch)
-			rv[size] = doc
-			err := fixup(doc)
-			if err != nil {
-				return nil, err
-			}
+	for i := size - 1; i >= 0; i-- {
+		doc := heap.Pop(c).(*search.DocumentMatch)
+		rv[i] = doc
+		err := fixup(doc)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return rv, nil


### PR DESCRIPTION
The previous heap Final() loop would decrement count all the way to 0
when it only has to fill enough of the return slice.