### PR TITLE
open use mapping, reduce memory usage by maping.UnmarshalJSON(special…

### DIFF
--- a/index.go
+++ b/index.go
@@ -245,7 +245,7 @@ func NewUsing(path string, mapping mapping.IndexMapping, indexType string, kvsto
 // Open index at the specified path, must exist.
 // The mapping used when it was created will be used for all Index/Search operations.
 func Open(path string) (Index, error) {
-	return openIndexUsing(path, nil)
+	return openIndexUsing(path, nil, nil)
 }
 
 // OpenUsing opens index at the specified path, must exist.
@@ -253,5 +253,14 @@ func Open(path string) (Index, error) {
 // The provided runtimeConfig can override settings
 // persisted when the kvstore was created.
 func OpenUsing(path string, runtimeConfig map[string]interface{}) (Index, error) {
-	return openIndexUsing(path, runtimeConfig)
+	return openIndexUsing(path, nil, runtimeConfig)
+}
+
+// OpenUsingMapping opens index at the specified path, must exist.
+// The mapping used when it was created will be used for all Index/Search operations.
+// The provided runtimeConfig can override settings
+// persisted when the kvstore was created.
+// The provided mapping will be used for all, when alias use multiple the same index mapping.
+func OpenUsingMapping(path string, mapping mapping.IndexMapping) (Index, error) {
+	return openIndexUsing(path, mapping, nil)
 }


### PR DESCRIPTION
…ly load dict)

`	
        alias := bleve.NewIndexAlias()

	subDirs, err := file.DirsUnder(dir)
	if err != nil {
		return nil, err
	}

	for _, subDir := range subDirs {
		path := filepath.Join(dir, subDir)
		nb, err := bleve.Open(path)
		//nb, err := bleve.OpenUsingMapping(path, im)
		if err != nil {
			return nil, err
		}

		alias.Add(nb)
	}

`

and indexMapping use load dict file, as :

`func zhIndexMapping() mapping.IndexMapping {
	indexMapping := bleve.NewIndexMapping()
	dictDir := "./dict/jieba"
	err := indexMapping.AddCustomTokenizer("gojieba",
		map[string]interface{}{
			"dictpath":     namedPath(dictDir, dictPath),
			"hmmpath":      namedPath(dictDir, hmmPath),
			"userdictpath": namedPath(dictDir, userDictPath),
			"idf":          namedPath(dictDir, idfPath),
			"stop_words":   namedPath(dictDir, stopWordsPath),
			"type":         "gojieba",
		},
	)
	if err != nil {
		logger.Errorf("zhIndexMapping AddCustomTokenizer failed: %v", err)
		return nil
	}
	err = indexMapping.AddCustomAnalyzer("gojieba",
		map[string]interface{}{
			"type":      "gojieba",
			"tokenizer": "gojieba",
		},
	)
	if err != nil {
		logger.Errorf("zhIndexMapping AddCustomAnalyzer failed: %v", err)
		return nil
	}
	indexMapping.DefaultAnalyzer = "gojieba"

	return indexMapping
}`

use `bleve.Open`  increase memory usage.

Signed-off-by: jerrylou <gunsluo@gmail.com>