### PR TITLE
scorch fix for TestSortMatchSearch

### DIFF
--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -540,7 +540,7 @@ func TestIndexInsertWithStore(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(storedDoc.Fields) != 2 {
+	if len(storedDoc.Fields) != 1 {
 		t.Errorf("expected 1 stored field, got %d", len(storedDoc.Fields))
 	}
 	for _, field := range storedDoc.Fields {
@@ -553,13 +553,7 @@ func TestIndexInsertWithStore(t *testing.T) {
 				t.Errorf("expected field content 'test', got '%s'", string(textField.Value()))
 			}
 		} else if field.Name() == "_id" {
-			textField, ok := field.(*document.TextField)
-			if !ok {
-				t.Errorf("expected text field")
-			}
-			if string(textField.Value()) != "1" {
-				t.Errorf("expected field content '1', got '%s'", string(textField.Value()))
-			}
+			t.Errorf("not expecting _id field")
 		}
 	}
 }
@@ -857,8 +851,8 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(storedDoc.Fields) != 4 {
-		t.Errorf("expected 4 stored field, got %d", len(storedDoc.Fields))
+	if len(storedDoc.Fields) != 3 {
+		t.Errorf("expected 3 stored field, got %d", len(storedDoc.Fields))
 	}
 	for _, field := range storedDoc.Fields {
 
@@ -896,8 +890,9 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 					t.Errorf("expected date value unix epoch, got %v", dateFieldDate)
 				}
 			}
+		} else if field.Name() == "_id" {
+			t.Errorf("not expecting _id field")
 		}
-
 	}
 
 	// now update the document, but omit one of the fields
@@ -934,8 +929,8 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(storedDoc.Fields) != 3 {
-		t.Errorf("expected 3 stored field, got %d", len(storedDoc.Fields))
+	if len(storedDoc.Fields) != 2 {
+		t.Errorf("expected 2 stored field, got %d", len(storedDoc.Fields))
 	}
 
 	for _, field := range storedDoc.Fields {
@@ -961,6 +956,8 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 					t.Errorf("expeted numeric value 36.99, got %f", numFieldNumer)
 				}
 			}
+		} else if field.Name() == "_id" {
+			t.Errorf("not expecting _id field")
 		}
 	}
 
@@ -1114,8 +1111,8 @@ func TestIndexUpdateComposites(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(storedDoc.Fields) != 3 {
-		t.Errorf("expected 3 stored field, got %d", len(storedDoc.Fields))
+	if len(storedDoc.Fields) != 2 {
+		t.Errorf("expected 2 stored field, got %d", len(storedDoc.Fields))
 	}
 	for _, field := range storedDoc.Fields {
 		if field.Name() == "name" {
@@ -1126,6 +1123,8 @@ func TestIndexUpdateComposites(t *testing.T) {
 			if string(textField.Value()) != "testupdated" {
 				t.Errorf("expected field content 'test', got '%s'", string(textField.Value()))
 			}
+		} else if field.Name() == "_id" {
+			t.Errorf("not expecting _id field")
 		}
 	}
 }

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -256,6 +256,9 @@ func (i *IndexSnapshot) Document(id string) (rv *document.Document, err error) {
 
 	rv = document.NewDocument(id)
 	err = i.segment[segmentIndex].VisitDocument(localDocNum, func(name string, typ byte, value []byte, pos []uint64) bool {
+		if name == "_id" {
+			return true
+		}
 		switch typ {
 		case 't':
 			rv.AddField(document.NewTextField(name, pos, value))

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -413,7 +413,7 @@ func (i *IndexSnapshot) DocumentVisitFieldTerms(id index.IndexInternalID,
 
 	ss := i.segment[segmentIndex]
 
-	err = ss.cachedDocs.prepareFields(localDocNum, fields, ss)
+	err = ss.cachedDocs.prepareFields(fields, ss)
 	if err != nil {
 		return err
 	}
@@ -421,11 +421,13 @@ func (i *IndexSnapshot) DocumentVisitFieldTerms(id index.IndexInternalID,
 	for _, field := range fields {
 		if cachedFieldDocs, exists := ss.cachedDocs.cache[field]; exists {
 			if tlist, exists := cachedFieldDocs.docs[localDocNum]; exists {
-				terms := bytes.SplitN(tlist, TermSeparatorSplitSlice, -1)
-				for _, term := range terms {
-					if len(term) > 0 {
-						visitor(field, term)
+				for {
+					i := bytes.Index(tlist, TermSeparatorSplitSlice)
+					if i < 0 {
+						break
 					}
+					visitor(field, tlist[0:i])
+					tlist = tlist[i+1:]
 				}
 			}
 		}


### PR DESCRIPTION
The cachedDocs preparation has to happen for all docs in the field,
not just on the currently requested docNum.

Also, as part of this commit, there's a loop optimization where we no
longer use bytes.Split() on the terms buffer, thus avoiding garbage
creation.