### PR TITLE
Fix for keeping the number of merge tasks within the calculated budget

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -186,8 +186,7 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 
 	// While we’re over budget, keep looping, which might produce
 	// another MergeTask.
-	newlyMerged := int(0)
-	for (len(eligibles) + newlyMerged) > budgetNumSegments {
+	for len(eligibles) > 0 && (len(eligibles)+len(rv.Tasks)) > budgetNumSegments {
 		// Track a current best roster as we examine and score
 		// potential rosters of merges.
 		var bestRoster []Segment
@@ -223,7 +222,6 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 		rv.Tasks = append(rv.Tasks, &MergeTask{Segments: bestRoster})
 
 		eligibles = removeSegments(eligibles, bestRoster)
-		newlyMerged++
 	}
 
 	return rv, nil

--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -186,13 +186,14 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 
 	// While we’re over budget, keep looping, which might produce
 	// another MergeTask.
-	for len(eligibles) > budgetNumSegments {
+	newlyMerged := int(0)
+	for (len(eligibles) + newlyMerged) > budgetNumSegments {
 		// Track a current best roster as we examine and score
 		// potential rosters of merges.
 		var bestRoster []Segment
 		var bestRosterScore float64 // Lower score is better.
 
-		for startIdx := 0; startIdx < len(eligibles)-o.SegmentsPerMergeTask; startIdx++ {
+		for startIdx := 0; startIdx < len(eligibles); startIdx++ {
 			var roster []Segment
 			var rosterLiveSize int64
 
@@ -222,6 +223,7 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 		rv.Tasks = append(rv.Tasks, &MergeTask{Segments: bestRoster})
 
 		eligibles = removeSegments(eligibles, bestRoster)
+		newlyMerged++
 	}
 
 	return rv, nil

--- a/index/scorch/mergeplan/merge_plan_test.go
+++ b/index/scorch/mergeplan/merge_plan_test.go
@@ -73,7 +73,16 @@ func TestSimplePlan(t *testing.T) {
 				segs[2],
 			},
 			nil,
-			&MergePlan{},
+			&MergePlan{
+				Tasks: []*MergeTask{
+					&MergeTask{
+						Segments: []Segment{
+							segs[2],
+							segs[1],
+						},
+					},
+				},
+			},
 			nil,
 		},
 		{"3 segments",
@@ -83,7 +92,17 @@ func TestSimplePlan(t *testing.T) {
 				segs[9],
 			},
 			nil,
-			&MergePlan{},
+			&MergePlan{
+				Tasks: []*MergeTask{
+					&MergeTask{
+						Segments: []Segment{
+							segs[9],
+							segs[2],
+							segs[1],
+						},
+					},
+				},
+			},
 			nil,
 		},
 		{"many segments",


### PR DESCRIPTION
Adjusting the merge task creation loop to accommodate the newly merged segments so that the eventual merge results/ number of segments stay within the calculated budget.