### PR TITLE
MB-28403: scorch introduceMerge doesn't prealloc segments capacity

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -195,19 +195,8 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	// acquire lock
 	s.rootLock.Lock()
 
-	// prepare new index snapshot
-	currSize := len(s.root.segment)
-	newSize := currSize + 1 - len(nextMerge.old)
-
-	// empty segments deletion
-	if nextMerge.new == nil {
-		newSize--
-	}
-
 	newSnapshot := &IndexSnapshot{
 		parent:   s,
-		segment:  make([]*SegmentSnapshot, 0, newSize),
-		offsets:  make([]uint64, 0, newSize),
 		internal: s.root.internal,
 		epoch:    s.nextSnapshotEpoch,
 		refs:     1,


### PR DESCRIPTION
There's now multiple competing merge activities (file-merging and
in-memory merging during persistence), so the simple math to
precalculate capacity for the slice of segments in introduceMerge() no
longer works for all cases and might have negative capacity.

This change removes that (sometimes wrong) precalculation, and instead
depends on append() to grow the slice correctly.