### PR TITLE
scorch unlocks in introduceSegment's DocNumbers() error codepath

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -117,6 +117,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			var err error
 			delta, err = s.root.segment[i].segment.DocNumbers(next.ids)
 			if err != nil {
+				s.rootLock.Unlock()
 				next.applied <- fmt.Errorf("error computing doc numbers: %v", err)
 				close(next.applied)
 				_ = newSnapshot.DecRef()


### PR DESCRIPTION
Saw this while trying to debug concurrency issues with the WIP prototyping on "in-memory segments that use zap's optimized data representation".

I'm thinking this probably isn't the cause of the other concurrency issues that we're seeing, but pushing this up for correctness.
