### PR TITLE
scorch cleanup of the rootBolt of old snapshots

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -68,6 +68,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 
 	// prepare new index snapshot, with curr size + 1
 	newSnapshot := &IndexSnapshot{
+		parent:   s,
 		segment:  make([]*SegmentSnapshot, len(s.root.segment)+1),
 		offsets:  make([]uint64, len(s.root.segment)+1),
 		internal: make(map[string][]byte, len(s.root.segment)),
@@ -155,6 +156,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	currSize := len(s.root.segment)
 	newSize := currSize + 1 - len(nextMerge.old)
 	newSnapshot := &IndexSnapshot{
+		parent:   s,
 		segment:  make([]*SegmentSnapshot, 0, newSize),
 		offsets:  make([]uint64, 0, newSize),
 		internal: make(map[string][]byte, len(s.root.segment)),

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -40,6 +40,7 @@ type asynchSegmentResult struct {
 }
 
 type IndexSnapshot struct {
+	parent   *Scorch
 	segment  []*SegmentSnapshot
 	offsets  []uint64
 	internal map[string][]byte
@@ -66,6 +67,9 @@ func (i *IndexSnapshot) DecRef() (err error) {
 					err = err2
 				}
 			}
+		}
+		if i.parent != nil {
+			go i.parent.AddEligibleForRemoval(i.epoch)
 		}
 	}
 	i.m.Unlock()


### PR DESCRIPTION
A new global variable, NumSnapshotsToKeep, represents the default
number of old snapshots that each scorch instance should maintain -- 0
is the default.  Apps that need rollback'ability may want to increase
this value in early initialization.

The Scorch.eligibleForRemoval field tracks epoches which are safe to
delete from the rootBolt.  The eligibleForRemoval is appended to
whenever the ref-count on an IndexSnapshot drops to 0.

On startup, eligibleForRemoval is also initialized with any older
epoch's found in the rootBolt.

The newly introduced Scorch.removeOldSnapshots() method is called on
every cycle of the persisterLoop(), where it maintains the
eligibleForRemoval slice to under a size defined by the
NumSnapshotsToKeep.

A future commit will remove actual storage files in order to match the
"source of truth" information found in the rootBolt.