### PR TITLE
scorch mergeplan explicitly weeds out empty segments

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -173,6 +173,17 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 
 	rv := &MergePlan{}
 
+	var empties []Segment
+	for _, eligible := range eligibles {
+		if eligible.LiveSize() <= 0 {
+			empties = append(empties, eligible)
+		}
+	}
+	if len(empties) > 0 {
+		rv.Tasks = append(rv.Tasks, &MergeTask{Segments: empties})
+		eligibles = removeSegments(eligibles, empties)
+	}
+
 	// While we’re over budget, keep looping, which might produce
 	// another MergeTask.
 	for len(eligibles) > budgetNumSegments {


### PR DESCRIPTION
Rather than relying on heuristic scoring to weed out empty segments, this commit
does the weeding out of empty segments explicitly and up front.