### PR TITLE
add support for BleveType() alternative for type detection

### DIFF
--- a/index.go
+++ b/index.go
@@ -110,12 +110,15 @@ func (b *Batch) Reset() {
 // them.
 //
 // The DocumentMapping used to index a value is deduced by the following rules:
-// 1) If value implements Classifier interface, resolve the mapping from Type().
-// 2) If value has a string field or value at IndexMapping.TypeField.
+// 1) If value implements mapping.bleveClassifier interface, resolve the mapping
+//    from BleveType().
+// 2) If value implements mapping.Classifier interface, resolve the mapping
+//    from Type().
+// 3) If value has a string field or value at IndexMapping.TypeField.
 // (defaulting to "_type"), use it to resolve the mapping. Fields addressing
 // is described below.
-// 3) If IndexMapping.DefaultType is registered, return it.
-// 4) Return IndexMapping.DefaultMapping.
+// 4) If IndexMapping.DefaultType is registered, return it.
+// 5) Return IndexMapping.DefaultMapping.
 //
 // Each field or nested field of the value is identified by a string path, then
 // mapped to one or several FieldMappings which extract the result for analysis.

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -289,7 +289,12 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 }
 
 func (im *IndexMappingImpl) determineType(data interface{}) string {
-	// first see if the object implements Classifier
+	// first see if the object implements bleveClassifier
+	bleveClassifier, ok := data.(bleveClassifier)
+	if ok {
+		return bleveClassifier.BleveType()
+	}
+	// next see if the object implements Classifier
 	classifier, ok := data.(Classifier)
 	if ok {
 		return classifier.Type()

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -22,10 +22,19 @@ import (
 	"github.com/blevesearch/bleve/document"
 )
 
-// A Classifier is an interface describing any object
-// which knows how to identify its own type.
+// A Classifier is an interface describing any object which knows how to
+// identify its own type.  Alternatively, if a struct already has a Type
+// field or method in conflict, one can use BleveType instead.
 type Classifier interface {
 	Type() string
+}
+
+// A bleveClassifier is an interface describing any object which knows how
+// to identify its own type.  This is introduced as an alternative to the
+// Classifier interface which often has naming conflicts with existing
+// structures.
+type bleveClassifier interface {
+	BleveType() string
 }
 
 var logger = log.New(ioutil.Discard, "bleve mapping ", log.LstdFlags)


### PR DESCRIPTION
Many existing structs already have a Type field or method which
conflicts with the bleve Classifier interface.  To address this
without breaking existing applications, we introduce an
alternate BleveType() method which will be checked first.  The
interface describing this method is private, as it should never
need to be referenced outside this package.

fixes #283