### PR TITLE
unblock the files for clean up, esp for merged new segment files

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -266,9 +266,7 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 		for k, v := range s.root.internal {
 			newIndexSnapshot.internal[k] = v
 		}
-		for _, filename := range filenames {
-			delete(s.ineligibleForRemoval, filename)
-		}
+
 		rootPrev := s.root
 		s.root = newIndexSnapshot
 		s.rootLock.Unlock()
@@ -276,6 +274,12 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 			_ = rootPrev.DecRef()
 		}
 	}
+	// unlock the files for clean up
+	s.rootLock.Lock()
+	for _, filename := range filenames {
+		delete(s.ineligibleForRemoval, filename)
+	}
+	s.rootLock.Unlock()
 
 	return nil
 }

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -274,7 +274,7 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 			_ = rootPrev.DecRef()
 		}
 	}
-	// unlock the files for clean up
+	// allow files to become eligible for removal
 	s.rootLock.Lock()
 	for _, filename := range filenames {
 		delete(s.ineligibleForRemoval, filename)


### PR DESCRIPTION
Making the unblock outside the loop to ensure that it covers all the cases like only merged segments and the usual mix of both mem & zap segments.