### PR TITLE
scorch tracks zap files that can't be removed yet

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -129,14 +129,17 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot) error {
 			}
 		}
 
-		filename := fmt.Sprintf("%08x.zap", newSegmentID)
+		filename := zapFileName(newSegmentID)
+		s.markIneligibleForRemoval(filename)
 		path := s.path + string(os.PathSeparator) + filename
 		newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024)
 		if err != nil {
+			s.unmarkIneligibleForRemoval(filename)
 			return fmt.Errorf("merging failed: %v", err)
 		}
 		segment, err := zap.Open(path)
 		if err != nil {
+			s.unmarkIneligibleForRemoval(filename)
 			return err
 		}
 		sm := &segmentMerge{


### PR DESCRIPTION
A race & solution found by Marty Schoch... consider a case when the
merger might grab a nextSegmentID, like 4, but takes awhile to
complete.  Meanwhile, the persister grabs the nextSegmentID of 5, but
finishes its persistence work fast, and then loops to cleanup any old
files.  The simple approach of checking a "highest segment ID" of 5 is
wrong now, because the deleter now thinks that segment 4's zap file is
(incorrectly) ok to delete.

The solution in this commit is to track an ephemeral map of filenames
which are ineligibleForRemoval, because they're still being written
(by the merger) and haven't been fully incorporated into the rootBolt
yet.

The merger adds to that ineligibleForRemoval map as it starts a merged
zap file, the persister cleans up entries from that map when it
persists zap filenames into the rootBolt, and the deleter (part of the
persister's loop) consults the map before performing any actual zap
file deletions.