### PR TITLE
scorch docNumberToBytes() checks cap(buf) before allocating

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -367,7 +367,11 @@ func (i *IndexSnapshot) TermFieldReader(term []byte, field string, includeFreq,
 
 func docNumberToBytes(buf []byte, in uint64) []byte {
 	if len(buf) != 8 {
-		buf = make([]byte, 8)
+		if cap(buf) >= 8 {
+			buf = buf[0:8]
+		} else {
+			buf = make([]byte, 8)
+		}
 	}
 	binary.BigEndian.PutUint64(buf, in)
 	return buf


### PR DESCRIPTION
With more pprof focusing (zooming in on a particular func), there were
still some memory allocations showing up with docNumberToBytes() in
micro benchmarks of bleve-query.  On a dev macbook, on an index of 50K
wikipedia docs, using search of relatively common "text:date"...

   400 qps - upsidedown/moss
   680 qps - scorch before
   775 qps - scorch after