### PR TITLE
in-memory segment representation using zap's optimized encoding

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -141,7 +141,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot) error {
 		filename := zapFileName(newSegmentID)
 		s.markIneligibleForRemoval(filename)
 		path := s.path + string(os.PathSeparator) + filename
-		newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024)
+		newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, DefaultChunkFactor)
 		if err != nil {
 			s.unmarkIneligibleForRemoval(filename)
 			return fmt.Errorf("merging failed: %v", err)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -54,7 +54,6 @@ OUTER:
 				lastEpochMergePlanned = ourSnapshot.epoch
 
 				s.fireEvent(EventKindMergerProgress, time.Since(startTime))
-
 			}
 			_ = ourSnapshot.DecRef()
 
@@ -81,6 +80,7 @@ OUTER:
 				// lets get started
 				err := s.planMergeAtSnapshot(ourSnapshot)
 				if err != nil {
+					s.fireAsyncError(fmt.Errorf("merging err: %v", err))
 					_ = ourSnapshot.DecRef()
 					continue OUTER
 				}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -28,10 +28,11 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index/scorch/segment"
-	"github.com/blevesearch/bleve/index/scorch/segment/mem"
 	"github.com/blevesearch/bleve/index/scorch/segment/zap"
 	"github.com/boltdb/bolt"
 )
+
+var DefaultChunkFactor uint32 = 1024
 
 type notificationChan chan struct{}
 
