### PR TITLE
Adapting rollback test to better test the scenario

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -289,7 +289,7 @@ func (s *Scorch) revertToSnapshot(revertTo *snapshotReversion) error {
 			deleted:    segmentSnapshot.deleted,
 			cachedDocs: segmentSnapshot.cachedDocs,
 		}
-		segmentSnapshot.segment.AddRef()
+		newSnapshot.segment[i].segment.AddRef()
 	}
 
 	if revertTo.persisted != nil {

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -290,6 +290,10 @@ func (s *Scorch) revertToSnapshot(revertTo *snapshotReversion) error {
 			cachedDocs: segmentSnapshot.cachedDocs,
 		}
 		newSnapshot.segment[i].segment.AddRef()
+
+		// remove segment from ineligibleForRemoval map
+		filename := zapFileName(segmentSnapshot.id)
+		delete(s.ineligibleForRemoval, filename)
 	}
 
 	if revertTo.persisted != nil {


### PR DESCRIPTION
The rollback test only checks if the new root has an epoch
that is less than or equal to the one reverted to .. which
is pretty weak. Improving this test to write a couple of
batches and retrieve the snapshot between the two and
rollback to that. Now we can better validate that rollback
was successful by ensuring that we only see the data before
the second batch.