### PR TITLE
Estimating RAM needed for a Search operation

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -14,7 +14,19 @@
 
 package document
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/blevesearch/bleve/size"
+)
+
+var reflectStaticSizeDocument int
+
+func init() {
+	var d Document
+	reflectStaticSizeDocument = int(reflect.TypeOf(d).Size())
+}
 
 type Document struct {
 	ID              string  `json:"id"`
@@ -28,6 +40,13 @@ func NewDocument(id string) *Document {
 		Fields:          make([]Field, 0),
 		CompositeFields: make([]*CompositeField, 0),
 	}
+}
+
+func (d *Document) Size() int {
+	return reflectStaticSizeDocument + size.SizeOfPtr +
+		len(d.ID) +
+		len(d.Fields)*size.SizeOfPtr +
+		len(d.CompositeFields)*(size.SizeOfPtr+reflectStaticSizeCompositeField)
 }
 
 func (d *Document) AddField(f Field) *Document {

--- a/document/field_composite.go
+++ b/document/field_composite.go
@@ -15,8 +15,17 @@
 package document
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/analysis"
 )
+
+var reflectStaticSizeCompositeField int
+
+func init() {
+	var cf CompositeField
+	reflectStaticSizeCompositeField = int(reflect.TypeOf(cf).Size())
+}
 
 const DefaultCompositeIndexingOptions = IndexField
 

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -468,20 +468,20 @@ func (s *Scorch) AddEligibleForRemoval(epoch uint64) {
 }
 
 func (s *Scorch) MemoryUsed() uint64 {
-	var memUsed uint64
+	var memUsed int
 	s.rootLock.RLock()
 	if s.root != nil {
 		for _, segmentSnapshot := range s.root.segment {
 			memUsed += 8 /* size of id -> uint64 */ +
-				segmentSnapshot.segment.SizeInBytes()
+				segmentSnapshot.segment.Size()
 			if segmentSnapshot.deleted != nil {
-				memUsed += segmentSnapshot.deleted.GetSizeInBytes()
+				memUsed += int(segmentSnapshot.deleted.GetSizeInBytes())
 			}
-			memUsed += segmentSnapshot.cachedDocs.sizeInBytes()
+			memUsed += segmentSnapshot.cachedDocs.size()
 		}
 	}
 	s.rootLock.RUnlock()
-	return memUsed
+	return uint64(memUsed)
 }
 
 func (s *Scorch) markIneligibleForRemoval(filename string) {

--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -46,6 +46,10 @@ func (e *EmptySegment) Close() error {
 	return nil
 }
 
+func (e *EmptySegment) Size() uint64 {
+	return 0
+}
+
 func (e *EmptySegment) AddRef() {
 }
 
@@ -84,6 +88,10 @@ func (e *EmptyPostingsList) Iterator() PostingsIterator {
 	return &EmptyPostingsIterator{}
 }
 
+func (e *EmptyPostingsList) Size() int {
+	return 0
+}
+
 func (e *EmptyPostingsList) Count() uint64 {
 	return 0
 }
@@ -92,4 +100,8 @@ type EmptyPostingsIterator struct{}
 
 func (e *EmptyPostingsIterator) Next() (Posting, error) {
 	return nil, nil
+}
+
+func (e *EmptyPostingsIterator) Size() int {
+	return 0
 }

--- a/index/scorch/segment/mem/build.go
+++ b/index/scorch/segment/mem/build.go
@@ -45,7 +45,7 @@ func NewFromAnalyzedDocs(results []*index.AnalysisResult) *Segment {
 	}
 
 	// compute memory usage of segment
-	s.updateSizeInBytes()
+	s.updateSize()
 
 	// professional debugging
 	//

--- a/index/scorch/segment/mem/dict.go
+++ b/index/scorch/segment/mem/dict.go
@@ -15,19 +15,39 @@
 package mem
 
 import (
+	"reflect"
 	"sort"
 	"strings"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/scorch/segment"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeDictionary int
+
+func init() {
+	var d Dictionary
+	reflectStaticSizeDictionary = int(reflect.TypeOf(d).Size())
+}
 
 // Dictionary is the in-memory representation of the term dictionary
 type Dictionary struct {
 	segment *Segment
 	field   string
 	fieldID uint16
+}
+
+func (d *Dictionary) Size() int {
+	sizeInBytes := reflectStaticSizeDictionary + size.SizeOfPtr +
+		len(d.field)
+
+	if d.segment != nil {
+		sizeInBytes += int(d.segment.Size())
+	}
+
+	return sizeInBytes
 }
 
 // PostingsList returns the postings list for the specified term

--- a/index/scorch/segment/mem/posting.go
+++ b/index/scorch/segment/mem/posting.go
@@ -15,9 +15,28 @@
 package mem
 
 import (
+	"reflect"
+
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index/scorch/segment"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizePostingsList int
+var reflectStaticSizePostingsIterator int
+var reflectStaticSizePosting int
+var reflectStaticSizeLocation int
+
+func init() {
+	var pl PostingsList
+	reflectStaticSizePostingsList = int(reflect.TypeOf(pl).Size())
+	var pi PostingsIterator
+	reflectStaticSizePostingsIterator = int(reflect.TypeOf(pi).Size())
+	var p Posting
+	reflectStaticSizePosting = int(reflect.TypeOf(p).Size())
+	var l Location
+	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
+}
 
 // PostingsList is an in-memory represenation of a postings list
 type PostingsList struct {
@@ -25,6 +44,20 @@ type PostingsList struct {
 	term       string
 	postingsID uint64
 	except     *roaring.Bitmap
+}
+
+func (p *PostingsList) Size() int {
+	sizeInBytes := reflectStaticSizePostingsList + size.SizeOfPtr
+
+	if p.dictionary != nil {
+		sizeInBytes += p.dictionary.Size()
+	}
+
+	if p.except != nil {
+		sizeInBytes += int(p.except.GetSizeInBytes())
+	}
+
+	return sizeInBytes
 }
 
 // Count returns the number of items on this postings list
@@ -75,6 +108,16 @@ type PostingsIterator struct {
 	actual    roaring.IntIterable
 }
 
+func (i *PostingsIterator) Size() int {
+	sizeInBytes := reflectStaticSizePostingsIterator + size.SizeOfPtr
+
+	if i.locations != nil {
+		sizeInBytes += int(i.locations.GetSizeInBytes())
+	}
+
+	return sizeInBytes
+}
+
 // Next returns the next posting on the postings list, or nil at the end
 func (i *PostingsIterator) Next() (segment.Posting, error) {
 	if i.actual == nil || !i.actual.HasNext() {
@@ -114,6 +157,16 @@ type Posting struct {
 	hasLoc    bool
 }
 
+func (p *Posting) Size() int {
+	sizeInBytes := reflectStaticSizePosting + size.SizeOfPtr
+
+	if p.iterator != nil {
+		sizeInBytes += p.iterator.Size()
+	}
+
+	return sizeInBytes
+}
+
 // Number returns the document number of this posting in this segment
 func (p *Posting) Number() uint64 {
 	return p.docNum
@@ -149,6 +202,15 @@ func (p *Posting) Locations() []segment.Location {
 type Location struct {
 	p      *Posting
 	offset int
+}
+
+func (l *Location) Size() int {
+	sizeInBytes := reflectStaticSizeLocation
+	if l.p != nil {
+		sizeInBytes += l.p.Size()
+	}
+
+	return sizeInBytes
 }
 
 // Field returns the name of the field (useful in composite fields to know

--- a/index/scorch/segment/mem/segment_test.go
+++ b/index/scorch/segment/mem/segment_test.go
@@ -169,7 +169,7 @@ func TestSingle(t *testing.T) {
 		t.Fatalf("segment nil, not expected")
 	}
 
-	if segment.SizeInBytes() <= 0 {
+	if segment.Size() <= 0 {
 		t.Fatalf("segment size not updated")
 	}
 

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -19,12 +19,6 @@ import (
 	"github.com/blevesearch/bleve/index"
 )
 
-// Overhead from go data structures when deployed on a 64-bit system.
-const SizeOfMap uint64 = 8
-const SizeOfPointer uint64 = 8
-const SizeOfSlice uint64 = 24
-const SizeOfString uint64 = 16
-
 // DocumentFieldValueVisitor defines a callback to be visited for each
 // stored field value.  The return value determines if the visitor
 // should keep going.  Returning true continues visiting, false stops.
@@ -42,7 +36,7 @@ type Segment interface {
 
 	Close() error
 
-	SizeInBytes() uint64
+	Size() int
 
 	AddRef()
 	DecRef() error
@@ -63,6 +57,8 @@ type DictionaryIterator interface {
 type PostingsList interface {
 	Iterator() PostingsIterator
 
+	Size() int
+
 	Count() uint64
 
 	// NOTE deferred for future work
@@ -77,6 +73,8 @@ type PostingsIterator interface {
 	// implementations may return a shared instance to reduce memory
 	// allocations.
 	Next() (Posting, error)
+
+	Size() int
 }
 
 type Posting interface {
@@ -86,6 +84,8 @@ type Posting interface {
 	Norm() float64
 
 	Locations() []Location
+
+	Size() int
 }
 
 type Location interface {
@@ -94,6 +94,7 @@ type Location interface {
 	End() uint64
 	Pos() uint64
 	ArrayPositions() []uint64
+	Size() int
 }
 
 // DocumentFieldTermVisitable is implemented by various scorch segment

--- a/index/scorch/segment/zap/contentcoder.go
+++ b/index/scorch/segment/zap/contentcoder.go
@@ -18,9 +18,17 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"reflect"
 
 	"github.com/golang/snappy"
 )
+
+var reflectStaticSizeMetaData int
+
+func init() {
+	var md MetaData
+	reflectStaticSizeMetaData = int(reflect.TypeOf(md).Size())
+}
 
 var termSeparator byte = 0xff
 var termSeparatorSplitSlice = []byte{termSeparator}

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -19,11 +19,29 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/Smerity/govarint"
 	"github.com/blevesearch/bleve/index/scorch/segment"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizePostingsList int
+var reflectStaticSizePostingsIterator int
+var reflectStaticSizePosting int
+var reflectStaticSizeLocation int
+
+func init() {
+	var pl PostingsList
+	reflectStaticSizePostingsList = int(reflect.TypeOf(pl).Size())
+	var pi PostingsIterator
+	reflectStaticSizePostingsIterator = int(reflect.TypeOf(pi).Size())
+	var p Posting
+	reflectStaticSizePosting = int(reflect.TypeOf(p).Size())
+	var l Location
+	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
+}
 
 // PostingsList is an in-memory represenation of a postings list
 type PostingsList struct {
@@ -34,6 +52,28 @@ type PostingsList struct {
 	locBitmap      *roaring.Bitmap
 	postings       *roaring.Bitmap
 	except         *roaring.Bitmap
+}
+
+func (p *PostingsList) Size() int {
+	sizeInBytes := reflectStaticSizePostingsList + size.SizeOfPtr
+
+	if p.sb != nil {
+		sizeInBytes += (p.sb.Size() - len(p.sb.mem)) // do not include the mmap'ed part
+	}
+
+	if p.locBitmap != nil {
+		sizeInBytes += int(p.locBitmap.GetSizeInBytes())
+	}
+
+	if p.postings != nil {
+		sizeInBytes += int(p.postings.GetSizeInBytes())
+	}
+
+	if p.except != nil {
+		sizeInBytes += int(p.except.GetSizeInBytes())
+	}
+
+	return sizeInBytes
 }
 
 // Iterator returns an iterator for this postings list
@@ -173,6 +213,25 @@ type PostingsIterator struct {
 
 	next     Posting    // reused across Next() calls
 	nextLocs []Location // reused across Next() calls
+}
+
+func (i *PostingsIterator) Size() int {
+	sizeInBytes := reflectStaticSizePostingsIterator + size.SizeOfPtr +
+		len(i.currChunkFreqNorm) +
+		len(i.currChunkLoc) +
+		len(i.freqChunkLens)*size.SizeOfUint64 +
+		len(i.locChunkLens)*size.SizeOfUint64 +
+		i.next.Size()
+
+	if i.locBitmap != nil {
+		sizeInBytes += int(i.locBitmap.GetSizeInBytes())
+	}
+
+	for _, entry := range i.nextLocs {
+		sizeInBytes += entry.Size()
+	}
+
+	return sizeInBytes
 }
 
 func (i *PostingsIterator) loadChunk(chunk int) error {
@@ -381,6 +440,20 @@ type Posting struct {
 	locs []segment.Location
 }
 
+func (p *Posting) Size() int {
+	sizeInBytes := reflectStaticSizePosting
+
+	if p.iterator != nil {
+		sizeInBytes += p.iterator.Size()
+	}
+
+	for _, entry := range p.locs {
+		sizeInBytes += entry.Size()
+	}
+
+	return sizeInBytes
+}
+
 // Number returns the document number of this posting in this segment
 func (p *Posting) Number() uint64 {
 	return p.docNum
@@ -408,6 +481,12 @@ type Location struct {
 	start uint64
 	end   uint64
 	ap    []uint64
+}
+
+func (l *Location) Size() int {
+	return reflectStaticSizeLocation +
+		len(l.field) +
+		len(l.ap)*size.SizeOfUint64
 }
 
 // Field returns the name of the field (useful in composite fields to know

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/scorch/segment"
+	"github.com/blevesearch/bleve/size"
 )
 
 type asynchSegmentResult struct {
@@ -87,6 +88,12 @@ func (i *IndexSnapshot) DecRef() (err error) {
 
 func (i *IndexSnapshot) Close() error {
 	return i.DecRef()
+}
+
+func (i *IndexSnapshot) Size() int {
+	// Just return the size of the pointer for estimating the overhead
+	// during Search, a reference of the IndexSnapshot serves as the reader.
+	return size.SizeOfPtr
 }
 
 func (i *IndexSnapshot) newIndexSnapshotFieldDict(field string, makeItr func(i segment.TermDictionary) segment.DictionaryIterator) (*IndexSnapshotFieldDict, error) {

--- a/index/scorch/snapshot_index_doc.go
+++ b/index/scorch/snapshot_index_doc.go
@@ -16,15 +16,28 @@ package scorch
 
 import (
 	"bytes"
+	"reflect"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeIndexSnapshotDocIDReader int
+
+func init() {
+	var isdr IndexSnapshotDocIDReader
+	reflectStaticSizeIndexSnapshotDocIDReader = int(reflect.TypeOf(isdr).Size())
+}
 
 type IndexSnapshotDocIDReader struct {
 	snapshot      *IndexSnapshot
 	iterators     []roaring.IntIterable
 	segmentOffset int
+}
+
+func (i *IndexSnapshotDocIDReader) Size() int {
+	return reflectStaticSizeIndexSnapshotDocIDReader + size.SizeOfPtr
 }
 
 func (i *IndexSnapshotDocIDReader) Next() (index.IndexInternalID, error) {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -213,7 +213,7 @@ func (c *cachedDocs) prepareFields(wantedFields []string, ss *SegmentSnapshot) e
 	return nil
 }
 
-func (c *cachedDocs) sizeInBytes() uint64 {
+func (c *cachedDocs) size() int {
 	sizeInBytes := 0
 	c.m.Lock()
 	for k, v := range c.cache { // cachedFieldDocs
@@ -225,5 +225,5 @@ func (c *cachedDocs) sizeInBytes() uint64 {
 		}
 	}
 	c.m.Unlock()
-	return uint64(sizeInBytes)
+	return sizeInBytes
 }

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -15,15 +15,29 @@
 package upsidedown
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeIndexReader int
+
+func init() {
+	var ir IndexReader
+	reflectStaticSizeIndexReader = int(reflect.TypeOf(ir).Size())
+}
 
 type IndexReader struct {
 	index    *UpsideDownCouch
 	kvreader store.KVReader
 	docCount uint64
+}
+
+func (i *IndexReader) Size() int {
+	return reflectStaticSizeIndexReader + size.SizeOfPtr
 }
 
 func (i *IndexReader) TermFieldReader(term []byte, fieldName string, includeFreq, includeNorm, includeTermVectors bool) (index.TermFieldReader, error) {

--- a/index/upsidedown/reader.go
+++ b/index/upsidedown/reader.go
@@ -16,12 +16,26 @@ package upsidedown
 
 import (
 	"bytes"
+	"reflect"
 	"sort"
 	"sync/atomic"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeUpsideDownCouchTermFieldReader int
+var reflectStaticSizeUpsideDownCouchDocIDReader int
+
+func init() {
+	var tfr UpsideDownCouchTermFieldReader
+	reflectStaticSizeUpsideDownCouchTermFieldReader =
+		int(reflect.TypeOf(tfr).Size())
+	var cdr UpsideDownCouchDocIDReader
+	reflectStaticSizeUpsideDownCouchDocIDReader =
+		int(reflect.TypeOf(cdr).Size())
+}
 
 type UpsideDownCouchTermFieldReader struct {
 	count              uint64
@@ -33,6 +47,19 @@ type UpsideDownCouchTermFieldReader struct {
 	keyBuf             []byte
 	field              uint16
 	includeTermVectors bool
+}
+
+func (r *UpsideDownCouchTermFieldReader) Size() int {
+	sizeInBytes := reflectStaticSizeUpsideDownCouchTermFieldReader + size.SizeOfPtr +
+		len(r.term) +
+		r.tfrPrealloc.Size() +
+		len(r.keyBuf)
+
+	if r.tfrNext != nil {
+		sizeInBytes += r.tfrNext.Size()
+	}
+
+	return sizeInBytes
 }
 
 func newUpsideDownCouchTermFieldReader(indexReader *IndexReader, term []byte, field uint16, includeFreq, includeNorm, includeTermVectors bool) (*UpsideDownCouchTermFieldReader, error) {
@@ -174,8 +201,18 @@ type UpsideDownCouchDocIDReader struct {
 	onlyMode    bool
 }
 
-func newUpsideDownCouchDocIDReader(indexReader *IndexReader) (*UpsideDownCouchDocIDReader, error) {
+func (r *UpsideDownCouchDocIDReader) Size() int {
+	sizeInBytes := reflectStaticSizeUpsideDownCouchDocIDReader +
+		r.indexReader.Size()
 
+	for _, entry := range r.only {
+		sizeInBytes += size.SizeOfString + len(entry)
+	}
+
+	return sizeInBytes
+}
+
+func newUpsideDownCouchDocIDReader(indexReader *IndexReader) (*UpsideDownCouchDocIDReader, error) {
 	startBytes := []byte{0x0}
 	endBytes := []byte{0xff}
 

--- a/index/upsidedown/row.go
+++ b/index/upsidedown/row.go
@@ -20,9 +20,21 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 
+	"github.com/blevesearch/bleve/size"
 	"github.com/golang/protobuf/proto"
 )
+
+var reflectStaticSizeTermFrequencyRow int
+var reflectStaticSizeTermVector int
+
+func init() {
+	var tfr TermFrequencyRow
+	reflectStaticSizeTermFrequencyRow = int(reflect.TypeOf(tfr).Size())
+	var tv TermVector
+	reflectStaticSizeTermVector = int(reflect.TypeOf(tv).Size())
+}
 
 const ByteSeparator byte = 0xff
 
@@ -358,6 +370,11 @@ type TermVector struct {
 	end            uint64
 }
 
+func (tv *TermVector) Size() int {
+	return reflectStaticSizeTermVector + size.SizeOfPtr +
+		len(tv.arrayPositions)*size.SizeOfUint64
+}
+
 func (tv *TermVector) String() string {
 	return fmt.Sprintf("Field: %d Pos: %d Start: %d End %d ArrayPositions: %#v", tv.field, tv.pos, tv.start, tv.end, tv.arrayPositions)
 }
@@ -369,6 +386,18 @@ type TermFrequencyRow struct {
 	vectors []*TermVector
 	norm    float32
 	field   uint16
+}
+
+func (tfr *TermFrequencyRow) Size() int {
+	sizeInBytes := reflectStaticSizeTermFrequencyRow +
+		len(tfr.term) +
+		len(tfr.doc)
+
+	for _, entry := range tfr.vectors {
+		sizeInBytes += entry.Size()
+	}
+
+	return sizeInBytes
 }
 
 func (tfr *TermFrequencyRow) Term() []byte {

--- a/index_impl.go
+++ b/index_impl.go
@@ -362,8 +362,59 @@ func (i *indexImpl) Search(req *SearchRequest) (sr *SearchResult, err error) {
 	return i.SearchInContext(context.Background(), req)
 }
 
+// memNeededForSearch is a helper function that returns an estimate of RAM
+// needed to execute a search request.
+func memNeededForSearch(req *SearchRequest,
+	searcher search.Searcher,
+	topnCollector *collector.TopNCollector) uint64 {
+
+	backingSize := req.Size + req.From + 1
+	if req.Size+req.From > collector.PreAllocSizeSkipCap {
+		backingSize = collector.PreAllocSizeSkipCap + 1
+	}
+	numDocMatches := backingSize + searcher.DocumentMatchPoolSize()
+
+	estimate := 0
+
+	// overhead, size in bytes from collector
+	estimate += topnCollector.Size()
+
+	var dm search.DocumentMatch
+	sizeOfDocumentMatch := dm.Size()
+
+	// pre-allocing DocumentMatchPool
+	var sc search.SearchContext
+	estimate += sc.Size() + numDocMatches*sizeOfDocumentMatch
+
+	// searcher overhead
+	estimate += searcher.Size()
+
+	// overhead from results, lowestMatchOutsideResults
+	estimate += (numDocMatches + 1) * sizeOfDocumentMatch
+
+	// additional overhead from SearchResult
+	var sr SearchResult
+	estimate += sr.Size()
+
+	// overhead from facet results
+	if req.Facets != nil {
+		var fr search.FacetResult
+		estimate += len(req.Facets) * fr.Size()
+	}
+
+	// highlighting, store
+	var d document.Document
+	if len(req.Fields) > 0 || req.Highlight != nil {
+		for i := 0; i < (req.Size + req.From); i++ { // size + from => number of hits
+			estimate += (req.Size + req.From) * d.Size()
+		}
+	}
+
+	return uint64(estimate)
+}
+
 // SearchInContext executes a search request operation within the provided
-// Context.  Returns a SearchResult object or an error.
+// Context. Returns a SearchResult object or an error.
 func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr *SearchResult, err error) {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -15,6 +15,8 @@
 package collector
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
@@ -23,6 +25,18 @@ import (
 type stubSearcher struct {
 	index   int
 	matches []*search.DocumentMatch
+}
+
+func (ss *stubSearcher) Size() int {
+	sizeInBytes := int(reflect.TypeOf(*ss).Size())
+
+	for _, entry := range ss.matches {
+		if entry != nil {
+			sizeInBytes += entry.Size()
+		}
+	}
+
+	return sizeInBytes
 }
 
 func (ss *stubSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
@@ -75,6 +89,10 @@ func (ss *stubSearcher) DocumentMatchPoolSize() int {
 }
 
 type stubReader struct{}
+
+func (sr *stubReader) Size() int {
+	return 0
+}
 
 func (sr *stubReader) TermFieldReader(term []byte, field string, includeFreq, includeNorm, includeTermVectors bool) (index.TermFieldReader, error) {
 	return nil, nil

--- a/search/explanation.go
+++ b/search/explanation.go
@@ -17,7 +17,17 @@ package search
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeExplanation int
+
+func init() {
+	var e Explanation
+	reflectStaticSizeExplanation = int(reflect.TypeOf(e).Size())
+}
 
 type Explanation struct {
 	Value    float64        `json:"value"`
@@ -31,4 +41,15 @@ func (expl *Explanation) String() string {
 		return fmt.Sprintf("error serializing explanation to json: %v", err)
 	}
 	return string(js)
+}
+
+func (expl *Explanation) Size() int {
+	sizeInBytes := reflectStaticSizeExplanation + size.SizeOfPtr +
+		len(expl.Message)
+
+	for _, entry := range expl.Children {
+		sizeInBytes += entry.Size()
+	}
+
+	return sizeInBytes
 }

--- a/search/facet/facet_builder_datetime.go
+++ b/search/facet/facet_builder_datetime.go
@@ -15,12 +15,24 @@
 package facet
 
 import (
+	"reflect"
 	"sort"
 	"time"
 
 	"github.com/blevesearch/bleve/numeric"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeDateTimeFacetBuilder int
+var reflectStaticSizedateTimeRange int
+
+func init() {
+	var dtfb DateTimeFacetBuilder
+	reflectStaticSizeDateTimeFacetBuilder = int(reflect.TypeOf(dtfb).Size())
+	var dtr dateTimeRange
+	reflectStaticSizedateTimeRange = int(reflect.TypeOf(dtr).Size())
+}
 
 type dateTimeRange struct {
 	start time.Time
@@ -44,6 +56,23 @@ func NewDateTimeFacetBuilder(field string, size int) *DateTimeFacetBuilder {
 		termsCount: make(map[string]int),
 		ranges:     make(map[string]*dateTimeRange, 0),
 	}
+}
+
+func (fb *DateTimeFacetBuilder) Size() int {
+	sizeInBytes := reflectStaticSizeDateTimeFacetBuilder + size.SizeOfPtr +
+		len(fb.field)
+
+	for k, _ := range fb.termsCount {
+		sizeInBytes += size.SizeOfString + len(k) +
+			size.SizeOfInt
+	}
+
+	for k, _ := range fb.ranges {
+		sizeInBytes += size.SizeOfString + len(k) +
+			size.SizeOfPtr + reflectStaticSizedateTimeRange
+	}
+
+	return sizeInBytes
 }
 
 func (fb *DateTimeFacetBuilder) AddRange(name string, start, end time.Time) {

--- a/search/facet/facet_builder_numeric.go
+++ b/search/facet/facet_builder_numeric.go
@@ -15,11 +15,23 @@
 package facet
 
 import (
+	"reflect"
 	"sort"
 
 	"github.com/blevesearch/bleve/numeric"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeNumericFacetBuilder int
+var reflectStaticSizenumericRange int
+
+func init() {
+	var nfb NumericFacetBuilder
+	reflectStaticSizeNumericFacetBuilder = int(reflect.TypeOf(nfb).Size())
+	var nr numericRange
+	reflectStaticSizenumericRange = int(reflect.TypeOf(nr).Size())
+}
 
 type numericRange struct {
 	min *float64
@@ -43,6 +55,23 @@ func NewNumericFacetBuilder(field string, size int) *NumericFacetBuilder {
 		termsCount: make(map[string]int),
 		ranges:     make(map[string]*numericRange, 0),
 	}
+}
+
+func (fb *NumericFacetBuilder) Size() int {
+	sizeInBytes := reflectStaticSizeNumericFacetBuilder + size.SizeOfPtr +
+		len(fb.field)
+
+	for k, _ := range fb.termsCount {
+		sizeInBytes += size.SizeOfString + len(k) +
+			size.SizeOfInt
+	}
+
+	for k, _ := range fb.ranges {
+		sizeInBytes += size.SizeOfString + len(k) +
+			size.SizeOfPtr + reflectStaticSizenumericRange
+	}
+
+	return sizeInBytes
 }
 
 func (fb *NumericFacetBuilder) AddRange(name string, min, max *float64) {

--- a/search/facet/facet_builder_terms.go
+++ b/search/facet/facet_builder_terms.go
@@ -15,10 +15,19 @@
 package facet
 
 import (
+	"reflect"
 	"sort"
 
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeTermsFacetBuilder int
+
+func init() {
+	var tfb TermsFacetBuilder
+	reflectStaticSizeTermsFacetBuilder = int(reflect.TypeOf(tfb).Size())
+}
 
 type TermsFacetBuilder struct {
 	size       int
@@ -35,6 +44,18 @@ func NewTermsFacetBuilder(field string, size int) *TermsFacetBuilder {
 		field:      field,
 		termsCount: make(map[string]int),
 	}
+}
+
+func (fb *TermsFacetBuilder) Size() int {
+	sizeInBytes := reflectStaticSizeTermsFacetBuilder + size.SizeOfPtr +
+		len(fb.field)
+
+	for k, _ := range fb.termsCount {
+		sizeInBytes += size.SizeOfString + len(k) +
+			size.SizeOfInt
+	}
+
+	return sizeInBytes
 }
 
 func (fb *TermsFacetBuilder) Field() string {

--- a/search/pool.go
+++ b/search/pool.go
@@ -14,6 +14,17 @@
 
 package search
 
+import (
+	"reflect"
+)
+
+var reflectStaticSizeDocumentMatchPool int
+
+func init() {
+	var dmp DocumentMatchPool
+	reflectStaticSizeDocumentMatchPool = int(reflect.TypeOf(dmp).Size())
+}
+
 // DocumentMatchPoolTooSmall is a callback function that can be executed
 // when the DocumentMatchPool does not have sufficient capacity
 // By default we just perform just-in-time allocation, but you could log

--- a/search/scorer/scorer_conjunction.go
+++ b/search/scorer/scorer_conjunction.go
@@ -15,11 +15,25 @@
 package scorer
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeConjunctionQueryScorer int
+
+func init() {
+	var cqs ConjunctionQueryScorer
+	reflectStaticSizeConjunctionQueryScorer = int(reflect.TypeOf(cqs).Size())
+}
 
 type ConjunctionQueryScorer struct {
 	options search.SearcherOptions
+}
+
+func (s *ConjunctionQueryScorer) Size() int {
+	return reflectStaticSizeConjunctionQueryScorer + size.SizeOfPtr
 }
 
 func NewConjunctionQueryScorer(options search.SearcherOptions) *ConjunctionQueryScorer {

--- a/search/scorer/scorer_constant.go
+++ b/search/scorer/scorer_constant.go
@@ -16,10 +16,19 @@ package scorer
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeConstantScorer int
+
+func init() {
+	var cs ConstantScorer
+	reflectStaticSizeConstantScorer = int(reflect.TypeOf(cs).Size())
+}
 
 type ConstantScorer struct {
 	constant               float64
@@ -28,6 +37,16 @@ type ConstantScorer struct {
 	queryNorm              float64
 	queryWeight            float64
 	queryWeightExplanation *search.Explanation
+}
+
+func (s *ConstantScorer) Size() int {
+	sizeInBytes := reflectStaticSizeConstantScorer + size.SizeOfPtr
+
+	if s.queryWeightExplanation != nil {
+		sizeInBytes += s.queryWeightExplanation.Size()
+	}
+
+	return sizeInBytes
 }
 
 func NewConstantScorer(constant float64, boost float64, options search.SearcherOptions) *ConstantScorer {

--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -16,12 +16,25 @@ package scorer
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeDisjunctionQueryScorer int
+
+func init() {
+	var dqs DisjunctionQueryScorer
+	reflectStaticSizeDisjunctionQueryScorer = int(reflect.TypeOf(dqs).Size())
+}
 
 type DisjunctionQueryScorer struct {
 	options search.SearcherOptions
+}
+
+func (s *DisjunctionQueryScorer) Size() int {
+	return reflectStaticSizeDisjunctionQueryScorer + size.SizeOfPtr
 }
 
 func NewDisjunctionQueryScorer(options search.SearcherOptions) *DisjunctionQueryScorer {

--- a/search/scorer/scorer_term.go
+++ b/search/scorer/scorer_term.go
@@ -17,10 +17,19 @@ package scorer
 import (
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeTermQueryScorer int
+
+func init() {
+	var tqs TermQueryScorer
+	reflectStaticSizeTermQueryScorer = int(reflect.TypeOf(tqs).Size())
+}
 
 type TermQueryScorer struct {
 	queryTerm              []byte
@@ -34,6 +43,21 @@ type TermQueryScorer struct {
 	queryNorm              float64
 	queryWeight            float64
 	queryWeightExplanation *search.Explanation
+}
+
+func (s *TermQueryScorer) Size() int {
+	sizeInBytes := reflectStaticSizeTermQueryScorer + size.SizeOfPtr +
+		len(s.queryTerm) + len(s.queryField)
+
+	if s.idfExplanation != nil {
+		sizeInBytes += s.idfExplanation.Size()
+	}
+
+	if s.queryWeightExplanation != nil {
+		sizeInBytes += s.queryWeightExplanation.Size()
+	}
+
+	return sizeInBytes
 }
 
 func NewTermQueryScorer(queryTerm []byte, queryField string, queryBoost float64, docTotal, docTerm uint64, options search.SearcherOptions) *TermQueryScorer {

--- a/search/searcher/search_docid.go
+++ b/search/searcher/search_docid.go
@@ -15,10 +15,20 @@
 package searcher
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
 	"github.com/blevesearch/bleve/search/scorer"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeDocIDSearcher int
+
+func init() {
+	var ds DocIDSearcher
+	reflectStaticSizeDocIDSearcher = int(reflect.TypeOf(ds).Size())
+}
 
 // DocIDSearcher returns documents matching a predefined set of identifiers.
 type DocIDSearcher struct {
@@ -40,6 +50,12 @@ func NewDocIDSearcher(indexReader index.IndexReader, ids []string, boost float64
 		reader: reader,
 		count:  len(ids),
 	}, nil
+}
+
+func (s *DocIDSearcher) Size() int {
+	return reflectStaticSizeDocIDSearcher + size.SizeOfPtr +
+		s.reader.Size() +
+		s.scorer.Size()
 }
 
 func (s *DocIDSearcher) Count() uint64 {

--- a/search/searcher/search_filter.go
+++ b/search/searcher/search_filter.go
@@ -15,9 +15,19 @@
 package searcher
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeFilteringSearcher int
+
+func init() {
+	var fs FilteringSearcher
+	reflectStaticSizeFilteringSearcher = int(reflect.TypeOf(fs).Size())
+}
 
 // FilterFunc defines a function which can filter documents
 // returning true means keep the document
@@ -36,6 +46,11 @@ func NewFilteringSearcher(s search.Searcher, filter FilterFunc) *FilteringSearch
 		child:  s,
 		accept: filter,
 	}
+}
+
+func (f *FilteringSearcher) Size() int {
+	return reflectStaticSizeFilteringSearcher + size.SizeOfPtr +
+		f.child.Size()
 }
 
 func (f *FilteringSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {

--- a/search/searcher/search_match_all.go
+++ b/search/searcher/search_match_all.go
@@ -15,10 +15,20 @@
 package searcher
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
 	"github.com/blevesearch/bleve/search/scorer"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeMatchAllSearcher int
+
+func init() {
+	var mas MatchAllSearcher
+	reflectStaticSizeMatchAllSearcher = int(reflect.TypeOf(mas).Size())
+}
 
 type MatchAllSearcher struct {
 	indexReader index.IndexReader
@@ -44,6 +54,13 @@ func NewMatchAllSearcher(indexReader index.IndexReader, boost float64, options s
 		scorer:      scorer,
 		count:       count,
 	}, nil
+}
+
+func (s *MatchAllSearcher) Size() int {
+	return reflectStaticSizeMatchAllSearcher + size.SizeOfPtr +
+		s.indexReader.Size() +
+		s.reader.Size() +
+		s.scorer.Size()
 }
 
 func (s *MatchAllSearcher) Count() uint64 {

--- a/search/searcher/search_match_none.go
+++ b/search/searcher/search_match_none.go
@@ -15,9 +15,19 @@
 package searcher
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeMatchNoneSearcher int
+
+func init() {
+	var mns MatchNoneSearcher
+	reflectStaticSizeMatchNoneSearcher = int(reflect.TypeOf(mns).Size())
+}
 
 type MatchNoneSearcher struct {
 	indexReader index.IndexReader
@@ -27,6 +37,11 @@ func NewMatchNoneSearcher(indexReader index.IndexReader) (*MatchNoneSearcher, er
 	return &MatchNoneSearcher{
 		indexReader: indexReader,
 	}, nil
+}
+
+func (s *MatchNoneSearcher) Size() int {
+	return reflectStaticSizeMatchNoneSearcher + size.SizeOfPtr +
+		s.indexReader.Size()
 }
 
 func (s *MatchNoneSearcher) Count() uint64 {

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -15,10 +15,20 @@
 package searcher
 
 import (
+	"reflect"
+
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
 	"github.com/blevesearch/bleve/search/scorer"
+	"github.com/blevesearch/bleve/size"
 )
+
+var reflectStaticSizeTermSearcher int
+
+func init() {
+	var ts TermSearcher
+	reflectStaticSizeTermSearcher = int(reflect.TypeOf(ts).Size())
+}
 
 type TermSearcher struct {
 	indexReader index.IndexReader
@@ -61,6 +71,14 @@ func NewTermSearcherBytes(indexReader index.IndexReader, term []byte, field stri
 		reader:      reader,
 		scorer:      scorer,
 	}, nil
+}
+
+func (s *TermSearcher) Size() int {
+	return reflectStaticSizeTermSearcher + size.SizeOfPtr +
+		s.indexReader.Size() +
+		s.reader.Size() +
+		s.tfd.Size() +
+		s.scorer.Size()
 }
 
 func (s *TermSearcher) Count() uint64 {

--- a/size/sizes.go
+++ b/size/sizes.go
@@ -1,0 +1,57 @@
+//  Copyright (c) 2018 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package size
+
+import (
+	"reflect"
+)
+
+func init() {
+	var a bool
+	SizeOfBool = int(reflect.TypeOf(a).Size())
+	var b float32
+	SizeOfFloat32 = int(reflect.TypeOf(b).Size())
+	var c float64
+	SizeOfFloat64 = int(reflect.TypeOf(c).Size())
+	var d map[int]int
+	SizeOfMap = int(reflect.TypeOf(d).Size())
+	var e *int
+	SizeOfPtr = int(reflect.TypeOf(e).Size())
+	var f []int
+	SizeOfSlice = int(reflect.TypeOf(f).Size())
+	var g string
+	SizeOfString = int(reflect.TypeOf(g).Size())
+	var h uint8
+	SizeOfUint8 = int(reflect.TypeOf(h).Size())
+	var i uint16
+	SizeOfUint16 = int(reflect.TypeOf(i).Size())
+	var j uint32
+	SizeOfUint32 = int(reflect.TypeOf(j).Size())
+	var k uint64
+	SizeOfUint64 = int(reflect.TypeOf(k).Size())
+}
+
+var SizeOfBool int
+var SizeOfFloat32 int
+var SizeOfFloat64 int
+var SizeOfInt int
+var SizeOfMap int
+var SizeOfPtr int
+var SizeOfSlice int
+var SizeOfString int
+var SizeOfUint8 int
+var SizeOfUint16 int
+var SizeOfUint32 int
+var SizeOfUint64 int


### PR DESCRIPTION
The intention here is to estimate the amount of memory needed to execute a
search query over an index prior to actually running the search operation.

Sample estimates for certain queries:
{Size: 10, BenchmarkUpsidedownSearchOverhead}

    ESTIMATE     BENCHMEM       TEST
    4616          4796          TermQuery
    5210          5405          MatchQuery
    7700          8447          DisjunctionQuery (of match queries)
    6514          6591          DisjunctionQuery (of term queries)
    7524          8175          ConjunctionQuery (of match queries)
    10306         10708         DisjunctionQuery (disjunction of disjunctions)
    …