### PR TITLE
optimize zap merge byte copy stored docs

### DIFF
--- a/index/scorch/segment/mem/build.go
+++ b/index/scorch/segment/mem/build.go
@@ -95,6 +95,21 @@ func (s *Segment) initializeDict(results []*index.AnalysisResult) {
 	var numTokenFrequencies int
 	var totLocs int
 
+	// initial scan for all fieldID's to sort them
+	for _, result := range results {
+		for _, field := range result.Document.CompositeFields {
+			s.getOrDefineField(field.Name())
+		}
+		for _, field := range result.Document.Fields {
+			s.getOrDefineField(field.Name())
+		}
+	}
+	sort.Strings(s.FieldsInv[1:]) // keep _id as first field
+	s.FieldsMap = make(map[string]uint16, len(s.FieldsInv))
+	for fieldID, fieldName := range s.FieldsInv {
+		s.FieldsMap[fieldName] = uint16(fieldID + 1)
+	}
+
 	processField := func(fieldID uint16, tfs analysis.TokenFrequencies) {
 		for term, tf := range tfs {
 			pidPlus1, exists := s.Dicts[fieldID][term]

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/snappy"
 )
 
-const version uint32 = 2
+const version uint32 = 3
 
 const fieldNotUninverted = math.MaxUint64
 

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
@@ -545,5 +546,8 @@ func mergeFields(segments []*SegmentBase) []string {
 			rv = append(rv, k)
 		}
 	}
+
+	sort.Strings(rv[1:]) // leave _id as first
+
 	return rv
 }

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -29,6 +29,8 @@ import (
 	"github.com/golang/snappy"
 )
 
+const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
+
 // Merge takes a slice of zap segments and bit masks describing which
 // documents may be dropped, and creates a new segment containing the
 // remaining data.  This new segment is built at the specified path,
@@ -411,8 +413,6 @@ func persistMergedRest(segments []*SegmentBase, drops []*roaring.Bitmap,
 
 	return rv, fieldDvLocsOffset, nil
 }
-
-const docDropped = math.MaxUint64
 
 func mergeStoredAndRemap(segments []*SegmentBase, drops []*roaring.Bitmap,
 	fieldsMap map[string]uint16, fieldsInv []string, fieldsSame bool, newSegDocCount uint64,

--- a/index/scorch/segment/zap/merge_test.go
+++ b/index/scorch/segment/zap/merge_test.go
@@ -398,6 +398,40 @@ func compareSegments(a, b *Segment) string {
 								fieldName, next.Term, aloc, bloc))
 						}
 					}
+
+					if fieldName == "_id" {
+						docId := next.Term
+						docNumA := apitrn.Number()
+						docNumB := bpitrn.Number()
+						afields := map[string]interface{}{}
+						err = a.VisitDocument(apitrn.Number(),
+							func(field string, typ byte, value []byte, pos []uint64) bool {
+								afields[field+"-typ"] = typ
+								afields[field+"-value"] = value
+								afields[field+"-pos"] = pos
+								return true
+							})
+						if err != nil {
+							rv = append(rv, fmt.Sprintf("a.VisitDocument err: %v", err))
+						}
+						bfields := map[string]interface{}{}
+						err = b.VisitDocument(bpitrn.Number(),
+							func(field string, typ byte, value []byte, pos []uint64) bool {
+								bfields[field+"-typ"] = typ
+								bfields[field+"-value"] = value
+								bfields[field+"-pos"] = pos
+								return true
+							})
+						if err != nil {
+							rv = append(rv, fmt.Sprintf("b.VisitDocument err: %v", err))
+						}
+						if !reflect.DeepEqual(afields, bfields) {
+							rv = append(rv, fmt.Sprintf("afields != bfields,"+
+								" id: %s, docNumA: %d, docNumB: %d,"+
+								" afields: %#v, bfields: %#v",
+								docId, docNumA, docNumB, afields, bfields))
+						}
+					}
 				}
 			}
 		}

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/blevesearch/bleve/index"
@@ -574,6 +575,7 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 			t.Fatalf("segment VisitableDocValueFields err: %v", err)
 		}
 
+		sort.Strings(expectedFields[1:]) // keep _id as first field
 		if !reflect.DeepEqual(fields, expectedFields) {
 			t.Errorf("expected field terms: %#v, got: %#v", expectedFields, fields)
 		}


### PR DESCRIPTION
This PR has an optimization for merging to use byte-copying of a segment's stored docs when there are no doc deletions for a segment and when fields are the same across all the segments being merged.

