### PR TITLE
Synchronous writing for moss store

### DIFF
--- a/cmd/bleve/cmd/create.go
+++ b/cmd/bleve/cmd/create.go
@@ -48,7 +48,15 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error building mapping: %v", err)
 		}
-		idx, err = bleve.NewUsing(args[0], mapping, indexType, storeType, nil)
+
+		// If we are using moss, turn on persistSync
+		var kvconfig map[string]interface{}
+		if storeType == "moss" {
+			kvconfig = make(map[string]interface{})
+			kvconfig["mossPersistSync"] = true
+		}
+
+		idx, err = bleve.NewUsing(args[0], mapping, indexType, storeType, kvconfig)
 		if err != nil {
 			return fmt.Errorf("error creating index: %v", err)
 		}

--- a/index/store/moss/lower.go
+++ b/index/store/moss/lower.go
@@ -522,7 +522,9 @@ type mossStoreWrapper struct {
 	s    *moss.Store
 
 	pendingWrites int
-	persistCh     chan struct{}
+
+	enablePersistSync bool
+	persistCh         chan struct{}
 }
 
 func (w *mossStoreWrapper) AddRef() {

--- a/index/store/moss/lower.go
+++ b/index/store/moss/lower.go
@@ -520,6 +520,9 @@ type mossStoreWrapper struct {
 	m    sync.Mutex
 	refs int
 	s    *moss.Store
+
+	pendingWrites int
+	persistCh     chan struct{}
 }
 
 func (w *mossStoreWrapper) AddRef() {


### PR DESCRIPTION
This should fix #529 by allowing synchronous writes for `moss`.

With this PR and the example as provided by @simonz05:

```
$ ./bleve create -s moss moss.data

$ ./bleve index moss.data -j blevesearch/bleve/test/tests/basic/data/a.json
Indexing: a

$ ./bleve query moss.data marty
1 matches, showing 1 through 1, took 199.289µs
    1. a (0.068614)
	name
		marty
```

To enable synchronous writing, set `mossPersistSync` in KVConfig to true. This has been done automatically in the `bleve` command: https://github.com/bt/bleve/blob/0b2d32aff9924b5f32e4711fa0f225bdba950551/cmd/bleve/cmd/create.go#L56