### PR TITLE
add support for mapping to recognize/use TextMarshaler interface

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -15,6 +15,7 @@
 package mapping
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -481,6 +482,17 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 				fieldMapping := newDateTimeFieldMappingDynamic(context.im)
 				fieldMapping.processTime(property, pathString, path, indexes, context)
 			}
+		case encoding.TextMarshaler:
+			txt, err := property.MarshalText()
+			if err == nil && subDocMapping != nil {
+				// index by explicit mapping
+				for _, fieldMapping := range subDocMapping.Fields {
+					if fieldMapping.Type == "text" {
+						fieldMapping.processString(string(txt), pathString, path, indexes, context)
+					}
+				}
+			}
+			dm.walkDocument(property, path, indexes, context)
 		default:
 			if subDocMapping != nil {
 				for _, fieldMapping := range subDocMapping.Fields {
@@ -500,6 +512,23 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 			}
 		}
 		dm.walkDocument(property, path, indexes, context)
+	case reflect.Ptr:
+		switch property := property.(type) {
+		case encoding.TextMarshaler:
+			txt, err := property.MarshalText()
+			if err == nil && subDocMapping != nil {
+				// index by explicit mapping
+				for _, fieldMapping := range subDocMapping.Fields {
+					if fieldMapping.Type == "text" {
+						fieldMapping.processString(string(txt), pathString, path, indexes, context)
+					}
+				}
+			} else {
+				dm.walkDocument(property, path, indexes, context)
+			}
+		default:
+			dm.walkDocument(property, path, indexes, context)
+		}
 	default:
 		dm.walkDocument(property, path, indexes, context)
 	}


### PR DESCRIPTION
Sometimes you have structs which contain data which isn't
exported, or for which the correct data to index isn't just the
contents of it's exported fields.  In these cases your struct
can implement TextMarshaler to return a suitable text
representation.

Previously bleve did not recognize this interface and do anything
to use it.  Now, if the field containing such a struct is
explicitly mapped as "text" and if the struct (or pointer to it)
implements TextMarshaler, we index a text field with the
contents returned by MarshalText().

For backwards compatibilty, dynamic mappings will never use
this feature, and will continue to traverse into the struct
and index the exported fields directly.

fixes #281