### PR TITLE
change indexMeta to public

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -39,7 +39,7 @@ import (
 type indexImpl struct {
 	path  string
 	name  string
-	meta  *indexMeta
+	meta  *IndexMeta
 	i     index.Index
 	m     mapping.IndexMapping
 	mutex sync.RWMutex
@@ -74,7 +74,7 @@ func newIndexUsing(path string, mapping mapping.IndexMapping, indexType string, 
 		path: path,
 		name: path,
 		m:    mapping,
-		meta: newIndexMeta(indexType, kvstore, kvconfig),
+		meta: NewIndexMeta(indexType, kvstore, kvconfig),
 	}
 	rv.stats = &IndexStat{i: &rv}
 	// at this point there is hope that we can be successful, so save index meta
@@ -133,7 +133,7 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 	}
 	rv.stats = &IndexStat{i: rv}
 
-	rv.meta, err = openIndexMeta(path)
+	rv.meta, err = OpenIndexMeta(path)
 	if err != nil {
 		return nil, err
 	}

--- a/index_meta.go
+++ b/index_meta.go
@@ -24,21 +24,21 @@ import (
 
 const metaFilename = "index_meta.json"
 
-type indexMeta struct {
+type IndexMeta struct {
 	Storage   string                 `json:"storage"`
 	IndexType string                 `json:"index_type"`
 	Config    map[string]interface{} `json:"config,omitempty"`
 }
 
-func newIndexMeta(indexType string, storage string, config map[string]interface{}) *indexMeta {
-	return &indexMeta{
+func NewIndexMeta(indexType string, storage string, config map[string]interface{}) *IndexMeta {
+	return &IndexMeta{
 		IndexType: indexType,
 		Storage:   storage,
 		Config:    config,
 	}
 }
 
-func openIndexMeta(path string) (*indexMeta, error) {
+func OpenIndexMeta(path string) (*IndexMeta, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, ErrorIndexPathDoesNotExist
 	}
@@ -47,7 +47,7 @@ func openIndexMeta(path string) (*indexMeta, error) {
 	if err != nil {
 		return nil, ErrorIndexMetaMissing
 	}
-	var im indexMeta
+	var im IndexMeta
 	err = json.Unmarshal(metaBytes, &im)
 	if err != nil {
 		return nil, ErrorIndexMetaCorrupt
@@ -58,7 +58,7 @@ func openIndexMeta(path string) (*indexMeta, error) {
 	return &im, nil
 }
 
-func (i *indexMeta) Save(path string) (err error) {
+func (i *IndexMeta) Save(path string) (err error) {
 	indexMetaPath := indexMetaPath(path)
 	// ensure any necessary parent directories exist
 	err = os.MkdirAll(path, 0700)

--- a/index_meta_test.go
+++ b/index_meta_test.go
@@ -29,13 +29,13 @@ func TestIndexMeta(t *testing.T) {
 	}()
 
 	// open non-existent meta should give an error
-	_, err := openIndexMeta(testIndexPath)
+	_, err := OpenIndexMeta(testIndexPath)
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
 
 	// create meta
-	im := &indexMeta{Storage: "boltdb"}
+	im := &IndexMeta{Storage: "boltdb"}
 	err = im.Save(testIndexPath)
 	if err != nil {
 		t.Error(err)
@@ -43,7 +43,7 @@ func TestIndexMeta(t *testing.T) {
 	im = nil
 
 	// open a meta that exists
-	im, err = openIndexMeta(testIndexPath)
+	im, err = OpenIndexMeta(testIndexPath)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
I'd like to use indexMeta from outside of bleve package for controlling index_mapping.json and index_meta.json.

For example:

```
indexPath := "./data"

indexMappingFile, err := os.Open("index_mapping.json")
indexMappingBytes, err := ioutil.ReadAll(indexMappingFile)
var indexMapping *mapping.IndexMappingImpl
err = json.Unmarshal(indexMappingBytes, indexMapping)
if err != nil {
	fmt.Println(err)
	return
}

indexMetaFile, err := os.Open("index_meta.json")
indexMetaBytes, err := ioutil.ReadAll(indexMetaFile)
var indexMeta *bleve.IndexMeta
err = json.Unmarshal(indexMetaBytes, indexMeta)
if err != nil {
	fmt.Println(err)
	return
}

index, err = bleve.NewUsing(indexPath, indexMapping, indexMeta.IndexType, indexMeta.Storage, indexMeta.Config)
```

I propose to change indexMeta to public. How about this PR?