### PR TITLE
scorch added kvconfig unsafe_batch option

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -81,9 +81,9 @@ func NewScorch(storeName string, config map[string]interface{}, analysisQueue *i
 	if ok {
 		rv.readOnly = ro
 	}
-	// hack for now to disable safe batches in FTS
-	if storeName == "moss" {
-		rv.unsafeBatch = true
+	ub, ok := config["unsafe_batch"].(bool)
+	if ok {
+		rv.unsafeBatch = ub
 	}
 	return rv, nil
 }


### PR DESCRIPTION
Added an option to the kvconfig JSON, called "unsafe_batch" (bool).
Default is false, so Batch() calls are synchronously persisted by
default.  Advanced users may want to unsafe, asynchronous persistence
to tradeoff performance (mutations are queryable sooner) over safety.

    {
      "index_type": "scorch",
      "kvconfig": { "unsafe_batch": true }
    }

This change replaces the previous kvstore=="moss" workaround.