### PR TITLE
MB-26396: Handling docs with geopoints in slice format

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -504,7 +504,7 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 			}
 			dm.walkDocument(property, path, indexes, context)
 		}
-	case reflect.Map:
+	case reflect.Map, reflect.Slice:
 		if subDocMapping != nil {
 			for _, fieldMapping := range subDocMapping.Fields {
 				if fieldMapping.Type == "geopoint" {


### PR DESCRIPTION
This handles the missing case for a geopoint when the
coordinates are in a slice format.