### PR TITLE
Adding a num_items_to_persist stat

### DIFF
--- a/index/scorch/reader.go
+++ b/index/scorch/reader.go
@@ -15,6 +15,8 @@
 package scorch
 
 import (
+	"sync/atomic"
+
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 )
@@ -106,5 +108,6 @@ func (r *Reader) DumpFields() chan interface{} {
 }
 
 func (r *Reader) Close() error {
+	atomic.AddUint64(&r.root.parent.stats.termSearchersFinished, 1)
 	return r.root.DecRef()
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -71,11 +71,11 @@ func NewScorch(storeName string, config map[string]interface{}, analysisQueue *i
 		version:              Version,
 		config:               config,
 		analysisQueue:        analysisQueue,
-		stats:                &Stats{},
 		nextSnapshotEpoch:    1,
 		closeCh:              make(chan struct{}),
 		ineligibleForRemoval: map[string]bool{},
 	}
+	rv.stats = &Stats{i: rv}
 	rv.root = &IndexSnapshot{parent: rv, refs: 1}
 	ro, ok := config["read_only"].(bool)
 	if ok {

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -192,6 +192,7 @@ func (s *Scorch) Batch(batch *index.Batch) error {
 	resultChan := make(chan *index.AnalysisResult, len(batch.IndexOps))
 
 	var numUpdates uint64
+	var numDeletes uint64
 	var numPlainTextBytes uint64
 	var ids []string
 	for docID, doc := range batch.IndexOps {
@@ -200,6 +201,8 @@ func (s *Scorch) Batch(batch *index.Batch) error {
 			doc.AddField(document.NewTextFieldCustom("_id", nil, []byte(doc.ID), document.IndexField|document.StoreField, nil))
 			numUpdates++
 			numPlainTextBytes += doc.NumPlainTextBytes()
+		} else {
+			numDeletes++
 		}
 		ids = append(ids, docID)
 	}
@@ -234,8 +237,16 @@ func (s *Scorch) Batch(batch *index.Batch) error {
 	}
 
 	err := s.prepareSegment(newSegment, ids, batch.InternalOps)
-	if err != nil && newSegment != nil {
-		_ = newSegment.Close()
+	if err != nil {
+		if newSegment != nil {
+			_ = newSegment.Close()
+		}
+		atomic.AddUint64(&s.stats.errors, 1)
+	} else {
+		atomic.AddUint64(&s.stats.updates, numUpdates)
+		atomic.AddUint64(&s.stats.deletes, numDeletes)
+		atomic.AddUint64(&s.stats.batches, 1)
+		atomic.AddUint64(&s.stats.numPlainTextBytesIndexed, numPlainTextBytes)
 	}
 	return err
 }
@@ -303,6 +314,7 @@ func (s *Scorch) Reader() (index.IndexReader, error) {
 	rv := &Reader{root: s.root}
 	rv.root.AddRef()
 	s.rootLock.RUnlock()
+	atomic.AddUint64(&s.stats.termSearchersStarted, 1)
 	return rv, nil
 }
 

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -46,6 +46,8 @@ type IndexSnapshot struct {
 	internal map[string][]byte
 	epoch    uint64
 
+	numItems uint64
+
 	m    sync.Mutex // Protects the fields that follow.
 	refs int64
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -22,6 +22,8 @@ import (
 // Stats tracks statistics about the index
 type Stats struct {
 	analysisTime, indexTime uint64
+	numItemsToPersist       uint64
+	i                       *Scorch
 }
 
 // FIXME wire up these other stats again
@@ -36,6 +38,7 @@ func (s *Stats) statsMap() map[string]interface{} {
 	// m["term_searchers_started"] = atomic.LoadUint64(&i.termSearchersStarted)
 	// m["term_searchers_finished"] = atomic.LoadUint64(&i.termSearchersFinished)
 	// m["num_plain_text_bytes_indexed"] = atomic.LoadUint64(&i.numPlainTextBytesIndexed)
+	m["num_items_to_persist"] = atomic.LoadUint64(&s.i.root.numItems)
 
 	return m
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -21,23 +21,26 @@ import (
 
 // Stats tracks statistics about the index
 type Stats struct {
-	analysisTime, indexTime uint64
-	numItemsToPersist       uint64
-	i                       *Scorch
+	updates, deletes, batches, errors uint64
+	analysisTime, indexTime           uint64
+	termSearchersStarted              uint64
+	termSearchersFinished             uint64
+	numPlainTextBytesIndexed          uint64
+	numItemsToPersist                 uint64
+	i                                 *Scorch
 }
 
-// FIXME wire up these other stats again
 func (s *Stats) statsMap() map[string]interface{} {
 	m := map[string]interface{}{}
-	// m["updates"] = atomic.LoadUint64(&i.updates)
-	// m["deletes"] = atomic.LoadUint64(&i.deletes)
-	// m["batches"] = atomic.LoadUint64(&i.batches)
-	// m["errors"] = atomic.LoadUint64(&i.errors)
+	m["updates"] = atomic.LoadUint64(&s.updates)
+	m["deletes"] = atomic.LoadUint64(&s.deletes)
+	m["batches"] = atomic.LoadUint64(&s.batches)
+	m["errors"] = atomic.LoadUint64(&s.errors)
 	m["analysis_time"] = atomic.LoadUint64(&s.analysisTime)
 	m["index_time"] = atomic.LoadUint64(&s.indexTime)
-	// m["term_searchers_started"] = atomic.LoadUint64(&i.termSearchersStarted)
-	// m["term_searchers_finished"] = atomic.LoadUint64(&i.termSearchersFinished)
-	// m["num_plain_text_bytes_indexed"] = atomic.LoadUint64(&i.numPlainTextBytesIndexed)
+	m["term_searchers_started"] = atomic.LoadUint64(&s.termSearchersStarted)
+	m["term_searchers_finished"] = atomic.LoadUint64(&s.termSearchersFinished)
+	m["num_plain_text_bytes_indexed"] = atomic.LoadUint64(&s.numPlainTextBytesIndexed)
 	m["num_items_to_persist"] = atomic.LoadUint64(&s.i.root.numItems)
 
 	return m


### PR DESCRIPTION
+ For this stat's purpose, adding a new item to the
  IndexSnapshot's struct - call it numItems .. which
  is updated whenever a segment is added to it - be it
  an introduction or a merge.
+ Whenever the Stats API for scorch is invoked, the
  num_items_to_persist value can directly be fetched
  from the index's root snapshot.