### PR TITLE
scorch rollback ignores unsafeBatch flag

### DIFF
--- a/index/scorch/snapshot_rollback.go
+++ b/index/scorch/snapshot_rollback.go
@@ -149,10 +149,7 @@ func (s *Scorch) Rollback(to *RollbackPoint) error {
 
 		revert.snapshot = indexSnapshot
 		revert.applied = make(chan error)
-
-		if !s.unsafeBatch {
-			revert.persisted = make(chan error)
-		}
+		revert.persisted = make(chan error)
 
 		return nil
 	})
@@ -172,9 +169,5 @@ func (s *Scorch) Rollback(to *RollbackPoint) error {
 		return fmt.Errorf("Rollback: failed with err: %v", err)
 	}
 
-	if revert.persisted != nil {
-		err = <-revert.persisted
-	}
-
-	return err
+	return <-revert.persisted
 }


### PR DESCRIPTION
Picking off the easiest subpart of issue #760 -- ignoring the unsafeBatch flag in Rollback()