### PR TITLE
FuzzyResult scoring driven by the edit distance

### DIFF
--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -21,12 +21,20 @@ import (
 )
 
 type DisjunctionQueryScorer struct {
-	options search.SearcherOptions
+	options    search.SearcherOptions
+	scoreFuzzy bool
 }
 
 func NewDisjunctionQueryScorer(options search.SearcherOptions) *DisjunctionQueryScorer {
 	return &DisjunctionQueryScorer{
 		options: options,
+	}
+}
+
+func NewDisjunctionFuzzyQueryScorer(scoreFuzzy bool, options search.SearcherOptions) *DisjunctionQueryScorer {
+	return &DisjunctionQueryScorer{
+		options:    options,
+		scoreFuzzy: scoreFuzzy,
 	}
 }
 
@@ -54,7 +62,11 @@ func (s *DisjunctionQueryScorer) Score(ctx *search.SearchContext, constituents [
 	}
 
 	coord := float64(countMatch) / float64(countTotal)
-	newScore := sum * coord
+	newScore := sum
+	if !s.scoreFuzzy {
+		newScore *= coord
+	}
+
 	var newExpl *search.Explanation
 	if s.options.Explain {
 		ce := make([]*search.Explanation, 2)

--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -15,6 +15,8 @@
 package searcher
 
 import (
+	"math"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
 )
@@ -40,7 +42,61 @@ func NewMultiTermSearcher(indexReader index.IndexReader, terms []string,
 	}
 	// build disjunction searcher of these ranges
 	return newMultiTermSearcherBytes(indexReader, qsearchers, field, boost,
-		options, limit)
+		options, limit, false)
+}
+
+func NewFuzzyMultiTermSearcher(indexReader index.IndexReader, terms []candidateTerm,
+	field string, boost float64, options search.SearcherOptions, limit bool) (
+	search.Searcher, error) {
+	qsearchers := make([]search.Searcher, len(terms))
+	qsearchersClose := func() {
+		for _, searcher := range qsearchers {
+			if searcher != nil {
+				_ = searcher.Close()
+			}
+		}
+	}
+
+	// compute the aggregated doc freq and total doc count
+	// to normalise the idf factor against the edit distance
+	df := float64(0)
+	tfrs := make([]index.TermFieldReader, len(terms))
+	for i, term := range terms {
+		reader, err := indexReader.TermFieldReader([]byte(term.term), field,
+			true, true, options.IncludeTermVectors)
+		if err != nil {
+			return nil, err
+		}
+
+		tfrs[i] = reader
+		df = math.Max(float64(reader.Count()), df)
+	}
+
+	docCount, err := indexReader.DocCount()
+	if err != nil {
+		return nil, err
+	}
+
+	// apply fuzzy boost based on edit distance
+	edBoost := 0.0
+	for i, term := range terms {
+		if term.ed == 0 {
+			edBoost = 1
+		} else {
+			edBoost = 1 - float64(term.ed)/float64(len(term.term))
+		}
+
+		qsearchers[i], err = NewTermSearcherWithTermFieldDetails(indexReader, tfrs[i],
+			term.term, field, boost*edBoost, docCount, uint64(df), options)
+		if err != nil {
+			qsearchersClose()
+			return nil, err
+		}
+	}
+
+	// build disjunction searcher of these ranges
+	return newMultiTermSearcherBytes(indexReader, qsearchers, field, boost,
+		options, limit, true)
 }
 
 func NewMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byte,
