### PR TITLE
scorch persister goes through introducer to affect root

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -39,6 +39,8 @@ const Name = "scorch"
 
 const Version uint8 = 1
 
+var ErrClosed = fmt.Errorf("scorch closed")
+
 type Scorch struct {
 	readOnly      bool
 	version       uint8
@@ -59,6 +61,7 @@ type Scorch struct {
 
 	closeCh            chan struct{}
 	introductions      chan *segmentIntroduction
+	persists           chan *persistIntroduction
 	merges             chan *segmentMerge
 	introducerNotifier chan *epochWatcher
 	revertToSnapshots  chan *snapshotReversion
@@ -174,6 +177,7 @@ func (s *Scorch) openBolt() error {
 	}
 
 	s.introductions = make(chan *segmentIntroduction)
+	s.persists = make(chan *persistIntroduction)
 	s.merges = make(chan *segmentMerge)
 	s.introducerNotifier = make(chan *epochWatcher, 1)
 	s.revertToSnapshots = make(chan *snapshotReversion)

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -46,6 +46,8 @@ type Stats struct {
 	TotIntroduceLoop       uint64
 	TotIntroduceSegmentBeg uint64
 	TotIntroduceSegmentEnd uint64
+	TotIntroducePersistBeg uint64
+	TotIntroducePersistEnd uint64
 	TotIntroduceMergeBeg   uint64
 	TotIntroduceMergeEnd   uint64
 	TotIntroduceRevertBeg  uint64


### PR DESCRIPTION
This change allows the introducer to become the only goroutine to
modify the root, which in turn allows the introducer to greatly reduce
its surface area of holding the root lock.