### PR TITLE
scorch optimize zap Count()

### DIFF
--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -85,10 +85,15 @@ func (p *PostingsList) Iterator() segment.PostingsIterator {
 // Count returns the number of items on this postings list
 func (p *PostingsList) Count() uint64 {
 	if p.postings != nil {
+		n := p.postings.GetCardinality()
 		if p.except != nil {
-			return roaring.AndNot(p.postings, p.except).GetCardinality()
+			e := p.except.GetCardinality()
+			if e > n {
+				e = n
+			}
+			return n - e
 		}
-		return p.postings.GetCardinality()
+		return n
 	}
 	return 0
 }

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -32,6 +32,7 @@ type SegmentDictionarySnapshot struct {
 }
 
 func (s *SegmentDictionarySnapshot) PostingsList(term string, except *roaring.Bitmap) (segment.PostingsList, error) {
+	// TODO: if except is non-nil, perhaps need to OR it with s.s.deleted?
 	return s.d.PostingsList(term, s.s.deleted)
 }
 


### PR DESCRIPTION
This proposed approach avoids building a temporary AndNot() bitmap,
following the same kind of optimization used by mem segments.