### PR TITLE
fix panic in term range search

### DIFF
--- a/search/searcher/search_term_range.go
+++ b/search/searcher/search_term_range.go
@@ -64,6 +64,10 @@ func NewTermRangeSearcher(indexReader index.IndexReader,
 
 	if !*inclusiveMin && min != nil && string(min) == terms[0] {
 		terms = terms[1:]
+		// check again, as we might have removed only entry
+		if len(terms) < 1 {
+			return NewMatchNoneSearcher(indexReader)
+		}
 	}
 
 	// if our term list included the max, it would be the last item

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -157,6 +157,15 @@ func TestTermRangeSearch(t *testing.T) {
 			inclusiveMax: true,
 			want:         nil,
 		},
+		// min and max same (and term exists), both exlusive
+		{
+			min:          []byte("marty"),
+			max:          []byte("marty"),
+			field:        "name",
+			inclusiveMin: false,
+			inclusiveMax: false,
+			want:         nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
if min and max are the same term
and the term is in dictionary
and both in and max are set to exclusive
then we would panic attempting to access element -1 of a slice.

now, after trimming the slice, we recheck that the length is > 0