### PR TITLE
mapping: Fix closestDocMapping selecting wrong mapping

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -179,6 +179,7 @@ OUTER:
 				continue OUTER
 			}
 		}
+		break
 	}
 	return current
 }

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -991,3 +991,26 @@ func TestMappingForNilTextMarshaler(t *testing.T) {
 	}
 
 }
+
+func TestClosestDocDynamicMapping(t *testing.T) {
+	mapping := NewIndexMapping()
+	mapping.IndexDynamic = false
+	mapping.DefaultMapping = NewDocumentStaticMapping()
+	mapping.DefaultMapping.AddFieldMappingsAt("foo", NewTextFieldMapping())
+
+	doc := document.NewDocument("x")
+	err := mapping.MapDocument(doc, map[string]interface{}{
+		"foo": "value",
+		"bar": map[string]string{
+			"foo": "value2",
+			"baz": "value3",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(doc.Fields) != 1 {
+		t.Fatalf("expected 1 field, got: %d", len(doc.Fields))
+	}
+}


### PR DESCRIPTION
With a document like:

```
{
  "foo": "value",
  "bar": {
    "foo": "value2",
    "baz": "value3"
  }
}
```

And a mapping like:

```
mapping := bleve.NewIndexMapping()
mapping.IndexDynamic = false
mapping.DefaultMapping = bleve.NewDocumentStaticMapping()
mapping.DefaultMapping.AddFieldMappingsAt("foo", bleve.NewTextFieldMapping())
```

The default mapper will incorrectly index `bar.foo` as a dynamic field, but will correctly skip `bar.baz`.