### PR TITLE
Do not account mmap'ed part of zap segments in MemoryUsed

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -410,13 +410,15 @@ func (s *Scorch) AddEligibleForRemoval(epoch uint64) {
 func (s *Scorch) MemoryUsed() uint64 {
 	var memUsed uint64
 	s.rootLock.RLock()
-	for _, segmentSnapshot := range s.root.segment {
-		memUsed += 8 /* size of id -> uint64 */ +
-			segmentSnapshot.segment.SizeInBytes()
-		if segmentSnapshot.deleted != nil {
-			memUsed += segmentSnapshot.deleted.GetSizeInBytes()
+	if s.root != nil {
+		for _, segmentSnapshot := range s.root.segment {
+			memUsed += 8 /* size of id -> uint64 */ +
+				segmentSnapshot.segment.SizeInBytes()
+			if segmentSnapshot.deleted != nil {
+				memUsed += segmentSnapshot.deleted.GetSizeInBytes()
+			}
+			memUsed += segmentSnapshot.cachedDocs.sizeInBytes()
 		}
-		memUsed += segmentSnapshot.cachedDocs.sizeInBytes()
 	}
 	s.rootLock.RUnlock()
 	return memUsed

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -105,7 +105,8 @@ func (s *Segment) SizeInBytes() uint64 {
 	// 8 /* size of fieldsIndexOffset -> uint64 */
 	sizeOfUints := 36
 
-	sizeInBytes := len(s.mm) + len(s.path) + sizeOfUints
+	// Do not include the mmap'ed part
+	sizeInBytes := len(s.path) + sizeOfUints
 
 	for k, _ := range s.fieldsMap {
 		sizeInBytes += len(k) + 2 /* size of uint16 */


### PR DESCRIPTION
This API is designed to only emit the dirty "unpersisted"
bytes only. This does not included the mmap'ed part in the
zap segments (disk).