### PR TITLE
scorch zap merge related refactorings / optimizations

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -588,7 +588,7 @@ func persistDocValues(memSegment *mem.Segment, w *CountHashWriter,
 		if err != nil {
 			return nil, err
 		}
-		// resetting encoder for the next field
+		// reseting encoder for the next field
 		fdvEncoder.Reset()
 	}
 

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -456,6 +456,9 @@ func mergeStoredAndRemap(segments []*Segment, drops []*roaring.Bitmap,
 				// has stored values for this field
 				num := len(storedFieldValues)
 
+				stf := typs[int(fieldID)]
+				spf := poss[int(fieldID)]
+
 				// process each value
 				for i := 0; i < num; i++ {
 					// encode field
@@ -464,7 +467,7 @@ func mergeStoredAndRemap(segments []*Segment, drops []*roaring.Bitmap,
 						return 0, nil, err2
 					}
 					// encode type
-					_, err2 = metaEncoder.PutU64(uint64(typs[int(fieldID)][i]))
+					_, err2 = metaEncoder.PutU64(uint64(stf[i]))
 					if err2 != nil {
 						return 0, nil, err2
 					}
@@ -479,13 +482,13 @@ func mergeStoredAndRemap(segments []*Segment, drops []*roaring.Bitmap,
 						return 0, nil, err2
 					}
 					// encode number of array pos
-					_, err2 = metaEncoder.PutU64(uint64(len(poss[int(fieldID)][i])))
+					_, err2 = metaEncoder.PutU64(uint64(len(spf[i])))
 					if err2 != nil {
 						return 0, nil, err2
 					}
 					// encode all array positions
-					for j := 0; j < len(poss[int(fieldID)][i]); j++ {
-						_, err2 = metaEncoder.PutU64(poss[int(fieldID)][i][j])
+					for _, pos := range spf[i] {
+						_, err2 = metaEncoder.PutU64(pos)
 						if err2 != nil {
 							return 0, nil, err2
 						}


### PR DESCRIPTION
Most of this PR is about "mechanical" refactoring -- e.g., refactoring out a helper function to remove code duplication -- and, as steps towards in-memory segment merging.

But, special note should be taken of the change that reduces the read-lock area in prepareSegment(), which seems correct to me, but perhaps @mshoch will see subtleties that escape me.