### PR TITLE
scorch handle zero-doc segments

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -222,7 +222,10 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 	}
 
 	// get write lock and update the current snapshot with disk-based versions
-	var notifications []chan error
+	snapshot.m.Lock()
+	notifications := snapshot.persisted
+	snapshot.persisted = nil
+	snapshot.m.Unlock()
 
 	s.rootLock.Lock()
 	newIndexSnapshot := &IndexSnapshot{
@@ -244,7 +247,7 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 			}
 			newIndexSnapshot.segment[i] = newSegmentSnapshot
 			// add the old segment snapshots notifications to the list
-			for _, notification := range segmentSnapshot.notify {
+			for _, notification := range segmentSnapshot.persisted {
 				notifications = append(notifications, notification)
 			}
 		} else {

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -215,11 +215,9 @@ func (s *Scorch) Batch(batch *index.Batch) error {
 
 	// wait for analysis result
 	analysisResults := make([]*index.AnalysisResult, int(numUpdates))
-	// newRowsMap := make(map[string][]index.IndexRow)
 	var itemsDeQueued uint64
 	for itemsDeQueued < numUpdates {
 		result := <-resultChan
-		//newRowsMap[result.DocID] = result.Rows
 		analysisResults[itemsDeQueued] = result
 		itemsDeQueued++
 	}
@@ -230,12 +228,10 @@ func (s *Scorch) Batch(batch *index.Batch) error {
 	var newSegment segment.Segment
 	if len(analysisResults) > 0 {
 		newSegment = mem.NewFromAnalyzedDocs(analysisResults)
-	} else {
-		newSegment = mem.New()
 	}
 
 	err := s.prepareSegment(newSegment, ids, batch.InternalOps)
-	if err != nil {
+	if err != nil && newSegment != nil {
 		_ = newSegment.Close()
 	}
 	return err
@@ -278,7 +274,7 @@ func (s *Scorch) prepareSegment(newSegment segment.Segment, ids []string,
 		return err
 	}
 
-	if !s.unsafeBatch {
+	if introduction.persisted != nil {
 		err = <-introduction.persisted
 	}
 

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -587,6 +587,10 @@ func TestIndexInternalCRUD(t *testing.T) {
 		t.Error(err)
 	}
 
+	if len(indexReader.(*Reader).root.segment) != 0 {
+		t.Errorf("expected 0 segments")
+	}
+
 	// get something that doesn't exist yet
 	val, err := indexReader.GetInternal([]byte("key"))
 	if err != nil {
@@ -612,6 +616,10 @@ func TestIndexInternalCRUD(t *testing.T) {
 		t.Error(err)
 	}
 
+	if len(indexReader2.(*Reader).root.segment) != 0 {
+		t.Errorf("expected 0 segments")
+	}
+
 	// get
 	val, err = indexReader2.GetInternal([]byte("key"))
 	if err != nil {
@@ -635,6 +643,10 @@ func TestIndexInternalCRUD(t *testing.T) {
 	indexReader3, err := idx.Reader()
 	if err != nil {
 		t.Error(err)
+	}
+
+	if len(indexReader3.(*Reader).root.segment) != 0 {
+		t.Errorf("expected 0 segments")
 	}
 
 	// get again
@@ -725,6 +737,11 @@ func TestIndexBatch(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
+
+	numSegments := len(indexReader.(*Reader).root.segment)
+	if numSegments <= 0 {
+		t.Errorf("expected some segments, got: %d", numSegments)
+	}
 
 	docCount, err := indexReader.DocCount()
 	if err != nil {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -48,6 +48,8 @@ type IndexSnapshot struct {
 
 	m    sync.Mutex // Protects the fields that follow.
 	refs int64
+
+	persisted []chan error
 }
 
 func (i *IndexSnapshot) AddRef() {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -48,8 +48,6 @@ type IndexSnapshot struct {
 
 	m    sync.Mutex // Protects the fields that follow.
 	refs int64
-
-	persisted []chan error
 }
 
 func (i *IndexSnapshot) AddRef() {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -52,8 +52,6 @@ type SegmentSnapshot struct {
 	segment segment.Segment
 	deleted *roaring.Bitmap
 
-	persisted []chan error // closed when the segment is persisted
-
 	cachedDocs *cachedDocs
 }
 

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -52,7 +52,8 @@ type SegmentSnapshot struct {
 	segment segment.Segment
 	deleted *roaring.Bitmap
 
-	notify     []chan error
+	persisted []chan error // closed when the segment is persisted
+
 	cachedDocs *cachedDocs
 }
 


### PR DESCRIPTION
The changes...

- allow a segmentIntroduction struct to have a nil segment

- persisted notification channels are now at the Scorch struct level (see rootPersisted field) instead of at the SegmentSnapshot level, so no more copying or "carrying over" the persisted notification channels from segment snapshot to segment snapshot.

- added an epochWatcher struct, which is how the persister now makes requests to the introducer when it wants to be notified when there's an updated root.  This replaces the double checking logic in the persister, removing a race condition.