### PR TITLE
fix issue with numeric range queries in query string

### DIFF
--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -57,15 +57,15 @@ func NewNumericRangeSearcher(indexReader index.IndexReader,
 	termRanges := splitInt64Range(minInt64, maxInt64, 4)
 	terms := termRanges.Enumerate()
 	if len(terms) < 1 {
-		return NewMatchNoneSearcher(indexReader)
+		// cannot return MatchNoneSearcher because of interaction with
+		// commit f391b991c20f02681bacd197afc6d8aed444e132
+		return NewMultiTermSearcherBytes(indexReader, terms, field, boost, options,
+			true)
 	}
 	var err error
 	terms, err = filterCandidateTerms(indexReader, terms, field)
 	if err != nil {
 		return nil, err
-	}
-	if len(terms) < 1 {
-		return NewMatchNoneSearcher(indexReader)
 	}
 	if tooManyClauses(len(terms)) {
 		return nil, tooManyClausesErr()


### PR DESCRIPTION
previously the query string queries were modified to aid in
compatibility with other search systems.  this change:
f391b991c20f02681bacd197afc6d8aed444e132
has a problem when combined with:
77101ae424bb385095b8094dc9fd1cd116a3de8c
due to the introduction of MatchNoneSearchers being returned
in a case where previously they never would.

the fix for now is to simply return disjunction queries on 0
terms instead.  this ultimately also matches nothing, but avoids
triggering the logic which handles match none searchers in a
special way.