### PR TITLE
scorch conjuncts match phrase

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -343,6 +343,7 @@ func (i *IndexSnapshot) TermFieldReader(term []byte, field string, includeFreq,
 
 	rv := &IndexSnapshotTermFieldReader{
 		term:               term,
+		field:              field,
 		snapshot:           i,
 		postings:           make([]segment.PostingsList, len(i.segment)),
 		iterators:          make([]segment.PostingsIterator, len(i.segment)),

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -184,6 +184,9 @@ func (s *ConjunctionSearcher) Advance(ctx *search.SearchContext, ID index.IndexI
 		}
 	}
 	for i := range s.searchers {
+		if s.currs[i] != nil && s.currs[i].IndexInternalID.Compare(ID) >= 0 {
+			continue
+		}
 		err := s.advanceChild(ctx, i, ID)
 		if err != nil {
 			return nil, err

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -313,6 +313,12 @@ func (s *PhraseSearcher) Advance(ctx *search.SearchContext, ID index.IndexIntern
 			return nil, err
 		}
 	}
+	if s.currMust != nil {
+		if s.currMust.IndexInternalID.Compare(ID) >= 0 {
+			return s.Next(ctx)
+		}
+		ctx.DocumentMatchPool.Put(s.currMust)
+	}
 	var err error
 	s.currMust, err = s.mustSearcher.Advance(ctx, ID)
 	if err != nil {


### PR DESCRIPTION
While looking through some recent testrunner RQG runs, saw another case where there was a search result discrepancy.  This WIP change replicates this in the scorch-vs-upsidedown unit test.

From http://qa.sc.couchbase.com/job/test_suite_executor/39085/consoleText...

> [2017-12-18 22:07:02,054] - [task:1312] INFO - FTS hits for query: {"conjuncts": [{"field": "manages.reports", "match": "Balandria Cynara"}, {"field": "manages.reports", "match_phrase": "Maura"}]} is 5 (took 5.586473ms)
> [2017-12-18 22:07:02,060] - [task:1322] INFO - ES hits for query: {"query": {"bool": {"must": [{"match": {"manages.reports": "Balandria Cynara"}}, {"match_phrase": {"manages.reports": "Maura"}}]}}} on es_index is 7 (took 2ms)
> [2017-12-18 22:07:02,060] - [task:1327] ERROR - FAIL: FTS hits: 5, while ES hits: 7
> 