### PR TITLE
Adding a num_items_to_persist stat

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -16,6 +16,7 @@ package scorch
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index/scorch/segment"
@@ -137,8 +138,10 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 
 		newSnapshot.offsets[i] = running
 		running += s.root.segment[i].Count()
-
 	}
+
+	numItems := running
+
 	// append new segment, if any, to end of the new index snapshot
 	if next.data != nil {
 		newSnapshot.segment = append(newSnapshot.segment, &SegmentSnapshot{
@@ -147,6 +150,9 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			cachedDocs: &cachedDocs{cache: nil},
 		})
 		newSnapshot.offsets = append(newSnapshot.offsets, running)
+
+		// Get numDocs from the new segment
+		numItems += next.data.Count()
 	}
 	// copy old values
 	for key, oldVal := range s.root.internal {
@@ -166,6 +172,10 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 	// swap in new index snapshot
 	rootPrev := s.root
 	s.root = newSnapshot
+
+	// Update the numItems count of the root
+	atomic.StoreUint64(&s.root.numItems, numItems)
+
 	// release lock
 	s.rootLock.Unlock()
 
@@ -231,17 +241,22 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	}
 
 	// put new segment at end
-	newSnapshot.segment = append(newSnapshot.segment, &SegmentSnapshot{
+	newSegment := &SegmentSnapshot{
 		id:         nextMerge.id,
 		segment:    nextMerge.new, // take ownership for nextMerge.new's ref-count
 		deleted:    newSegmentDeleted,
 		cachedDocs: &cachedDocs{cache: nil},
-	})
+	}
+	newSnapshot.segment = append(newSnapshot.segment, newSegment)
 	newSnapshot.offsets = append(newSnapshot.offsets, running)
 
 	// swap in new segment
 	rootPrev := s.root
 	s.root = newSnapshot
+
+	// Update the numItems count of the root
+	atomic.StoreUint64(&s.root.numItems, running+newSegment.Count())
+
 	// release lock
 	s.rootLock.Unlock()
 

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -307,10 +307,17 @@ func (s *Scorch) Reader() (index.IndexReader, error) {
 }
 
 func (s *Scorch) Stats() json.Marshaler {
+	s.updateStats()
 	return s.stats
 }
 func (s *Scorch) StatsMap() map[string]interface{} {
+	s.updateStats()
 	return s.stats.statsMap()
+}
+
+func (s *Scorch) updateStats() {
+	numItems := atomic.LoadUint64(&s.root.numItems)
+	atomic.StoreUint64(&s.stats.numItemsToPersist, numItems)
 }
 
 func (s *Scorch) Analyze(d *document.Document) *index.AnalysisResult {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -46,6 +46,8 @@ type IndexSnapshot struct {
 	internal map[string][]byte
 	epoch    uint64
 
+	numItems uint64
+
 	m    sync.Mutex // Protects the fields that follow.
 	refs int64
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -22,6 +22,7 @@ import (
 // Stats tracks statistics about the index
 type Stats struct {
 	analysisTime, indexTime uint64
+	numItemsToPersist       uint64
 }
 
 // FIXME wire up these other stats again
@@ -36,6 +37,7 @@ func (s *Stats) statsMap() map[string]interface{} {
 	// m["term_searchers_started"] = atomic.LoadUint64(&i.termSearchersStarted)
 	// m["term_searchers_finished"] = atomic.LoadUint64(&i.termSearchersFinished)
 	// m["num_plain_text_bytes_indexed"] = atomic.LoadUint64(&i.numPlainTextBytesIndexed)
+	m["num_items_to_persist"] = atomic.LoadUint64(&s.numItemsToPersist)
 
 	return m
 }


### PR DESCRIPTION
+ For this stat's purpose, adding a new item to the
  IndexSnapshot's struct - call it numItems .. which
  is updated whenever a segment is added to it - be it
  an introduction or a merge.
+ Whenever the Stats API for scorch is invoked, it
  firstly calls an internal API to updateStats which
  applies the root's stats, thereby letting the Stats
  API return the most updated values.