### PR TITLE
fix nil ptr panic on newly introduced text marshaler support

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -513,21 +513,25 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		}
 		dm.walkDocument(property, path, indexes, context)
 	case reflect.Ptr:
-		switch property := property.(type) {
-		case encoding.TextMarshaler:
-			txt, err := property.MarshalText()
-			if err == nil && subDocMapping != nil {
-				// index by explicit mapping
-				for _, fieldMapping := range subDocMapping.Fields {
-					if fieldMapping.Type == "text" {
-						fieldMapping.processString(string(txt), pathString, path, indexes, context)
+		if !propertyValue.IsNil() {
+			switch property := property.(type) {
+			case encoding.TextMarshaler:
+
+				txt, err := property.MarshalText()
+				if err == nil && subDocMapping != nil {
+					// index by explicit mapping
+					for _, fieldMapping := range subDocMapping.Fields {
+						if fieldMapping.Type == "text" {
+							fieldMapping.processString(string(txt), pathString, path, indexes, context)
+						}
 					}
+				} else {
+					dm.walkDocument(property, path, indexes, context)
 				}
-			} else {
+
+			default:
 				dm.walkDocument(property, path, indexes, context)
 			}
-		default:
-			dm.walkDocument(property, path, indexes, context)
 		}
 	default:
 		dm.walkDocument(property, path, indexes, context)

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/blevesearch/bleve/analysis/tokenizer/exception"
 	"github.com/blevesearch/bleve/analysis/tokenizer/regexp"
@@ -963,6 +964,30 @@ func TestMappingForTextMarshaler(t *testing.T) {
 	}
 	if string(doc.Fields[0].Value()) != string(want) {
 		t.Errorf("expected field value to be  '%s', got: '%s'", string(want), string(doc.Fields[0].Value()))
+	}
+
+}
+
+func TestMappingForNilTextMarshaler(t *testing.T) {
+	tm := struct {
+		Marshalable *time.Time
+	}{
+		Marshalable: nil,
+	}
+
+	// now verify that when a mapping explicity
+	m := NewIndexMapping()
+	txt := NewTextFieldMapping()
+	m.DefaultMapping.AddFieldMappingsAt("Marshalable", txt)
+	doc := document.NewDocument("x")
+	err := m.MapDocument(doc, tm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(doc.Fields) != 0 {
+		t.Fatalf("expected 1 field, got: %d", len(doc.Fields))
+
 	}
 
 }


### PR DESCRIPTION
We recenlty introduced support for indexing the content of
things implementing TextMarshaler.  Since often times interfaces
are implemented via pointer receivers, we added support to
introspect pointers (previously we just dereferenceed them and
traversed into their underlying structs).  However, in doing so
we neglected to consider the case where the pointer does
implement the interface we care about, but happens to be nil.

fixes #603