### PR TITLE
Rollback: GC'ing segments referenced by an indexSnapshot

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -289,7 +289,7 @@ func (s *Scorch) revertToSnapshot(revertTo *snapshotReversion) error {
 			deleted:    segmentSnapshot.deleted,
 			cachedDocs: segmentSnapshot.cachedDocs,
 		}
-		segmentSnapshot.segment.AddRef()
+		newSnapshot.segment[i].segment.AddRef()
 	}
 
 	if revertTo.persisted != nil {

--- a/index/scorch/snapshot_rollback.go
+++ b/index/scorch/snapshot_rollback.go
@@ -79,6 +79,12 @@ func (s *Scorch) PreviousPersistedSnapshot(is *IndexSnapshot) (*IndexSnapshot, e
 			}
 
 			indexSnapshot.epoch = snapshotEpoch
+			// Mark segments that are referenced by this indexSnapshot
+			// as ineligible for removal.
+			for _, segSnapshot := range indexSnapshot.segment {
+				filename := zapFileName(segSnapshot.id)
+				s.markIneligibleForRemoval(filename)
+			}
 			return indexSnapshot, nil
 		}
 	}


### PR DESCRIPTION
+ When an indexSnapshot is returned through the API:
  PreviousPersistedSnapshot(...), add all the segment files
  that fall within the snapshot as inEligibleForRemoval.
  This is so that these files aren't removed when midway
  through the rollback operation.
+ Update rollback test to better test the scenario