@@ -63,17 +119,17 @@ func NewMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byte,
 		}
 	}
 	return newMultiTermSearcherBytes(indexReader, qsearchers, field, boost,
-		options, limit)
+		options, limit, false)
 }
 
 func newMultiTermSearcherBytes(indexReader index.IndexReader,
 	searchers []search.Searcher, field string, boost float64,
-	options search.SearcherOptions, limit bool) (
+	options search.SearcherOptions, limit, fuzzyQuery bool) (
 	search.Searcher, error) {
 
 	// build disjunction searcher of these ranges
 	searcher, err := newDisjunctionSearcher(indexReader, searchers, 0, options,
-		limit)
+		limit, fuzzyQuery)
 	if err != nil {
 		for _, s := range searchers {
 			_ = s.Close()

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -63,6 +63,17 @@ func NewTermSearcherBytes(indexReader index.IndexReader, term []byte, field stri
 	}, nil
 }
 
+func NewTermSearcherWithTermFieldDetails(indexReader index.IndexReader, tfr index.TermFieldReader,
+	term string, field string, boost float64, docTotal, docTerm uint64,
+	options search.SearcherOptions) (*TermSearcher, error) {
+	scorer := scorer.NewTermQueryScorer([]byte(term), field, boost, docTotal, docTerm, options)
+	return &TermSearcher{
+		indexReader: indexReader,
+		reader:      tfr,
+		scorer:      scorer,
+	}, nil
+}
+
 func (s *TermSearcher) Count() uint64 {
 	return s.reader.Count()
 }

--- a/test/tests/fuzzy/data/a.json
+++ b/test/tests/fuzzy/data/a.json
@@ -1,0 +1,7 @@
+{
+	"id": "a",
+	"name": "blevescorch",
+	"age": 19,
+	"title": "mista",
+	"tags": ["gopher", "belieber"]
+}

--- a/test/tests/fuzzy/data/b.json
+++ b/test/tests/fuzzy/data/b.json
@@ -1,0 +1,7 @@
+{
+	"id": "b",
+	"name": "steve",
+	"age": 19,
+	"title": "mista",
+	"tags": ["gopher", "belieber"]
+}

--- a/test/tests/fuzzy/data/c.json
+++ b/test/tests/fuzzy/data/c.json
@@ -1,0 +1,7 @@
+{
+	"id": "c",
+	"name": "sree scorch",
+	"age": 33,
+	"title": "mr",
+	"tags": ["apple", "cherry"]
+}

--- a/test/tests/fuzzy/data/d.json
+++ b/test/tests/fuzzy/data/d.json
@@ -1,0 +1,7 @@
+{
+	"id": "d",
+	"name": "blevescorch",
+	"age": 44,
+	"title": "mista",
+	"tags": ["gopher", "belieber"]
+}

--- a/test/tests/fuzzy/data/e.json
+++ b/test/tests/fuzzy/data/e.json
@@ -1,0 +1,7 @@
+{
+	"id": "e",
+	"name": "ticker",
+	"age": 33,
+	"title": "mr",
+	"tags": ["apple", "cherry"]
+}

--- a/test/tests/fuzzy/data/f.json
+++ b/test/tests/fuzzy/data/f.json
@@ -1,0 +1,7 @@
+{
+	"id": "f",
+	"name": "picker",
+	"age": 33,
+	"title": "mr",
+	"tags": ["apple", "cherry"]
+}

--- a/test/tests/fuzzy/data/g.json
+++ b/test/tests/fuzzy/data/g.json
@@ -1,0 +1,7 @@
+{
+	"id": "g",
+	"name": "mocker",
+	"age": 33,
+	"title": "mr",
+	"tags": ["apple", "cherry"]
+}

--- a/test/tests/fuzzy/data/h.json
+++ b/test/tests/fuzzy/data/h.json
@@ -1,0 +1,7 @@
+{
+	"id": "h",
+	"name": "soccer",
+	"age": 33,
+	"title": "mr",
+	"tags": ["apple", "cherry"]
+}

--- a/test/tests/fuzzy/mapping.json
+++ b/test/tests/fuzzy/mapping.json
@@ -1,0 +1,27 @@
+{
+  "types": {
+    "person": {
+      "properties": {
+        "name": {
+          "fields": [
+            {
+              "include_term_vectors": true,
+              "include_in_all": true,
+              "index": true,
+              "store": true,
+              "analyzer": "en",
+              "type": "text"
+            }
+          ],
+          "dynamic": true,
+          "enabled": true
+        },
+        "id": {
+          "dynamic": false,
+          "enabled": false
+        }
+      }
+    }
+  },
+  "default_type": "person"
+}

--- a/test/tests/fuzzy/searches.json
+++ b/test/tests/fuzzy/searches.json
@@ -1,0 +1,168 @@
+[
+
+    {
+		"comment": "test boost",
+		"search": {
+			"from": 0,
+			"size": 10,
+			"query": {
+				"disjuncts": [
+					{
+						"field": "name",
+						"term": "blevescore",
+						"boost": 1.0
+					},
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "steve",
+						"boost": 5.0
+					}
+				]
+			}
+		},
+		"result": {
+			"total_hits": 1,
+			"hits": [
+				{
+					"id": "b"
+				}
+			]
+		}
+	},
+	{
+		"comment": "test boost with fuzziness",
+		"search": {
+			"from": 0,
+			"size": 10,
+			"query": {
+				"disjuncts": [
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "blevescorc",
+						"boost": 1.0
+					},
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "steven",
+						"boost": 3.0
+					}
+				]
+			}
+		},
+		"result": {
+			"total_hits": 3,
+			"hits": [
+				{
+					"id": "b"
+				},
+				{
+					"id": "a"
+				},
+                {
+					"id": "d"
+				}
+			]
+		}
+	},
+
+     {
+		"comment": "test fuzziness rank with idf",
+		"search": {
+			"from": 0,
+			"size": 10,
+			"query": {
+				"disjuncts": [
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "levescorch"
+					},
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "steven"
+					}
+				]
+			}
+		},
+		"result": {
+			"total_hits": 3,
+			"hits": [
+				{
+					"id": "b"
+				},
+                {
+					"id": "a"
+				},
+                {
+					"id": "d"
+				}
+			]
+		}
+	},
+	 {
+		"comment": "test fuzziness rank with term norm",
+		"search": {
+			"from": 0,
+			"size": 10,
+			"query": {
+				"disjuncts": [
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "stefe"
+					},
+					{
+						"fuzziness": 1,
+						"field": "name",
+						"term": "sre"
+					}
+				]
+			}
+		},
+		"result": {
+			"total_hits": 2,
+			"hits": [
+                {
+					"id": "b"
+				},
+                {
+					"id": "c"
+				}
+			]
+		}
+	},
+
+	{
+		"comment": "test fuzziness rank",
+		"search": {
+			"from": 0,
+			"size": 10,
+			"query": {
+						"fuzziness": 3,
+						"field": "name",
+						"term": "kicker"
+					}				
+		},
+		"result": {
+			"total_hits": 4,
+			"hits": [
+                {
+					"id": "e"
+				},
+                {
+					"id": "f"
+				},
+                {
+					"id": "g"
+				},
+                {
+					"id": "h"
+				}
+			]
+		}
+	}
+]


### PR DESCRIPTION
Scoring logic changed to accomodate the edit distance
for the fuzzy query results, so that the exact matches
should rank higher than the other near similar terms.
FuzzyQuery is rewritten as a set of TermQueries that
share a common document frequency of the maximum
document frequency found.
The original boost is multiplied by an edit distance
based boost.
Query coordinate factor is ignored for a fuzzy query.