### PR TITLE
DocValue Config, new API Changes

### DIFF
--- a/document/field_boolean.go
+++ b/document/field_boolean.go
@@ -20,7 +20,7 @@ import (
 	"github.com/blevesearch/bleve/analysis"
 )
 
-const DefaultBooleanIndexingOptions = StoreField | IndexField
+const DefaultBooleanIndexingOptions = StoreField | IndexField | DocValues
 
 type BooleanField struct {
 	name              string

--- a/document/field_datetime.go
+++ b/document/field_datetime.go
@@ -23,7 +23,7 @@ import (
 	"github.com/blevesearch/bleve/numeric"
 )
 
-const DefaultDateTimeIndexingOptions = StoreField | IndexField
+const DefaultDateTimeIndexingOptions = StoreField | IndexField | DocValues
 const DefaultDateTimePrecisionStep uint = 4
 
 var MinTimeRepresentable = time.Unix(0, math.MinInt64)

--- a/document/field_numeric.go
+++ b/document/field_numeric.go
@@ -21,7 +21,7 @@ import (
 	"github.com/blevesearch/bleve/numeric"
 )
 
-const DefaultNumericIndexingOptions = StoreField | IndexField
+const DefaultNumericIndexingOptions = StoreField | IndexField | DocValues
 
 const DefaultPrecisionStep uint = 4
 

--- a/document/field_text.go
+++ b/document/field_text.go
@@ -20,7 +20,7 @@ import (
 	"github.com/blevesearch/bleve/analysis"
 )
 
-const DefaultTextIndexingOptions = IndexField
+const DefaultTextIndexingOptions = IndexField | DocValues
 
 type TextField struct {
 	name              string

--- a/document/indexing_options.go
+++ b/document/indexing_options.go
@@ -20,6 +20,7 @@ const (
 	IndexField IndexingOptions = 1 << iota
 	StoreField
 	IncludeTermVectors
+	DocValues
 )
 
 func (o IndexingOptions) IsIndexed() bool {
@@ -32,6 +33,10 @@ func (o IndexingOptions) IsStored() bool {
 
 func (o IndexingOptions) IncludeTermVectors() bool {
 	return o&IncludeTermVectors != 0
+}
+
+func (o IndexingOptions) IncludeDocValues() bool {
+	return o&DocValues != 0
 }
 
 func (o IndexingOptions) String() string {
@@ -50,6 +55,12 @@ func (o IndexingOptions) String() string {
 			rv += ", "
 		}
 		rv += "TV"
+	}
+	if o.IncludeDocValues() {
+		if rv != "" {
+			rv += ", "
+		}
+		rv += "DV"
 	}
 	return rv
 }

--- a/document/indexing_options_test.go
+++ b/document/indexing_options_test.go
@@ -24,36 +24,56 @@ func TestIndexingOptions(t *testing.T) {
 		isIndexed          bool
 		isStored           bool
 		includeTermVectors bool
+		docValues          bool
 	}{
 		{
 			options:            IndexField | StoreField | IncludeTermVectors,
 			isIndexed:          true,
 			isStored:           true,
 			includeTermVectors: true,
+			docValues:          false,
 		},
 		{
 			options:            IndexField | IncludeTermVectors,
 			isIndexed:          true,
 			isStored:           false,
 			includeTermVectors: true,
+			docValues:          false,
 		},
 		{
 			options:            StoreField | IncludeTermVectors,
 			isIndexed:          false,
 			isStored:           true,
 			includeTermVectors: true,
+			docValues:          false,
 		},
 		{
 			options:            IndexField,
 			isIndexed:          true,
 			isStored:           false,
 			includeTermVectors: false,
+			docValues:          false,
 		},
 		{
 			options:            StoreField,
 			isIndexed:          false,
 			isStored:           true,
 			includeTermVectors: false,
+			docValues:          false,
+		},
+		{
+			options:            DocValues,
+			isIndexed:          false,
+			isStored:           false,
+			includeTermVectors: false,
+			docValues:          true,
+		},
+		{
+			options:            IndexField | StoreField | IncludeTermVectors | DocValues,
+			isIndexed:          true,
+			isStored:           true,
+			includeTermVectors: true,
+			docValues:          true,
 		},
 	}
 
@@ -69,6 +89,10 @@ func TestIndexingOptions(t *testing.T) {
 		actuallyIncludeTermVectors := test.options.IncludeTermVectors()
 		if actuallyIncludeTermVectors != test.includeTermVectors {
 			t.Errorf("expected includeTermVectors to be %v, got %v for %d", test.includeTermVectors, actuallyIncludeTermVectors, test.options)
+		}
+		actuallyDocValues := test.options.IncludeDocValues()
+		if actuallyDocValues != test.docValues {
+			t.Errorf("expected docValue to be %v, got %v for %d", test.docValues, actuallyDocValues, test.options)
 		}
 	}
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -37,14 +37,6 @@ const Name = "scorch"
 
 const Version uint8 = 1
 
-// UnInvertIndex is implemented by various scorch index implementations
-// to provide the un inverting of the postings or other indexed values.
-type UnInvertIndex interface {
-	// apparently need better namings here..
-	VisitDocumentFieldTerms(localDocNum uint64, fields []string,
-		visitor index.DocumentFieldTermVisitor) error
-}
-
 type Scorch struct {
 	readOnly      bool
 	version       uint8

--- a/index/scorch/segment/mem/build.go
+++ b/index/scorch/segment/mem/build.go
@@ -119,10 +119,10 @@ func (s *Segment) processDocument(result *index.AnalysisResult) {
 		if field.Options().IsStored() {
 			storeField(docNum, fieldID, encodeFieldType(field), field.Value(), field.ArrayPositions())
 		}
-		// TODO with mapping changes for dv
-		//if field.Options().IncludeDocValues() {
-		s.DocValueFields[fieldID] = true
-		//}
+
+		if field.Options().IncludeDocValues() {
+			s.DocValueFields[fieldID] = true
+		}
 	}
 
 	// now that its been rolled up into docMap, walk that

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -91,9 +91,14 @@ type Location interface {
 }
 
 // DocumentFieldTermVisitable is implemented by various scorch segment
-// implementations to provide the un inverting of the postings
-// or other indexed values.
+// implementations with persistence for the un inverting of the
+// postings or other indexed values.
 type DocumentFieldTermVisitable interface {
 	VisitDocumentFieldTerms(localDocNum uint64, fields []string,
 		visitor index.DocumentFieldTermVisitor) error
+
+	// VisitableDocValueFields implementation should return
+	// the list of fields which are document value persisted and
+	// therefore visitable by the above VisitDocumentFieldTerms method.
+	VisitableDocValueFields() ([]string, error)
 }

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -184,10 +184,6 @@ func (s *Segment) VisitDocumentFieldTerms(localDocNum uint64, fields []string,
 // persisted doc value terms ready to be visitable using the
 // VisitDocumentFieldTerms method.
 func (s *Segment) VisitableDocValueFields() ([]string, error) {
-	if len(s.fieldsInv) == 0 {
-		return nil, nil
-	}
-
 	var rv []string
 	for fieldID, field := range s.fieldsInv {
 		if dvIter, ok := s.fieldDvIterMap[uint16(fieldID)]; ok &&
@@ -195,6 +191,5 @@ func (s *Segment) VisitableDocValueFields() ([]string, error) {
 			rv = append(rv, field)
 		}
 	}
-
 	return rv, nil
 }

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -151,7 +151,8 @@ func (di *docValueIterator) getDocValueLocs(docID uint64) (uint64, uint64) {
 	return math.MaxUint64, math.MaxUint64
 }
 
-// VisitDocumentFieldTerms is an implementation of the UnInvertIndex interface
+// VisitDocumentFieldTerms is an implementation of the
+// DocumentFieldTermVisitable interface
 func (s *Segment) VisitDocumentFieldTerms(localDocNum uint64, fields []string,
 	visitor index.DocumentFieldTermVisitor) error {
 	fieldID := uint16(0)
@@ -177,4 +178,23 @@ func (s *Segment) VisitDocumentFieldTerms(localDocNum uint64, fields []string,
 		}
 	}
 	return nil
+}
+
+// VisitableDocValueFields returns the list of fields with
+// persisted doc value terms ready to be visitable using the
+// VisitDocumentFieldTerms method.
+func (s *Segment) VisitableDocValueFields() ([]string, error) {
+	if len(s.fieldsInv) == 0 {
+		return nil, nil
+	}
+
+	var rv []string
+	for fieldID, field := range s.fieldsInv {
+		if dvIter, ok := s.fieldDvIterMap[uint16(fieldID)]; ok &&
+			dvIter != nil {
+			rv = append(rv, field)
+		}
+	}
+
+	return rv, nil
 }

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -40,7 +40,7 @@ func TestOpen(t *testing.T) {
 	defer func() {
 		cerr := segment.Close()
 		if cerr != nil {
-			t.Fatalf("error closing segment: %v", err)
+			t.Fatalf("error closing segment: %v", cerr)
 		}
 	}()
 
@@ -340,7 +340,7 @@ func TestOpenMulti(t *testing.T) {
 	defer func() {
 		cerr := segment.Close()
 		if cerr != nil {
-			t.Fatalf("error closing segment: %v", err)
+			t.Fatalf("error closing segment: %v", cerr)
 		}
 	}()
 
@@ -440,7 +440,7 @@ func TestOpenMultiWithTwoChunks(t *testing.T) {
 	defer func() {
 		cerr := segment.Close()
 		if cerr != nil {
-			t.Fatalf("error closing segment: %v", err)
+			t.Fatalf("error closing segment: %v", cerr)
 		}
 	}()
 
@@ -533,11 +533,6 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 		t.Fatalf("error opening segment: %v", err)
 	}
 
-	cerr := seg.Close()
-	if cerr != nil {
-		t.Fatalf("error closing segment: %v", err)
-	}
-
 	if zaps, ok := seg.(segment.DocumentFieldTermVisitable); ok {
 		fields, err := zaps.VisitableDocValueFields()
 		if err != nil {
@@ -549,6 +544,10 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 		}
 	}
 
+	err = seg.Close()
+	if err != nil {
+		t.Fatalf("error closing segment: %v", err)
+	}
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
 	memSegment, expectedFields := buildMemSegmentWithDefaultFieldMapping()
@@ -561,10 +560,11 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error opening segment: %v", err)
 	}
+
 	defer func() {
 		cerr := seg.Close()
 		if cerr != nil {
-			t.Fatalf("error closing segment: %v", err)
+			t.Fatalf("error closing segment: %v", cerr)
 		}
 	}()
 

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -19,6 +19,9 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/scorch/segment"
 )
 
 func TestOpen(t *testing.T) {
@@ -513,5 +516,85 @@ func TestOpenMultiWithTwoChunks(t *testing.T) {
 
 	if count != 1 {
 		t.Errorf("expected count to be 1, got %d", count)
+	}
+}
+
+func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
+	_ = os.RemoveAll("/tmp/scorch.zap")
+
+	memSegment := buildMemSegmentMulti()
+	err := PersistSegment(memSegment, "/tmp/scorch.zap", 1)
+	if err != nil {
+		t.Fatalf("error persisting segment: %v", err)
+	}
+
+	seg, err := Open("/tmp/scorch.zap")
+	if err != nil {
+		t.Fatalf("error opening segment: %v", err)
+	}
+
+	cerr := seg.Close()
+	if cerr != nil {
+		t.Fatalf("error closing segment: %v", err)
+	}
+
+	if zaps, ok := seg.(segment.DocumentFieldTermVisitable); ok {
+		fields, err := zaps.VisitableDocValueFields()
+		if err != nil {
+			t.Fatalf("segment VisitableDocValueFields err: %v", err)
+		}
+		// no persisted doc value fields
+		if len(fields) != 0 {
+			t.Errorf("expected no persisted fields for doc values, got: %#v", fields)
+		}
+	}
+
+	_ = os.RemoveAll("/tmp/scorch.zap")
+
+	memSegment, expectedFields := buildMemSegmentWithDefaultFieldMapping()
+	err = PersistSegment(memSegment, "/tmp/scorch.zap", 1)
+	if err != nil {
+		t.Fatalf("error persisting segment: %v", err)
+	}
+
+	seg, err = Open("/tmp/scorch.zap")
+	if err != nil {
+		t.Fatalf("error opening segment: %v", err)
+	}
+	defer func() {
+		cerr := seg.Close()
+		if cerr != nil {
+			t.Fatalf("error closing segment: %v", err)
+		}
+	}()
+
+	if zaps, ok := seg.(segment.DocumentFieldTermVisitable); ok {
+		fields, err := zaps.VisitableDocValueFields()
+		if err != nil {
+			t.Fatalf("segment VisitableDocValueFields err: %v", err)
+		}
+
+		if !reflect.DeepEqual(fields, expectedFields) {
+			t.Errorf("expected field terms: %#v, got: %#v", expectedFields, fields)
+		}
+
+		fieldTerms := make(index.FieldTerms)
+		err = zaps.VisitDocumentFieldTerms(0, fields, func(field string, term []byte) {
+			fieldTerms[field] = append(fieldTerms[field], string(term))
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		expectedFieldTerms := index.FieldTerms{
+			"name": []string{"wow"},
+			"desc": []string{"some", "thing"},
+			"tag":  []string{"cold"},
+			"_id":  []string{"a"},
+		}
+		if !reflect.DeepEqual(fieldTerms, expectedFieldTerms) {
+			t.Errorf("expected field terms: %#v, got: %#v", expectedFieldTerms, fieldTerms)
+		}
+
 	}
 }

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -28,6 +28,7 @@ import (
 var (
 	IndexDynamic = true
 	StoreDynamic = true
+	DocValues    = true // TODO revisit default?
 )
 
 // A FieldMapping describes how a specific item
@@ -54,6 +55,10 @@ type FieldMapping struct {
 	IncludeTermVectors bool   `json:"include_term_vectors,omitempty"`
 	IncludeInAll       bool   `json:"include_in_all,omitempty"`
 	DateFormat         string `json:"date_format,omitempty"`
+
+	// DocValues, if true makes the index uninverting possible for this field
+	// It is useful for faceting and sorting queries.
+	DocValues bool `json:"docvalues,omitempty"`
 }
 
 // NewTextFieldMapping returns a default field mapping for text
@@ -64,6 +69,7 @@ func NewTextFieldMapping() *FieldMapping {
 		Index:              true,
 		IncludeTermVectors: true,
 		IncludeInAll:       true,
+		DocValues:          true,
 	}
 }
 
@@ -71,6 +77,7 @@ func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewTextFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
+	rv.DocValues = im.DocValues
 	return rv
 }
 
@@ -81,6 +88,7 @@ func NewNumericFieldMapping() *FieldMapping {
 		Store:        true,
 		Index:        true,
 		IncludeInAll: true,
+		DocValues:    true,
 	}
 }
 
@@ -88,6 +96,7 @@ func newNumericFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewNumericFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
+	rv.DocValues = im.DocValues
 	return rv
 }
 
@@ -98,6 +107,7 @@ func NewDateTimeFieldMapping() *FieldMapping {
 		Store:        true,
 		Index:        true,
 		IncludeInAll: true,
+		DocValues:    true,
 	}
 }
 
@@ -105,6 +115,7 @@ func newDateTimeFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewDateTimeFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
+	rv.DocValues = im.DocValues
 	return rv
 }
 
@@ -115,6 +126,7 @@ func NewBooleanFieldMapping() *FieldMapping {
 		Store:        true,
 		Index:        true,
 		IncludeInAll: true,
+		DocValues:    true,
 	}
 }
 
