### PR TITLE
scorch fix data race w/ AddEligibleForRemoval

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -325,10 +325,12 @@ func (s *Scorch) loadFromBolt() error {
 			}
 			s.nextSegmentID++
 			s.nextSnapshotEpoch = snapshotEpoch + 1
+			s.rootLock.Lock()
 			if s.root != nil {
 				_ = s.root.DecRef()
 			}
 			s.root = indexSnapshot
+			s.rootLock.Unlock()
 			foundRoot = true
 		}
 		return nil


### PR DESCRIPTION
Found from "go test -race ./..."

WARNING: DATA RACE
Read at 0x00c420088060 by goroutine 48:
  github.com/blevesearch/bleve/index/scorch.(*Scorch).AddEligibleForRemoval()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:348 +0x6d

Previous write at 0x00c420088060 by goroutine 31:
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt.func1()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:332 +0x87b
  github.com/boltdb/bolt.(*DB).View()
      /Users/steveyen/go/src/github.com/boltdb/bolt/db.go:629 +0xc1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:290 +0xa1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).Open()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:121 +0x77f
  github.com/blevesearch/bleve/index/scorch.TestIndexOpenReopen()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/scorch_test.go:115 +0x1351
  testing.tRunner()
      /usr/local/Cellar/go/1.9/libexec/src/testing/testing.go:746 +0x16c

Goroutine 48 (running) created at:
  github.com/blevesearch/bleve/index/scorch.(*IndexSnapshot).DecRef()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_index.go:72 +0x23e
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt.func1()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:330 +0x8f4
  github.com/boltdb/bolt.(*DB).View()
      /Users/steveyen/go/src/github.com/boltdb/bolt/db.go:629 +0xc1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:290 +0xa1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).Open()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:121 +0x77f
  github.com/blevesearch/bleve/index/scorch.TestIndexOpenReopen()
      /Users/steveyen/go/src/github.com/blevesearch/bleve/index/scorch/scorch_test.go:115 +0x1351
  testing.tRunner()
      /usr/local/Cellar/go/1.9/libexec/src/testing/testing.go:746 +0x16c