### PR TITLE
scorch merge optimizations via tf/loc byte copy & reader/decoder reuse

### DIFF
--- a/index/scorch/segment/zap/intcoder.go
+++ b/index/scorch/segment/zap/intcoder.go
@@ -82,6 +82,19 @@ func (c *chunkedIntCoder) Add(docNum uint64, vals ...uint64) error {
 	return nil
 }
 
+func (c *chunkedIntCoder) AddBytes(docNum uint64, buf []byte) error {
+	chunk := docNum / c.chunkSize
+	if chunk != c.currChunk {
+		// starting a new chunk
+		c.Close()
+		c.chunkBuf.Reset()
+		c.currChunk = chunk
+	}
+
+	_, err := c.chunkBuf.Write(buf)
+	return err
+}
+
 // Close indicates you are done calling Add() this allows the final chunk
 // to be encoded.
 func (c *chunkedIntCoder) Close() {

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -337,7 +337,6 @@ func (i *PostingsIterator) Next() (segment.Posting, error) {
 	reuseLocs := i.next.locs // hold for reuse before struct clearing
 	i.next = Posting{}       // clear the struct
 	rv := &i.next
-	rv.iterator = i
 	rv.docNum = uint64(n)
 
 	var err error
@@ -373,12 +372,10 @@ func (i *PostingsIterator) Next() (segment.Posting, error) {
 
 // Posting is a single entry in a postings list
 type Posting struct {
-	iterator *PostingsIterator
-	docNum   uint64
-
-	freq uint64
-	norm float32
-	locs []segment.Location
+	docNum uint64
+	freq   uint64
+	norm   float32
+	locs   []segment.Location
 }
 
 // Number returns the document number of this posting in this segment

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -279,74 +279,26 @@ func (i *PostingsIterator) readLocation(l *Location) error {
 
 // Next returns the next posting on the postings list, or nil at the end
 func (i *PostingsIterator) Next() (segment.Posting, error) {
-	if i.actual == nil || !i.actual.HasNext() {
+	docNum, exists, err := i.nextDocNum()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
 		return nil, nil
-	}
-	n := i.actual.Next()
-	nChunk := n / i.postings.sb.chunkFactor
-	allN := i.all.Next()
-	allNChunk := allN / i.postings.sb.chunkFactor
-
-	// n is the next actual hit (excluding some postings)
-	// allN is the next hit in the full postings
-	// if they don't match, adjust offsets to factor in item we're skipping over
-	// incr the all iterator, and check again
-	for allN != n {
-
-		// in different chunks, reset offsets
-		if allNChunk != nChunk {
-			i.locoffset = 0
-			i.offset = 0
-		} else {
-
-			if i.currChunk != nChunk || i.currChunkFreqNorm == nil {
-				err := i.loadChunk(int(nChunk))
-				if err != nil {
-					return nil, fmt.Errorf("error loading chunk: %v", err)
-				}
-			}
-
-			// read off freq/offsets even though we don't care about them
-			freq, _, err := i.readFreqNorm()
-			if err != nil {
-				return nil, err
-			}
-			if i.locBitmap.Contains(allN) {
-				for j := 0; j < int(freq); j++ {
-					err := i.readLocation(nil)
-					if err != nil {
-						return nil, err
-					}
-				}
-			}
-
-			// in same chunk, need to account for offsets
-			i.offset++
-		}
-
-		allN = i.all.Next()
-	}
-
-	if i.currChunk != nChunk || i.currChunkFreqNorm == nil {
-		err := i.loadChunk(int(nChunk))
-		if err != nil {
-			return nil, fmt.Errorf("error loading chunk: %v", err)
-		}
 	}
 
 	reuseLocs := i.next.locs // hold for reuse before struct clearing
 	i.next = Posting{}       // clear the struct
 	rv := &i.next
-	rv.docNum = uint64(n)
+	rv.docNum = docNum
 
-	var err error
 	var normBits uint64
 	rv.freq, normBits, err = i.readFreqNorm()
 	if err != nil {
 		return nil, err
 	}
 	rv.norm = math.Float32frombits(uint32(normBits))
-	if i.locBitmap.Contains(n) {
+	if i.locBitmap.Contains(uint32(docNum)) {
 		// read off 'freq' locations, into reused slices
 		if cap(i.nextLocs) >= int(rv.freq) {
 			i.nextLocs = i.nextLocs[0:rv.freq]
@@ -368,6 +320,66 @@ func (i *PostingsIterator) Next() (segment.Posting, error) {
 	}
 
 	return rv, nil
+}
+
+// nextDocNum returns the next docNum on the postings list, and also
+// sets up the currChunk / loc related fields of the iterator.
+func (i *PostingsIterator) nextDocNum() (uint64, bool, error) {
+	if i.actual == nil || !i.actual.HasNext() {
+		return 0, false, nil
+	}
+
+	n := i.actual.Next()
+	nChunk := n / i.postings.sb.chunkFactor
+	allN := i.all.Next()
+	allNChunk := allN / i.postings.sb.chunkFactor
+
+	// n is the next actual hit (excluding some postings)
+	// allN is the next hit in the full postings
+	// if they don't match, adjust offsets to factor in item we're skipping over
+	// incr the all iterator, and check again
+	for allN != n {
+		// in different chunks, reset offsets
+		if allNChunk != nChunk {
+			i.locoffset = 0
+			i.offset = 0
+		} else {
+			if i.currChunk != nChunk || i.currChunkFreqNorm == nil {
+				err := i.loadChunk(int(nChunk))
+				if err != nil {
+					return 0, false, fmt.Errorf("error loading chunk: %v", err)
+				}
+			}
+
+			// read off freq/offsets even though we don't care about them
+			freq, _, err := i.readFreqNorm()
+			if err != nil {
+				return 0, false, err
+			}
+			if i.locBitmap.Contains(allN) {
+				for j := 0; j < int(freq); j++ {
+					err := i.readLocation(nil)
+					if err != nil {
+						return 0, false, err
+					}
+				}
+			}
+
+			// in same chunk, need to account for offsets
+			i.offset++
+		}
+
+		allN = i.all.Next()
+	}
+
+	if i.currChunk != nChunk || i.currChunkFreqNorm == nil {
+		err := i.loadChunk(int(nChunk))
+		if err != nil {
+			return 0, false, fmt.Errorf("error loading chunk: %v", err)
+		}
+	}
+
+	return uint64(n), true, nil
 }
 
 // Posting is a single entry in a postings list

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -45,7 +45,25 @@ func (p *PostingsList) iterator(rv *PostingsIterator) *PostingsIterator {
 	if rv == nil {
 		rv = &PostingsIterator{}
 	} else {
+		freqNormReader := rv.freqNormReader
+		if freqNormReader != nil {
+			freqNormReader.Reset([]byte(nil))
+		}
+		freqNormDecoder := rv.freqNormDecoder
+
+		locReader := rv.locReader
+		if locReader != nil {
+			locReader.Reset([]byte(nil))
+		}
+		locDecoder := rv.locDecoder
+
 		*rv = PostingsIterator{} // clear the struct
+
+		rv.freqNormReader = freqNormReader
+		rv.freqNormDecoder = freqNormDecoder
+
+		rv.locReader = locReader
+		rv.locDecoder = locDecoder
 	}
 	rv.postings = p
 


### PR DESCRIPTION
This PR optimizes zap segment merging by byte-copying the encoded tf/loc entries.

Also, PostingsIterator receive some more reuse of encoders/readers.