### PR TITLE
 MB-27498 - date range facet query panics

### DIFF
--- a/search.go
+++ b/search.go
@@ -481,7 +481,7 @@ func (sr *SearchResult) Merge(other *SearchResult) {
 	if other.MaxScore > sr.MaxScore {
 		sr.MaxScore = other.MaxScore
 	}
-	if len(sr.Facets) == 0 {
+	if len(sr.Facets) == 0 && len(other.Facets) != 0 {
 		sr.Facets = make(search.FacetResults)
 	}
 	sr.Facets.Merge(other.Facets)

--- a/search.go
+++ b/search.go
@@ -481,5 +481,8 @@ func (sr *SearchResult) Merge(other *SearchResult) {
 	if other.MaxScore > sr.MaxScore {
 		sr.MaxScore = other.MaxScore
 	}
+	if len(sr.Facets) == 0 {
+		sr.Facets = make(search.FacetResults)
+	}
 	sr.Facets.Merge(other.Facets)
 }

--- a/search.go
+++ b/search.go
@@ -481,8 +481,10 @@ func (sr *SearchResult) Merge(other *SearchResult) {
 	if other.MaxScore > sr.MaxScore {
 		sr.MaxScore = other.MaxScore
 	}
-	if len(sr.Facets) == 0 && len(other.Facets) != 0 {
-		sr.Facets = make(search.FacetResults)
+	if sr.Facets == nil && len(other.Facets) != 0 {
+		sr.Facets = other.Facets
+		return
 	}
+
 	sr.Facets.Merge(other.Facets)
 }


### PR DESCRIPTION
 Initialise the facet results map in case of an
 empty partial hits with a multi node cluster