### PR TITLE
MB-24680: Buffer up to 20 segments by default before compacting

### DIFF
--- a/index/store/moss/lower.go
+++ b/index/store/moss/lower.go
@@ -459,7 +459,9 @@ func InitMossStore(config map[string]interface{}, options moss.CollectionOptions
 	}
 
 	storeOptions := moss.StoreOptions{
-		CollectionOptions: options,
+		CollectionOptions:     options,
+		CompactionPercentage:  100.0,
+		CompactionMaxSegments: 20,
 	}
 	v, ok := config["mossStoreOptions"]
 	if ok {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -29,7 +29,7 @@
 			"importpath": "github.com/couchbase/moss",
 			"repository": "https://github.com/couchbase/moss",
 			"vcs": "git",
-			"revision": "fc637b3f82ec5b8139b0d295f6588c6a2bea5a16",
+			"revision": "e78f8d4d704eb8385778f7c857c720187f9d6f88",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Triggering full compactions on every single small update,
exacerbates the index building stall in moss.
To mitigate this, allow the file to buffer upto 20 segments, by default
before re-writing the file.
Standalone testing shows much lower blocking times without severe
impacts to query latencies.