### PR TITLE
import couchbase/vellum instead of couchbaselabs/vellum

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Smerity/govarint"
 	"github.com/blevesearch/bleve/index/scorch/segment/mem"
-	"github.com/couchbaselabs/vellum"
+	"github.com/couchbase/vellum"
 	"github.com/golang/snappy"
 )
 

--- a/index/scorch/segment/zap/cmd/zap/cmd/dict.go
+++ b/index/scorch/segment/zap/cmd/zap/cmd/dict.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/couchbaselabs/vellum"
+	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )
 

--- a/index/scorch/segment/zap/cmd/zap/cmd/explore.go
+++ b/index/scorch/segment/zap/cmd/zap/cmd/explore.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/couchbaselabs/vellum"
+	"github.com/couchbase/vellum"
 	"github.com/spf13/cobra"
 )
 

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -21,8 +21,8 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/scorch/segment"
-	"github.com/couchbaselabs/vellum"
-	"github.com/couchbaselabs/vellum/regexp"
+	"github.com/couchbase/vellum"
+	"github.com/couchbase/vellum/regexp"
 )
 
 // Dictionary is the zap representation of the term dictionary

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
-	"github.com/couchbaselabs/vellum"
+	"github.com/couchbase/vellum"
 	"github.com/golang/snappy"
 )
 

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -25,7 +25,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
 	"github.com/blevesearch/bleve/index/scorch/segment"
-	"github.com/couchbaselabs/vellum"
+	"github.com/couchbase/vellum"
 	mmap "github.com/edsrzf/mmap-go"
 	"github.com/golang/snappy"
 )

--- a/index/store/moss/lower.go
+++ b/index/store/moss/lower.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package moss provides a KVStore implementation based on the
-// github.com/couchbaselabs/moss library.
+// github.com/couchbase/moss library.
 
 package moss
 

--- a/index/store/moss/store.go
+++ b/index/store/moss/store.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package moss provides a KVStore implementation based on the
-// github.com/couchbaselabs/moss library.
+// github.com/couchbase/moss library.
 
 package moss
 

--- a/search/search.go
+++ b/search/search.go
@@ -37,12 +37,12 @@ func (ap ArrayPositions) Equals(other ArrayPositions) bool {
 
 type Location struct {
 	// Pos is the position of the term within the field, starting at 1
-	Pos            uint64         `json:"pos"`
-	
+	Pos uint64 `json:"pos"`
+
 	// Start and End are the byte offsets of the term in the field
-	Start          uint64         `json:"start"`
-	End            uint64         `json:"end"`
-	
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+
 	// ArrayPositions contains the positions of the term within any elements.
 	ArrayPositions ArrayPositions `json:"array_positions"`
 }


### PR DESCRIPTION
Also, scrubbed an old couchbaselabs/moss reference in comments.

Also, go fmt.