### PR TITLE
segment SizeInBytes  updates

### DIFF
--- a/index/scorch/segment/mem/segment.go
+++ b/index/scorch/segment/mem/segment.go
@@ -161,6 +161,9 @@ func (s *Segment) updateSizeInBytes() {
 
 	sizeInBytes += uint64(8 /* size of sizeInBytes -> uint64*/)
 
+	// uint16 (2) + bool (1) -> 3
+	sizeInBytes += uint64(len(s.DocValueFields)) * 3
+
 	s.sizeInBytes = sizeInBytes
 }
 

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -40,7 +40,6 @@ func (di *docValueIterator) sizeInBytes() uint64 {
 	sizeInBytes := 24
 	sizeInBytes += len(di.field)
 	sizeInBytes += len(di.chunkLens) * 8
-	sizeInBytes += len(di.curChunkData)
 	sizeInBytes += len(di.curChunkHeader) * 24
 	return uint64(sizeInBytes)
 }

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -35,6 +35,16 @@ type docValueIterator struct {
 	curChunkData   []byte // compressed data cache
 }
 
+func (di *docValueIterator) sizeInBytes() uint64 {
+	// curChunkNum, numChunks, dvDataLoc
+	sizeInBytes := 24
+	sizeInBytes += len(di.field)
+	sizeInBytes += len(di.chunkLens) * 8
+	sizeInBytes += len(di.curChunkData)
+	sizeInBytes += len(di.curChunkHeader) * 24
+	return uint64(sizeInBytes)
+}
+
 func (di *docValueIterator) fieldName() string {
 	return di.field
 }

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"unsafe"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
@@ -120,8 +119,8 @@ func (s *Segment) SizeInBytes() uint64 {
 	sizeInBytes += len(s.fieldsOffsets) * 8 /* size of uint64 */
 	sizeInBytes += 8                        /* size of refs -> int64 */
 
+	sizeInBytes += len(s.fieldDvIterMap) * 10 /* size of ptr(8) + uint16(2) */
 	for _, entry := range s.fieldDvIterMap {
-		sizeInBytes += int(unsafe.Sizeof(entry)) + 2 /* size of uint16 */
 		if entry != nil {
 			sizeInBytes += int(entry.sizeInBytes())
 		}

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -122,6 +122,9 @@ func (s *Segment) SizeInBytes() uint64 {
 
 	for _, entry := range s.fieldDvIterMap {
 		sizeInBytes += int(unsafe.Sizeof(entry)) + 2 /* size of uint16 */
+		if entry != nil {
+			sizeInBytes += int(entry.sizeInBytes())
+		}
 	}
 
 	return uint64(sizeInBytes)

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"unsafe"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
@@ -103,7 +104,8 @@ func (s *Segment) SizeInBytes() uint64 {
 	// 8 /* size of numDocs -> uint64 */ +
 	// 8 /* size of storedIndexOffset -> uint64 */ +
 	// 8 /* size of fieldsIndexOffset -> uint64 */
-	sizeOfUints := 36
+	// 8 /* size of docValueOffset -> uint64 */
+	sizeOfUints := 44
 
 	sizeInBytes := len(s.mm) + len(s.path) + sizeOfUints
 
@@ -117,6 +119,10 @@ func (s *Segment) SizeInBytes() uint64 {
 
 	sizeInBytes += len(s.fieldsOffsets) * 8 /* size of uint64 */
 	sizeInBytes += 8                        /* size of refs -> int64 */
+
+	for _, entry := range s.fieldDvIterMap {
+		sizeInBytes += int(unsafe.Sizeof(entry)) + 2 /* size of uint16 */
+	}
 
 	return uint64(sizeInBytes)
 }


### PR DESCRIPTION
-segment size computations updated with docValue fields

@abhinavdangeti ,sending the changes over a PR as it is easier for you to suggest/fix if anything went wrong (as I am about to sleep atm..)

@mschoch , one doubt I have regarding the SizeInBytes API is, 
Is it for computing the exact size of the fields/pointers embedded within the Segment structs, not accounting for size of items which are referenced through pointers.) (which may not be the case)
, Else if it is for giving an estimate about the actual memory consumption size, then we need to somehow compute the FieldCache size for mem segments (though its not a part of the segment, its a part of the snapshot atm and for persisted segment docValueIterator sizes needs to be accounted to be precise about the size figures. If so, I shall work on it tomorrow to make the size computations accommodate those changes?

  
  
  