### PR TITLE
adding compaction_written_bytes/sec stats to scorch

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -180,8 +180,9 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			s.markIneligibleForRemoval(filename)
 			path := s.path + string(os.PathSeparator) + filename
 			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
-			newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024, &s.stats)
+			newDocNums, nBytes, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024)
 			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
+			atomic.AddUint64(&s.stats.TotFileMergeWrittenBytes, nBytes)
 			if err != nil {
 				s.unmarkIneligibleForRemoval(filename)
 				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -185,7 +185,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
 			newDocNums, nBytes, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024)
 			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
-      atomic.AddUint64(&s.stats.TotFileMergeWrittenBytes, nBytes)
+			atomic.AddUint64(&s.stats.TotFileMergeWrittenBytes, nBytes)
       
 			fileMergeZapTime := uint64(time.Since(fileMergeZapStartTime))
 			atomic.AddUint64(&s.stats.TotFileMergeZapTime, fileMergeZapTime)
@@ -193,7 +193,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 				atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
 			}
       
-      if err != nil {
+      			if err != nil {
 				s.unmarkIneligibleForRemoval(filename)
 				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 				return fmt.Errorf("merging failed: %v", err)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -180,7 +180,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			s.markIneligibleForRemoval(filename)
 			path := s.path + string(os.PathSeparator) + filename
 			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
-			newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024)
+			newDocNums, err := zap.Merge(segmentsToMerge, docsToDrop, path, 1024, &s.stats)
 			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
 			if err != nil {
 				s.unmarkIneligibleForRemoval(filename)

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -430,6 +430,7 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_items_persisted"] = m["TotPersistedItems"]
 	m["num_bytes_used_disk"] = m["CurOnDiskBytes"]
 	m["num_files_on_disk"] = m["CurOnDiskFiles"]
+	m["total_compaction_written_bytes"] = m["TotCompactionWrittenBytes"]
 
 	return m
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -430,7 +430,7 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_items_persisted"] = m["TotPersistedItems"]
 	m["num_bytes_used_disk"] = m["CurOnDiskBytes"]
 	m["num_files_on_disk"] = m["CurOnDiskFiles"]
-	m["total_compaction_written_bytes"] = m["TotCompactionWrittenBytes"]
+	m["total_compaction_written_bytes"] = m["TotFileMergeWrittenBytes"]
 
 	return m
 }

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -31,22 +31,17 @@ import (
 
 const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
 
-// StatsReporter interface represents stats reporting methods.
-type StatsReporter interface {
-	ReportBytesWritten(numBytesWritten uint64)
-}
-
 // Merge takes a slice of zap segments and bit masks describing which
 // documents may be dropped, and creates a new segment containing the
 // remaining data.  This new segment is built at the specified path,
 // with the provided chunkFactor.
 func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
-	chunkFactor uint32, stats StatsReporter) ([][]uint64, error) {
+	chunkFactor uint32) ([][]uint64, uint64, error) {
 	flag := os.O_RDWR | os.O_CREATE
 
 	f, err := os.OpenFile(path, flag, 0600)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	cleanup := func() {
@@ -69,39 +64,35 @@ func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
 		MergeToWriter(segmentBases, drops, chunkFactor, cr)
 	if err != nil {
 		cleanup()
-		return nil, err
+		return nil, 0, err
 	}
 
 	err = persistFooter(numDocs, storedIndexOffset, fieldsIndexOffset,
 		docValueOffset, chunkFactor, cr.Sum32(), cr)
 	if err != nil {
 		cleanup()
-		return nil, err
+		return nil, 0, err
 	}
 
 	err = br.Flush()
 	if err != nil {
 		cleanup()
-		return nil, err
+		return nil, 0, err
 	}
 
 	err = f.Sync()
 	if err != nil {
 		cleanup()
-		return nil, err
+		return nil, 0, err
 	}
 
 	err = f.Close()
 	if err != nil {
 		cleanup()
-		return nil, err
+		return nil, 0, err
 	}
 
-	if stats != nil {
-		stats.ReportBytesWritten(uint64(cr.Count()))
-	}
-
-	return newDocNums, nil
+	return newDocNums, uint64(cr.Count()), nil
 }
 
 func MergeToWriter(segments []*SegmentBase, drops []*roaring.Bitmap,

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -97,7 +97,9 @@ func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
 		return nil, err
 	}
 
-	stats.ReportBytesWritten(uint64(cr.Count()))
+	if stats != nil {
+		stats.ReportBytesWritten(uint64(cr.Count()))
+	}
 
 	return newDocNums, nil
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -100,6 +100,8 @@ type Stats struct {
 	TotMemMergeZapBeg   uint64
 	TotMemMergeZapEnd   uint64
 	TotMemMergeSegments uint64
+
+	TotCompactionWrittenBytes uint64
 }
 
 // atomically populates the returned map
@@ -121,4 +123,8 @@ func (s *Stats) ToMap() map[string]interface{} {
 // json marshaling provides atomic safety
 func (s *Stats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToMap())
+}
+
+func (s *Stats) ReportBytesWritten(numBytesWritten uint64) {
+	atomic.AddUint64(&s.TotCompactionWrittenBytes, numBytesWritten)
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -87,6 +87,7 @@ type Stats struct {
 
 	TotFileMergeSegmentsEmpty uint64
 	TotFileMergeSegments      uint64
+	TotFileMergeWrittenBytes  uint64
 
 	TotFileMergeZapBeg uint64
 	TotFileMergeZapEnd uint64
@@ -100,8 +101,6 @@ type Stats struct {
 	TotMemMergeZapBeg   uint64
 	TotMemMergeZapEnd   uint64
 	TotMemMergeSegments uint64
-
-	TotCompactionWrittenBytes uint64
 }
 
 // atomically populates the returned map
@@ -123,8 +122,4 @@ func (s *Stats) ToMap() map[string]interface{} {
 // json marshaling provides atomic safety
 func (s *Stats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToMap())
-}
-
-func (s *Stats) ReportBytesWritten(numBytesWritten uint64) {
-	atomic.AddUint64(&s.TotCompactionWrittenBytes, numBytesWritten)
 }


### PR DESCRIPTION
I wasn't sure whether we need the written bytes to be tracked at the CountHashWriter write method level or not.