@@ -178,11 +179,11 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 			return err2
 		}
 		switch seg := segmentSnapshot.segment.(type) {
-		case *mem.Segment:
+		case *zap.SegmentBase:
 			// need to persist this to disk
 			filename := zapFileName(segmentSnapshot.id)
 			path := s.path + string(os.PathSeparator) + filename
-			err2 := zap.PersistSegment(seg, path, 1024)
+			err2 := zap.PersistSegmentBase(seg, path)
 			if err2 != nil {
 				return fmt.Errorf("error persisting segment: %v", err2)
 			}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -1395,7 +1395,7 @@ func TestConcurrentUpdate(t *testing.T) {
 
 	// do some concurrent updates
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func(i int) {
 			doc := document.NewDocument("1")

--- a/index/scorch/segment/mem/build.go
+++ b/index/scorch/segment/mem/build.go
@@ -267,15 +267,15 @@ func (s *Segment) processDocument(result *index.AnalysisResult) {
 }
 
 func (s *Segment) getOrDefineField(name string) int {
-	fieldID, ok := s.FieldsMap[name]
+	fieldIDPlus1, ok := s.FieldsMap[name]
 	if !ok {
-		fieldID = uint16(len(s.FieldsInv) + 1)
-		s.FieldsMap[name] = fieldID
+		fieldIDPlus1 = uint16(len(s.FieldsInv) + 1)
+		s.FieldsMap[name] = fieldIDPlus1
 		s.FieldsInv = append(s.FieldsInv, name)
 		s.Dicts = append(s.Dicts, make(map[string]uint64))
 		s.DictKeys = append(s.DictKeys, make([]string, 0))
 	}
-	return int(fieldID - 1)
+	return int(fieldIDPlus1 - 1)
 }
 
 func (s *Segment) addDocument() int {

--- a/index/scorch/segment/mem/segment.go
+++ b/index/scorch/segment/mem/segment.go
@@ -40,35 +40,38 @@ const idFieldID uint16 = 0
 // Segment is an in memory implementation of scorch.Segment
 type Segment struct {
 
-	// FieldsMap name -> id+1
+	// FieldsMap adds 1 to field id to avoid zero value issues
+	//  name -> field id + 1
 	FieldsMap map[string]uint16
-	// fields id -> name
+
+	// FieldsInv is the inverse of FieldsMap
+	//  field id -> name
 	FieldsInv []string
 
-	// term dictionary
+	// Term dictionaries for each field
 	//  field id -> term -> postings list id + 1
 	Dicts []map[string]uint64
 
-	// term dictionary keys
-	//  field id -> []dictionary keys
+	// Terms for each field, where terms are sorted ascending
+	//  field id -> []term
 	DictKeys [][]string
 
 	// Postings list
-	//  postings list id -> Postings bitmap
+	//  postings list id -> bitmap by docNum
 	Postings []*roaring.Bitmap
 
-	// Postings List has locations
+	// Postings list has locations
 	PostingsLocs []*roaring.Bitmap
 
-	// term frequencies
+	// Term frequencies
 	//  postings list id -> Freqs (one for each hit in bitmap)
 	Freqs [][]uint64
 
-	// field Norms
+	// Field norms
 	//  postings list id -> Norms (one for each hit in bitmap)
 	Norms [][]float32
 
-	// field/start/end/pos/locarraypos
+	// Field/start/end/pos/locarraypos
 	//  postings list id -> start/end/pos/locarraypos (one for each freq)
 	Locfields   [][]uint16
 	Locstarts   [][]uint64
@@ -80,18 +83,18 @@ type Segment struct {
 	//  docNum -> field id -> slice of values (each value []byte)
 	Stored []map[uint16][][]byte
 
-	// stored field types
+	// Stored field types
 	//  docNum -> field id -> slice of types (each type byte)
 	StoredTypes []map[uint16][]byte
 
-	// stored field array positions
+	// Stored field array positions
 	//  docNum -> field id -> slice of array positions (each is []uint64)
 	StoredPos []map[uint16][][]uint64
 
-	// for storing the docValue persisted fields
+	// For storing the docValue persisted fields
 	DocValueFields map[uint16]bool
 
-	// footprint of the segment, updated when analyzed document mutations
+	// Footprint of the segment, updated when analyzed document mutations
 	// are added into the segment
 	sizeInBytes uint64
 }

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -43,7 +43,7 @@ func PersistSegment(memSegment *mem.Segment, path string, chunkFactor uint32) (e
 		return err
 	}
 
-	// bufer the output
+	// buffer the output
 	br := bufio.NewWriter(f)
 
 	// wrap it for counting (tracking offsets)

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -421,11 +421,13 @@ func persistPostingDetails(memSegment *mem.Segment, w *CountHashWriter, chunkFac
 
 func persistPostingsLocs(memSegment *mem.Segment, w *CountHashWriter) (rv []uint64, err error) {
 	rv = make([]uint64, 0, len(memSegment.PostingsLocs))
+	var reuseBuf bytes.Buffer
+	reuseBufVarint := make([]byte, binary.MaxVarintLen64)
 	for postingID := range memSegment.PostingsLocs {
 		// record where we start this posting loc
 		rv = append(rv, uint64(w.Count()))
 		// write out the length and bitmap
-		_, err = writeRoaringWithLen(memSegment.PostingsLocs[postingID], w)
+		_, err = writeRoaringWithLen(memSegment.PostingsLocs[postingID], w, &reuseBuf, reuseBufVarint)
 		if err != nil {
 			return nil, err
 		}
@@ -436,6 +438,8 @@ func persistPostingsLocs(memSegment *mem.Segment, w *CountHashWriter) (rv []uint
 func persistPostingsLists(memSegment *mem.Segment, w *CountHashWriter,
 	postingsListLocs, freqOffsets, locOffsets []uint64) (rv []uint64, err error) {
 	rv = make([]uint64, 0, len(memSegment.Postings))
+	var reuseBuf bytes.Buffer
+	reuseBufVarint := make([]byte, binary.MaxVarintLen64)
 	for postingID := range memSegment.Postings {
 		// record where we start this posting list
 		rv = append(rv, uint64(w.Count()))
@@ -448,7 +452,7 @@ func persistPostingsLists(memSegment *mem.Segment, w *CountHashWriter,
 		}
 
 		// write out the length and bitmap
-		_, err = writeRoaringWithLen(memSegment.Postings[postingID], w)
+		_, err = writeRoaringWithLen(memSegment.Postings[postingID], w, &reuseBuf, reuseBufVarint)
 		if err != nil {
 			return nil, err
 		}

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -32,15 +32,69 @@ const version uint32 = 2
 
 const fieldNotUninverted = math.MaxUint64
 
-// PersistSegment takes the in-memory segment and persists it to the specified
-// path in the zap file format.
-func PersistSegment(memSegment *mem.Segment, path string, chunkFactor uint32) (err error) {
-
+// PersistSegmentBase persists SegmentBase in the zap file format.
+func PersistSegmentBase(sb *SegmentBase, path string) error {
 	flag := os.O_RDWR | os.O_CREATE
 
 	f, err := os.OpenFile(path, flag, 0600)
 	if err != nil {
 		return err
+	}
+
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(path)
+	}
+
+	br := bufio.NewWriter(f)
+
+	_, err = br.Write(sb.mem)
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	err = persistFooter(sb.numDocs, sb.storedIndexOffset, sb.fieldsIndexOffset, sb.docValueOffset,
+		sb.chunkFactor, sb.memCRC, br)
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	err = br.Flush()
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	err = f.Sync()
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	err = f.Close()
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	return nil
+}
+
+// PersistSegment takes the in-memory segment and persists it to
+// the specified path in the zap file format.
+func PersistSegment(memSegment *mem.Segment, path string, chunkFactor uint32) error {
+	flag := os.O_RDWR | os.O_CREATE
+
+	f, err := os.OpenFile(path, flag, 0600)
+	if err != nil {
+		return err
+	}
+
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(path)
 	}
 
 	// buffer the output
@@ -49,76 +103,87 @@ func PersistSegment(memSegment *mem.Segment, path string, chunkFactor uint32) (e
 	// wrap it for counting (tracking offsets)
 	cr := NewCountHashWriter(br)
 
-	var storedIndexOffset uint64
-	var dictLocs []uint64
-	docValueOffset := uint64(fieldNotUninverted)
-	if len(memSegment.Stored) > 0 {
-
-		storedIndexOffset, err = persistStored(memSegment, cr)
-		if err != nil {
-			return err
-		}
-
-		var freqOffsets, locOffsets []uint64
-		freqOffsets, locOffsets, err = persistPostingDetails(memSegment, cr, chunkFactor)
-		if err != nil {
-			return err
-		}
-
-		var postingsListLocs []uint64
-		postingsListLocs, err = persistPostingsLocs(memSegment, cr)
-		if err != nil {
-			return err
-		}
-
-		var postingsLocs []uint64
-		postingsLocs, err = persistPostingsLists(memSegment, cr, postingsListLocs, freqOffsets, locOffsets)
-		if err != nil {
-			return err
-		}
-
-		dictLocs, err = persistDictionary(memSegment, cr, postingsLocs)
-		if err != nil {
-			return err
-		}
-
-		docValueOffset, err = persistFieldDocValues(cr, chunkFactor, memSegment)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		dictLocs = make([]uint64, len(memSegment.FieldsInv))
-	}
-
-	var fieldIndexStart uint64
-	fieldIndexStart, err = persistFields(memSegment.FieldsInv, cr, dictLocs)
+	numDocs, storedIndexOffset, fieldsIndexOffset, docValueOffset, _, err :=
+		persistBase(memSegment, cr, chunkFactor)
 	if err != nil {
+		cleanup()
 		return err
 	}
 
-	err = persistFooter(uint64(len(memSegment.Stored)), storedIndexOffset,
-		fieldIndexStart, docValueOffset, chunkFactor, cr)
+	err = persistFooter(numDocs, storedIndexOffset, fieldsIndexOffset, docValueOffset,
+		chunkFactor, cr.Sum32(), cr)
 	if err != nil {
+		cleanup()
 		return err
 	}
 
 	err = br.Flush()
 	if err != nil {
+		cleanup()
 		return err
 	}
 
 	err = f.Sync()
 	if err != nil {
+		cleanup()
 		return err
 	}
 
 	err = f.Close()
 	if err != nil {
+		cleanup()
 		return err
 	}
 
 	return nil
+}
+
+func persistBase(memSegment *mem.Segment, cr *CountHashWriter, chunkFactor uint32) (
+	numDocs, storedIndexOffset, fieldsIndexOffset, docValueOffset uint64,
+	dictLocs []uint64, err error) {
+	docValueOffset = uint64(fieldNotUninverted)
+
+	if len(memSegment.Stored) > 0 {
+		storedIndexOffset, err = persistStored(memSegment, cr)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+
+		freqOffsets, locOffsets, err := persistPostingDetails(memSegment, cr, chunkFactor)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+
+		postingsListLocs, err := persistPostingsLocs(memSegment, cr)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+
+		postingsLocs, err := persistPostingsLists(memSegment, cr, postingsListLocs, freqOffsets, locOffsets)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+
+		dictLocs, err = persistDictionary(memSegment, cr, postingsLocs)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+
+		docValueOffset, err = persistFieldDocValues(memSegment, cr, chunkFactor)
+		if err != nil {
+			return 0, 0, 0, 0, nil, err
+		}
+	} else {
+		dictLocs = make([]uint64, len(memSegment.FieldsInv))
+	}
+
+	fieldsIndexOffset, err = persistFields(memSegment.FieldsInv, cr, dictLocs)
+	if err != nil {
+		return 0, 0, 0, 0, nil, err
+	}
+
+	return uint64(len(memSegment.Stored)), storedIndexOffset, fieldsIndexOffset, docValueOffset,
+		dictLocs, nil
 }
 
 func persistStored(memSegment *mem.Segment, w *CountHashWriter) (uint64, error) {
@@ -394,6 +459,8 @@ func persistPostingsLists(memSegment *mem.Segment, w *CountHashWriter,
 func persistDictionary(memSegment *mem.Segment, w *CountHashWriter, postingsLocs []uint64) ([]uint64, error) {
 	rv := make([]uint64, 0, len(memSegment.DictKeys))
 
+	varintBuf := make([]byte, binary.MaxVarintLen64)
+
 	var buffer bytes.Buffer
 	for fieldID, fieldTerms := range memSegment.DictKeys {
 		if fieldID != 0 {
@@ -427,10 +494,8 @@ func persistDictionary(memSegment *mem.Segment, w *CountHashWriter, postingsLocs
 		vellumData := buffer.Bytes()
 
 		// write out the length of the vellum data
-		buf := make([]byte, binary.MaxVarintLen64)
-		// write out the number of chunks
-		n := binary.PutUvarint(buf, uint64(len(vellumData)))
-		_, err = w.Write(buf[:n])
+		n := binary.PutUvarint(varintBuf, uint64(len(vellumData)))
+		_, err = w.Write(varintBuf[:n])
 		if err != nil {
 			return nil, err
 		}
@@ -521,9 +586,8 @@ func persistDocValues(memSegment *mem.Segment, w *CountHashWriter,
 	return fieldChunkOffsets, nil
 }
 
-func persistFieldDocValues(w *CountHashWriter, chunkFactor uint32,
-	memSegment *mem.Segment) (uint64, error) {
-
+func persistFieldDocValues(memSegment *mem.Segment, w *CountHashWriter,
+	chunkFactor uint32) (uint64, error) {
 	fieldDvOffsets, err := persistDocValues(memSegment, w, chunkFactor)
 	if err != nil {
 		return 0, err
@@ -547,4 +611,37 @@ func persistFieldDocValues(w *CountHashWriter, chunkFactor uint32,
 	}
 
 	return fieldDocValuesOffset, nil
+}
+
+func NewSegmentBase(memSegment *mem.Segment, chunkFactor uint32) (*SegmentBase, error) {
+	var br bytes.Buffer
+
+	cr := NewCountHashWriter(&br)
+
+	numDocs, storedIndexOffset, fieldsIndexOffset, docValueOffset, dictLocs, err :=
+		persistBase(memSegment, cr, chunkFactor)
+	if err != nil {
+		return nil, err
+	}
+
+	sb := &SegmentBase{
+		mem:               br.Bytes(),
+		memCRC:            cr.Sum32(),
+		chunkFactor:       chunkFactor,
+		fieldsMap:         memSegment.FieldsMap,
+		fieldsInv:         memSegment.FieldsInv,
+		numDocs:           numDocs,
+		storedIndexOffset: storedIndexOffset,
+		fieldsIndexOffset: fieldsIndexOffset,
+		docValueOffset:    docValueOffset,
+		dictLocs:          dictLocs,
+		fieldDvIterMap:    make(map[uint16]*docValueIterator),
+	}
+
+	err = sb.loadDvIterators()
+	if err != nil {
+		return nil, err
+	}
+
+	return sb, nil
 }

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -35,10 +35,10 @@ type Dictionary struct {
 
 // PostingsList returns the postings list for the specified term
 func (d *Dictionary) PostingsList(term string, except *roaring.Bitmap) (segment.PostingsList, error) {
-	return d.postingsList(term, except)
+	return d.postingsList([]byte(term), except)
 }
 
-func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*PostingsList, error) {
+func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap) (*PostingsList, error) {
 	rv := &PostingsList{
 		sb:     d.sb,
 		term:   term,
@@ -46,7 +46,7 @@ func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*Posting
 	}
 
 	if d.fst != nil {
-		postingsOffset, exists, err := d.fst.Get([]byte(term))
+		postingsOffset, exists, err := d.fst.Get(term)
 		if err != nil {
 			return nil, fmt.Errorf("vellum err: %v", err)
 		}
@@ -96,7 +96,6 @@ func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*Posting
 
 // Iterator returns an iterator for this dictionary
 func (d *Dictionary) Iterator() segment.DictionaryIterator {
-
 	rv := &DictionaryIterator{
 		d: d,
 	}

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -27,7 +27,7 @@ import (
 
 // Dictionary is the zap representation of the term dictionary
 type Dictionary struct {
-	segment *Segment
+	sb      *SegmentBase
 	field   string
 	fieldID uint16
 	fst     *vellum.FST
@@ -40,9 +40,9 @@ func (d *Dictionary) PostingsList(term string, except *roaring.Bitmap) (segment.
 
 func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*PostingsList, error) {
 	rv := &PostingsList{
-		dictionary: d,
-		term:       term,
-		except:     except,
+		sb:     d.sb,
+		term:   term,
+		except: except,
 	}
 
 	if d.fst != nil {
@@ -56,19 +56,19 @@ func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*Posting
 			var n uint64
 			var read int
 
-			rv.freqOffset, read = binary.Uvarint(d.segment.mm[postingsOffset+n : postingsOffset+binary.MaxVarintLen64])
+			rv.freqOffset, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+binary.MaxVarintLen64])
 			n += uint64(read)
-			rv.locOffset, read = binary.Uvarint(d.segment.mm[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
+			rv.locOffset, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
 			n += uint64(read)
 
 			var locBitmapOffset uint64
-			locBitmapOffset, read = binary.Uvarint(d.segment.mm[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
+			locBitmapOffset, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
 			n += uint64(read)
 
 			// go ahead and load loc bitmap
 			var locBitmapLen uint64
-			locBitmapLen, read = binary.Uvarint(d.segment.mm[locBitmapOffset : locBitmapOffset+binary.MaxVarintLen64])
-			locRoaringBytes := d.segment.mm[locBitmapOffset+uint64(read) : locBitmapOffset+uint64(read)+locBitmapLen]
+			locBitmapLen, read = binary.Uvarint(d.sb.mem[locBitmapOffset : locBitmapOffset+binary.MaxVarintLen64])
+			locRoaringBytes := d.sb.mem[locBitmapOffset+uint64(read) : locBitmapOffset+uint64(read)+locBitmapLen]
 			rv.locBitmap = roaring.NewBitmap()
 			_, err := rv.locBitmap.FromBuffer(locRoaringBytes)
 			if err != nil {
@@ -76,10 +76,10 @@ func (d *Dictionary) postingsList(term string, except *roaring.Bitmap) (*Posting
 			}
 
 			var postingsLen uint64
-			postingsLen, read = binary.Uvarint(d.segment.mm[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
+			postingsLen, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
 			n += uint64(read)
 
-			roaringBytes := d.segment.mm[postingsOffset+n : postingsOffset+n+postingsLen]
+			roaringBytes := d.sb.mem[postingsOffset+n : postingsOffset+n+postingsLen]
 
 			bitmap := roaring.NewBitmap()
 			_, err = bitmap.FromBuffer(roaringBytes)

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -65,7 +65,7 @@ func (s *Segment) loadFieldDocValueIterator(field string,
 	fieldDvLoc uint64) (*docValueIterator, error) {
 	// get the docValue offset for the given fields
 	if fieldDvLoc == fieldNotUninverted {
-		return nil, fmt.Errorf("loadFieldDocValueConfigs: "+
+		return nil, fmt.Errorf("loadFieldDocValueIterator: "+
 			"no docValues found for field: %s", field)
 	}
 

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -129,6 +129,7 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 	newSegDocCount uint64, chunkFactor uint32,
 	w *CountHashWriter) ([]uint64, uint64, error) {
 
+	var bufReuse bytes.Buffer
 	var bufMaxVarintLen64 []byte = make([]byte, binary.MaxVarintLen64)
 	var bufLoc []uint64
 
@@ -258,7 +259,7 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 					return nil, 0, err
 				}
 				postingLocOffset := uint64(w.Count())
-				_, err = writeRoaringWithLen(newRoaringLocs, w)
+				_, err = writeRoaringWithLen(newRoaringLocs, w, &bufReuse, bufMaxVarintLen64)
 				if err != nil {
 					return nil, 0, err
 				}
@@ -284,7 +285,7 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 				if err != nil {
 					return nil, 0, err
 				}
-				_, err = writeRoaringWithLen(newRoaring, w)
+				_, err = writeRoaringWithLen(newRoaring, w, &bufReuse, bufMaxVarintLen64)
 				if err != nil {
 					return nil, 0, err
 				}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -150,6 +150,8 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 	fieldDvLocs := make([]uint64, len(fieldsInv))
 	fieldDvLocsOffset := uint64(fieldNotUninverted)
 
+	var docNumbers docIDRange
+
 	var vellumBuf bytes.Buffer
 
 	// for each field
@@ -343,7 +345,10 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 		rv[fieldID] = dictOffset
 
 		// update the doc nums
-		docNumbers := make(docIDRange, 0, len(docTermMap))
+		if cap(docNumbers) < len(docTermMap) {
+			docNumbers = make(docIDRange, 0, len(docTermMap))
+		}
+		docNumbers = docNumbers[:0]
 		for k := range docTermMap {
 			docNumbers = append(docNumbers, k)
 		}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -72,14 +72,13 @@ func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
 		dictLocs = make([]uint64, len(fieldsInv))
 	}
 
-	var fieldsIndexOffset uint64
-	fieldsIndexOffset, err = persistFields(fieldsInv, cr, dictLocs)
+	fieldsIndexOffset, err := persistFields(fieldsInv, cr, dictLocs)
 	if err != nil {
 		return nil, err
 	}
 
 	err = persistFooter(newSegDocCount, storedIndexOffset,
-		fieldsIndexOffset, fieldDvLocsOffset, chunkFactor, cr)
+		fieldsIndexOffset, fieldDvLocsOffset, chunkFactor, cr.Sum32(), cr)
 	if err != nil {
 		return nil, err
 	}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -126,15 +126,14 @@ func mapFields(fields []string) map[string]uint16 {
 // computeNewDocCount determines how many documents will be in the newly
 // merged segment when obsoleted docs are dropped
 func computeNewDocCount(segments []*Segment, drops []*roaring.Bitmap) uint64 {
-	var newSegDocCount uint64
+	var newDocCount uint64
 	for segI, segment := range segments {
-		segIAfterDrop := segment.NumDocs()
+		newDocCount += segment.NumDocs()
 		if drops[segI] != nil {
-			segIAfterDrop -= drops[segI].GetCardinality()
+			newDocCount -= drops[segI].GetCardinality()
 		}
-		newSegDocCount += segIAfterDrop
 	}
-	return newSegDocCount
+	return newDocCount
 }
 
 func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -206,7 +206,7 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 				if dict == nil {
 					continue
 				}
-				postings, err2 := dict.postingsList(string(term), drops[dictI])
+				postings, err2 := dict.postingsList(term, drops[dictI])
 				if err2 != nil {
 					return nil, 0, err2
 				}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -247,7 +247,7 @@ func persistMergedRest(segments []*Segment, drops []*roaring.Bitmap,
 						}
 					}
 
-					docTermMap[hitNewDocNum] = append(docTermMap[hitNewDocNum], []byte(term)...)
+					docTermMap[hitNewDocNum] = append(docTermMap[hitNewDocNum], term...)
 					docTermMap[hitNewDocNum] = append(docTermMap[hitNewDocNum], termSeparator)
 					next, err2 = postItr.Next()
 				}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -390,6 +390,8 @@ func mergeStoredAndRemap(segments []*Segment, drops []*roaring.Bitmap,
 	var metaBuf bytes.Buffer
 	var data, compressed []byte
 
+	metaEncoder := govarint.NewU64Base128Encoder(&metaBuf)
+
 	vals := make([][][]byte, len(fieldsInv))
 	typs := make([][]byte, len(fieldsInv))
 	poss := make([][][]uint64, len(fieldsInv))
@@ -406,8 +408,6 @@ func mergeStoredAndRemap(segments []*Segment, drops []*roaring.Bitmap,
 			data = data[:0]
 			compressed = compressed[:0]
 			curr = 0
-
-			metaEncoder := govarint.NewU64Base128Encoder(&metaBuf)
 
 			if drops[segI] != nil && drops[segI].Contains(uint32(docNum)) {
 				segNewDocNums = append(segNewDocNums, docDropped)

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -28,7 +28,7 @@ import (
 // PostingsList is an in-memory represenation of a postings list
 type PostingsList struct {
 	sb             *SegmentBase
-	term           string
+	term           []byte
 	postingsOffset uint64
 	freqOffset     uint64
 	locOffset      uint64

--- a/index/scorch/segment/zap/read.go
+++ b/index/scorch/segment/zap/read.go
@@ -16,16 +16,16 @@ package zap
 
 import "encoding/binary"
 
-func (s *Segment) getStoredMetaAndCompressed(docNum uint64) ([]byte, []byte) {
+func (s *SegmentBase) getDocStoredMetaAndCompressed(docNum uint64) ([]byte, []byte) {
 	docStoredStartAddr := s.storedIndexOffset + (8 * docNum)
-	docStoredStart := binary.BigEndian.Uint64(s.mm[docStoredStartAddr : docStoredStartAddr+8])
+	docStoredStart := binary.BigEndian.Uint64(s.mem[docStoredStartAddr : docStoredStartAddr+8])
 	var n uint64
-	metaLen, read := binary.Uvarint(s.mm[docStoredStart : docStoredStart+binary.MaxVarintLen64])
+	metaLen, read := binary.Uvarint(s.mem[docStoredStart : docStoredStart+binary.MaxVarintLen64])
 	n += uint64(read)
 	var dataLen uint64
-	dataLen, read = binary.Uvarint(s.mm[docStoredStart+n : docStoredStart+n+binary.MaxVarintLen64])
+	dataLen, read = binary.Uvarint(s.mem[docStoredStart+n : docStoredStart+n+binary.MaxVarintLen64])
 	n += uint64(read)
-	meta := s.mm[docStoredStart+n : docStoredStart+n+metaLen]
-	data := s.mm[docStoredStart+n+metaLen : docStoredStart+n+metaLen+dataLen]
+	meta := s.mem[docStoredStart+n : docStoredStart+n+metaLen]
+	data := s.mem[docStoredStart+n+metaLen : docStoredStart+n+metaLen+dataLen]
 	return meta, data
 }

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -344,7 +344,7 @@ func (s *SegmentBase) DocNumbers(ids []string) (*roaring.Bitmap, error) {
 		}
 
 		for _, id := range ids {
-			postings, err := idDict.postingsList(id, nil)
+			postings, err := idDict.postingsList([]byte(id), nil)
 			if err != nil {
 				return nil, err
 			}

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -168,11 +168,13 @@ func (s *Segment) loadConfig() error {
 
 	docValueOffset := chunkOffset - 8
 	s.docValueOffset = binary.BigEndian.Uint64(s.mm[docValueOffset : docValueOffset+8])
-	fieldsOffset := docValueOffset - 8
 
+	fieldsOffset := docValueOffset - 8
 	s.fieldsIndexOffset = binary.BigEndian.Uint64(s.mm[fieldsOffset : fieldsOffset+8])
+
 	storedOffset := fieldsOffset - 8
 	s.storedIndexOffset = binary.BigEndian.Uint64(s.mm[storedOffset : storedOffset+8])
+
 	docNumOffset := storedOffset - 8
 	s.numDocs = binary.BigEndian.Uint64(s.mm[docNumOffset : docNumOffset+8])
 	return nil
@@ -181,7 +183,7 @@ func (s *Segment) loadConfig() error {
 
 func (s *Segment) loadFields() error {
 	// NOTE for now we assume the fields index immediately preceeds the footer
-	// if this changes, need to adjust accordingly (or store epxlicit length)
+	// if this changes, need to adjust accordingly (or store explicit length)
 	fieldsIndexEnd := uint64(len(s.mm) - FooterSize)
 
 	// iterate through fields index

--- a/index/scorch/segment/zap/write.go
+++ b/index/scorch/segment/zap/write.go
@@ -53,12 +53,11 @@ func writeRoaringWithLen(r *roaring.Bitmap, w io.Writer) (int, error) {
 
 func persistFields(fieldsInv []string, w *CountHashWriter, dictLocs []uint64) (uint64, error) {
 	var rv uint64
+	var fieldsOffsets []uint64
 
-	var fieldStarts []uint64
 	for fieldID, fieldName := range fieldsInv {
-
 		// record start of this field
-		fieldStarts = append(fieldStarts, uint64(w.Count()))
+		fieldsOffsets = append(fieldsOffsets, uint64(w.Count()))
 
 		// write out the dict location and field name length
 		_, err := writeUvarints(w, dictLocs[fieldID], uint64(len(fieldName)))
@@ -76,7 +75,7 @@ func persistFields(fieldsInv []string, w *CountHashWriter, dictLocs []uint64) (u
 	// now write out the fields index
 	rv = uint64(w.Count())
 	for fieldID := range fieldsInv {
-		err := binary.Write(w, binary.BigEndian, fieldStarts[fieldID])
+		err := binary.Write(w, binary.BigEndian, fieldsOffsets[fieldID])
 		if err != nil {
 			return 0, err
 		}
@@ -89,8 +88,11 @@ func persistFields(fieldsInv []string, w *CountHashWriter, dictLocs []uint64) (u
 // crc + ver + chunk + field offset + stored offset + num docs + docValueOffset
 const FooterSize = 4 + 4 + 4 + 8 + 8 + 8 + 8
 
-func persistFooter(numDocs, storedIndexOffset, fieldIndexOffset, docValueOffset uint64,
-	chunkFactor uint32, w *CountHashWriter) error {
+func persistFooter(numDocs, storedIndexOffset, fieldsIndexOffset, docValueOffset uint64,
+	chunkFactor uint32, crcBeforeFooter uint32, writerIn io.Writer) error {
+	w := NewCountHashWriter(writerIn)
+	w.crc = crcBeforeFooter
+
 	// write out the number of docs
 	err := binary.Write(w, binary.BigEndian, numDocs)
 	if err != nil {
@@ -102,7 +104,7 @@ func persistFooter(numDocs, storedIndexOffset, fieldIndexOffset, docValueOffset 
 		return err
 	}
 	// write out the field index location
-	err = binary.Write(w, binary.BigEndian, fieldIndexOffset)
+	err = binary.Write(w, binary.BigEndian, fieldsIndexOffset)
 	if err != nil {
 		return err
 	}
@@ -122,7 +124,7 @@ func persistFooter(numDocs, storedIndexOffset, fieldIndexOffset, docValueOffset 
 		return err
 	}
 	// write out CRC-32 of everything upto but not including this CRC
-	err = binary.Write(w, binary.BigEndian, w.Sum32())
+	err = binary.Write(w, binary.BigEndian, w.crc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A new struct, a zap.SegmentBase, is refactored out that has all the read-only, in-memory fields of a zap.Segment.  A zap.Segment struct now embeds a zap.SegmentBase and layers on persistence.  Both the zap Segment and zap SegmentBase implement the scorch Segment interface.