@@ -122,6 +134,7 @@ func newBooleanFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewBooleanFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
+	rv.DocValues = im.DocValues
 	return rv
 }
 
@@ -132,6 +145,7 @@ func NewGeoPointFieldMapping() *FieldMapping {
 		Store:        true,
 		Index:        true,
 		IncludeInAll: true,
+		DocValues:    true,
 	}
 }
 
@@ -146,6 +160,9 @@ func (fm *FieldMapping) Options() document.IndexingOptions {
 	}
 	if fm.IncludeTermVectors {
 		rv |= document.IncludeTermVectors
+	}
+	if fm.DocValues {
+		rv |= document.DocValues
 	}
 	return rv
 }
@@ -305,6 +322,11 @@ func (fm *FieldMapping) UnmarshalJSON(data []byte) error {
 			}
 		case "date_format":
 			err := json.Unmarshal(v, &fm.DateFormat)
+			if err != nil {
+				return err
+			}
+		case "docvalues":
+			err := json.Unmarshal(v, &fm.DocValues)
 			if err != nil {
 				return err
 			}

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -26,9 +26,9 @@ import (
 
 // control the default behavior for dynamic fields (those not explicitly mapped)
 var (
-	IndexDynamic = true
-	StoreDynamic = true
-	DocValues    = true // TODO revisit default?
+	IndexDynamic     = true
+	StoreDynamic     = true
+	DocValuesDynamic = true // TODO revisit default?
 )
 
 // A FieldMapping describes how a specific item
@@ -77,7 +77,7 @@ func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewTextFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
-	rv.DocValues = im.DocValues
+	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
 
@@ -96,7 +96,7 @@ func newNumericFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewNumericFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
-	rv.DocValues = im.DocValues
+	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
 
@@ -115,7 +115,7 @@ func newDateTimeFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewDateTimeFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
-	rv.DocValues = im.DocValues
+	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
 
@@ -134,7 +134,7 @@ func newBooleanFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewBooleanFieldMapping()
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
-	rv.DocValues = im.DocValues
+	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
 

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -50,7 +50,7 @@ type IndexMappingImpl struct {
 	DefaultField          string                      `json:"default_field"`
 	StoreDynamic          bool                        `json:"store_dynamic"`
 	IndexDynamic          bool                        `json:"index_dynamic"`
-	DocValues             bool                        `json:"docvalues,omitempty"`
+	DocValuesDynamic      bool                        `json:"docvalues_dynamic,omitempty"`
 	CustomAnalysis        *customAnalysis             `json:"analysis,omitempty"`
 	cache                 *registry.Cache
 }
@@ -155,7 +155,7 @@ func NewIndexMapping() *IndexMappingImpl {
 		DefaultField:          defaultField,
 		IndexDynamic:          IndexDynamic,
 		StoreDynamic:          StoreDynamic,
-		DocValues:             DocValues,
+		DocValuesDynamic:      DocValuesDynamic,
 		CustomAnalysis:        newCustomAnalysis(),
 		cache:                 registry.NewCache(),
 	}
@@ -219,7 +219,7 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 	im.TypeMapping = make(map[string]*DocumentMapping)
 	im.StoreDynamic = StoreDynamic
 	im.IndexDynamic = IndexDynamic
-	im.DocValues = DocValues
+	im.DocValuesDynamic = DocValuesDynamic
 
 	var invalidKeys []string
 	for k, v := range tmp {
@@ -274,8 +274,8 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 			if err != nil {
 				return err
 			}
-		case "docvalues":
-			err := json.Unmarshal(v, &im.DocValues)
+		case "docvalues_dynamic":
+			err := json.Unmarshal(v, &im.DocValuesDynamic)
 			if err != nil {
 				return err
 			}

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -50,6 +50,7 @@ type IndexMappingImpl struct {
 	DefaultField          string                      `json:"default_field"`
 	StoreDynamic          bool                        `json:"store_dynamic"`
 	IndexDynamic          bool                        `json:"index_dynamic"`
+	DocValues             bool                        `json:"docvalues,omitempty"`
 	CustomAnalysis        *customAnalysis             `json:"analysis,omitempty"`
 	cache                 *registry.Cache
 }
@@ -154,6 +155,7 @@ func NewIndexMapping() *IndexMappingImpl {
 		DefaultField:          defaultField,
 		IndexDynamic:          IndexDynamic,
 		StoreDynamic:          StoreDynamic,
+		DocValues:             DocValues,
 		CustomAnalysis:        newCustomAnalysis(),
 		cache:                 registry.NewCache(),
 	}
@@ -217,6 +219,7 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 	im.TypeMapping = make(map[string]*DocumentMapping)
 	im.StoreDynamic = StoreDynamic
 	im.IndexDynamic = IndexDynamic
+	im.DocValues = DocValues
 
 	var invalidKeys []string
 	for k, v := range tmp {
@@ -268,6 +271,11 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 			}
 		case "index_dynamic":
 			err := json.Unmarshal(v, &im.IndexDynamic)
+			if err != nil {
+				return err
+			}
+		case "docvalues":
+			err := json.Unmarshal(v, &im.DocValues)
 			if err != nil {
 				return err
 			}

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -40,7 +40,8 @@ var mappingSource = []byte(`{
     						"store": true,
     						"index": true,
                             "include_term_vectors": true,
-                            "include_in_all": true
+                            "include_in_all": true,
+                            "docvalues": true
     					}
     				]
     			}


### PR DESCRIPTION
-new `VisitableDocValueFields` API for persisted DV field list
-making dv configs overridable at field level
-enabling on the fly/runtime un inverting of doc values
-few UT updates