### PR TITLE
Allow pre parsing query strings

### DIFF
--- a/search/query/query_string.go
+++ b/search/query/query_string.go
@@ -43,6 +43,10 @@ func (q *QueryStringQuery) Boost() float64 {
 	return q.BoostVal.Value()
 }
 
+func (q *QueryStringQuery) Parse() (Query, error) {
+	return parseQuerySyntax(q.Query)
+}
+
 func (q *QueryStringQuery) Searcher(i index.IndexReader, m mapping.IndexMapping, options search.SearcherOptions) (search.Searcher, error) {
 	newQuery, err := parseQuerySyntax(q.Query)
 	if err != nil {


### PR DESCRIPTION
In the case of ```QueryStringQuery```, when reusing queries, each search request re-parses the the queries. It would be nice to be able to pre-parse the queries, at the same time validating them.