### PR TITLE
refactor searchers

### DIFF
--- a/search/scorer/scorer_term.go
+++ b/search/scorer/scorer_term.go
@@ -23,7 +23,7 @@ import (
 )
 
 type TermQueryScorer struct {
-	queryTerm              string
+	queryTerm              []byte
 	queryField             string
 	queryBoost             float64
 	docTerm                uint64
@@ -36,7 +36,7 @@ type TermQueryScorer struct {
 	queryWeightExplanation *search.Explanation
 }
 
-func NewTermQueryScorer(queryTerm string, queryField string, queryBoost float64, docTotal, docTerm uint64, options search.SearcherOptions) *TermQueryScorer {
+func NewTermQueryScorer(queryTerm []byte, queryField string, queryBoost float64, docTotal, docTerm uint64, options search.SearcherOptions) *TermQueryScorer {
 	rv := TermQueryScorer{
 		queryTerm:   queryTerm,
 		queryField:  queryField,
@@ -174,7 +174,7 @@ func (s *TermQueryScorer) Score(ctx *search.SearchContext, termMatch *index.Term
 				positionsUsed += len(v.ArrayPositions)
 			}
 
-			tlm[s.queryTerm] = append(tlm[s.queryTerm], loc)
+			tlm[string(s.queryTerm)] = append(tlm[string(s.queryTerm)], loc)
 		}
 	}
 

--- a/search/scorer/scorer_term_test.go
+++ b/search/scorer/scorer_term_test.go
@@ -27,7 +27,7 @@ func TestTermScorer(t *testing.T) {
 
 	var docTotal uint64 = 100
 	var docTerm uint64 = 9
-	var queryTerm = "beer"
+	var queryTerm = []byte("beer")
 	var queryField = "desc"
 	var queryBoost = 1.0
 	scorer := NewTermQueryScorer(queryTerm, queryField, queryBoost, docTotal, docTerm, search.SearcherOptions{Explain: true})
@@ -168,7 +168,7 @@ func TestTermScorerWithQueryNorm(t *testing.T) {
 
 	var docTotal uint64 = 100
 	var docTerm uint64 = 9
-	var queryTerm = "beer"
+	var queryTerm = []byte("beer")
 	var queryField = "desc"
 	var queryBoost = 3.0
 	scorer := NewTermQueryScorer(queryTerm, queryField, queryBoost, docTotal, docTerm, search.SearcherOptions{Explain: true})

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -19,17 +19,9 @@ import (
 	"github.com/blevesearch/bleve/search"
 )
 
-type FuzzySearcher struct {
-	indexReader index.IndexReader
-	term        string
-	prefix      int
-	fuzziness   int
-	field       string
-	options     search.SearcherOptions
-	searcher    *DisjunctionSearcher
-}
-
-func NewFuzzySearcher(indexReader index.IndexReader, term string, prefix, fuzziness int, field string, boost float64, options search.SearcherOptions) (*FuzzySearcher, error) {
+func NewFuzzySearcher(indexReader index.IndexReader, term string,
+	prefix, fuzziness int, field string, boost float64,
+	options search.SearcherOptions) (search.Searcher, error) {
 	// Note: we don't byte slice the term for a prefix because of runes.
 	prefixTerm := ""
 	for i, r := range term {
@@ -40,46 +32,18 @@ func NewFuzzySearcher(indexReader index.IndexReader, term string, prefix, fuzzin
 		}
 	}
 
-	candidateTerms, err := findFuzzyCandidateTerms(indexReader, term, fuzziness, field, prefixTerm)
+	candidateTerms, err := findFuzzyCandidateTerms(indexReader, term, fuzziness,
+		field, prefixTerm)
 	if err != nil {
 		return nil, err
 	}
 
-	// enumerate all the terms in the range
-	qsearchers := make([]search.Searcher, 0, len(candidateTerms))
-	qsearchersClose := func() {
-		for _, searcher := range qsearchers {
-			_ = searcher.Close()
-		}
-	}
-	for _, cterm := range candidateTerms {
-		qsearcher, err := NewTermSearcher(indexReader, cterm, field, boost, options)
-		if err != nil {
-			qsearchersClose()
-			return nil, err
-		}
-		qsearchers = append(qsearchers, qsearcher)
-	}
-
-	// build disjunction searcher of these ranges
-	searcher, err := NewDisjunctionSearcher(indexReader, qsearchers, 0, options)
-	if err != nil {
-		qsearchersClose()
-		return nil, err
-	}
-
-	return &FuzzySearcher{
-		indexReader: indexReader,
-		term:        term,
-		prefix:      prefix,
-		fuzziness:   fuzziness,
-		field:       field,
-		options:     options,
-		searcher:    searcher,
-	}, nil
+	return NewMultiTermSearcher(indexReader, candidateTerms, field,
+		boost, options)
 }
 
-func findFuzzyCandidateTerms(indexReader index.IndexReader, term string, fuzziness int, field, prefixTerm string) (rv []string, err error) {
+func findFuzzyCandidateTerms(indexReader index.IndexReader, term string,
+	fuzziness int, field, prefixTerm string) (rv []string, err error) {
 	rv = make([]string, 0)
 	var fieldDict index.FieldDict
 	if len(prefixTerm) > 0 {
@@ -107,37 +71,4 @@ func findFuzzyCandidateTerms(indexReader index.IndexReader, term string, fuzzine
 	}
 
 	return rv, err
-}
-
-func (s *FuzzySearcher) Count() uint64 {
-	return s.searcher.Count()
-}
-
-func (s *FuzzySearcher) Weight() float64 {
-	return s.searcher.Weight()
-}
-
-func (s *FuzzySearcher) SetQueryNorm(qnorm float64) {
-	s.searcher.SetQueryNorm(qnorm)
-}
-
-func (s *FuzzySearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
-	return s.searcher.Next(ctx)
-
-}
-
-func (s *FuzzySearcher) Advance(ctx *search.SearchContext, ID index.IndexInternalID) (*search.DocumentMatch, error) {
-	return s.searcher.Advance(ctx, ID)
-}
-
-func (s *FuzzySearcher) Close() error {
-	return s.searcher.Close()
-}
-
-func (s *FuzzySearcher) Min() int {
-	return 0
-}
-
-func (s *FuzzySearcher) DocumentMatchPoolSize() int {
-	return s.searcher.DocumentMatchPoolSize()
 }

--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -1,0 +1,78 @@
+//  Copyright (c) 2017 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/search"
+)
+
+func NewMultiTermSearcher(indexReader index.IndexReader, terms []string,
+	field string, boost float64, options search.SearcherOptions) (
+	search.Searcher, error) {
+	qsearchers := make([]search.Searcher, len(terms))
+	qsearchersClose := func() {
+		for _, searcher := range qsearchers {
+			if searcher != nil {
+				_ = searcher.Close()
+			}
+		}
+	}
+	for i, term := range terms {
+		var err error
+		qsearchers[i], err = NewTermSearcher(indexReader, term, field, boost, options)
+		if err != nil {
+			qsearchersClose()
+			return nil, err
+		}
+	}
+	// build disjunction searcher of these ranges
+	searcher, err := NewDisjunctionSearcher(indexReader, qsearchers, 0, options)
+	if err != nil {
+		qsearchersClose()
+		return nil, err
+	}
+
+	return searcher, nil
+}
+
+func NewMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byte,
+	field string, boost float64, options search.SearcherOptions) (
+	search.Searcher, error) {
+	qsearchers := make([]search.Searcher, len(terms))
+	qsearchersClose := func() {
+		for _, searcher := range qsearchers {
+			if searcher != nil {
+				_ = searcher.Close()
+			}
+		}
+	}
+	for i, term := range terms {
+		var err error
+		qsearchers[i], err = NewTermSearcherBytes(indexReader, term, field, boost, options)
+		if err != nil {
+			qsearchersClose()
+			return nil, err
+		}
+	}
+	// build disjunction searcher of these ranges
+	searcher, err := NewDisjunctionSearcher(indexReader, qsearchers, 0, options)
+	if err != nil {
+		qsearchersClose()
+		return nil, err
+	}
+
+	return searcher, nil
+}

--- a/search/searcher/search_term_prefix.go
+++ b/search/searcher/search_term_prefix.go
@@ -19,93 +19,21 @@ import (
 	"github.com/blevesearch/bleve/search"
 )
 
-type TermPrefixSearcher struct {
-	indexReader index.IndexReader
-	prefix      string
-	field       string
-	options     search.SearcherOptions
-	searcher    *DisjunctionSearcher
-}
-
-func NewTermPrefixSearcher(indexReader index.IndexReader, prefix string, field string, boost float64, options search.SearcherOptions) (*TermPrefixSearcher, error) {
+func NewTermPrefixSearcher(indexReader index.IndexReader, prefix string,
+	field string, boost float64, options search.SearcherOptions) (
+	search.Searcher, error) {
 	// find the terms with this prefix
 	fieldDict, err := indexReader.FieldDictPrefix(field, []byte(prefix))
 	if err != nil {
 		return nil, err
 	}
 
-	// enumerate all the terms in the range
-	qsearchers := make([]search.Searcher, 0, 25)
-	qsearchersClose := func() {
-		for _, searcher := range qsearchers {
-			_ = searcher.Close()
-		}
-	}
-
+	var terms []string
 	tfd, err := fieldDict.Next()
 	for err == nil && tfd != nil {
-		var qsearcher *TermSearcher
-		qsearcher, err = NewTermSearcher(indexReader, string(tfd.Term), field, 1.0, options)
-		if err != nil {
-			qsearchersClose()
-			_ = fieldDict.Close()
-			return nil, err
-		}
-		qsearchers = append(qsearchers, qsearcher)
+		terms = append(terms, tfd.Term)
 		tfd, err = fieldDict.Next()
 	}
 
-	err = fieldDict.Close()
-	if err != nil {
-		qsearchersClose()
-		return nil, err
-	}
-
-	// build disjunction searcher of these ranges
-	searcher, err := NewDisjunctionSearcher(indexReader, qsearchers, 0, options)
-	if err != nil {
-		qsearchersClose()
-		return nil, err
-	}
-
-	return &TermPrefixSearcher{
-		indexReader: indexReader,
-		prefix:      prefix,
-		field:       field,
-		options:     options,
-		searcher:    searcher,
-	}, nil
-}
-
-func (s *TermPrefixSearcher) Count() uint64 {
-	return s.searcher.Count()
-}
-
-func (s *TermPrefixSearcher) Weight() float64 {
-	return s.searcher.Weight()
-}
-
-func (s *TermPrefixSearcher) SetQueryNorm(qnorm float64) {
-	s.searcher.SetQueryNorm(qnorm)
-}
-
-func (s *TermPrefixSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
-	return s.searcher.Next(ctx)
-
-}
-
-func (s *TermPrefixSearcher) Advance(ctx *search.SearchContext, ID index.IndexInternalID) (*search.DocumentMatch, error) {
-	return s.searcher.Advance(ctx, ID)
-}
-
-func (s *TermPrefixSearcher) Close() error {
-	return s.searcher.Close()
-}
-
-func (s *TermPrefixSearcher) Min() int {
-	return 0
-}
-
-func (s *TermPrefixSearcher) DocumentMatchPoolSize() int {
-	return s.searcher.DocumentMatchPoolSize()
+	return NewMultiTermSearcher(indexReader, terms, field, boost, options)
 }


### PR DESCRIPTION
- TermSearcher has alternate constructor if term is []byte, this can avoid
  copying in some cases.  TermScorer updated to accept []byte term. Also
  removed a few struct fields which were not being used.

- New MultiTermSearcher searches for documents containing any of a list of
  terms.  Current implementation simply uses DisjunctionSearcher.

- Several other searcher constructors now simply build a list of terms and
  then delegate to the MultiTermSearcher
  - NewPrefixSearcher
  - NewRegexpSearcher
  - NewFuzzySearcher
  - NewNumericRangeSearcher

- NewGeoBoundingBoxSearcher and NewGeoPointDistanceSearcher make use of
  the MultiTermSearcher internally, and follow the pattern of returning
  an existing search.Searcher, as opposed to their own wrapping struct.

- Callback filter functions used in NewGeoBoundingBoxSearcher and
  NewGeoPointDistanceSearcher have been extracted into separate functions
  which makes the code much easier to read.