### PR TITLE
more zap merge-planner CalcBudget tests at larger sizes

### DIFF
--- a/index/scorch/mergeplan/merge_plan_test.go
+++ b/index/scorch/mergeplan/merge_plan_test.go
@@ -188,6 +188,18 @@ func TestCalcBudget(t *testing.T) {
 			},
 			7,
 		},
+		{1000, 2000, DefaultMergePlanOptions,
+			1},
+		{5000, 2000, DefaultMergePlanOptions,
+			3},
+		{10000, 2000, DefaultMergePlanOptions,
+			5},
+		{30000, 2000, DefaultMergePlanOptions,
+			11},
+		{1000000, 2000, DefaultMergePlanOptions,
+			24},
+		{1000000000, 2000, DefaultMergePlanOptions,
+			54},
 	}
 
 	for testi, test := range tests {


### PR DESCRIPTION
Helps provide a sense of how # of segments grows as # of documents
grows.  Ex: 1B docs => budget of 54 segments.