### PR TITLE
Fixing the scorch search request memory estimate

### DIFF
--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -57,18 +57,6 @@ type PostingsList struct {
 func (p *PostingsList) Size() int {
 	sizeInBytes := reflectStaticSizePostingsList + size.SizeOfPtr
 
-	if p.sb != nil {
-		sizeInBytes += (p.sb.Size() - len(p.sb.mem)) // do not include the mmap'ed part
-	}
-
-	if p.locBitmap != nil {
-		sizeInBytes += int(p.locBitmap.GetSizeInBytes())
-	}
-
-	if p.postings != nil {
-		sizeInBytes += int(p.postings.GetSizeInBytes())
-	}
-
 	if p.except != nil {
 		sizeInBytes += int(p.except.GetSizeInBytes())
 	}


### PR DESCRIPTION
Do not re-account for certain referenced data in the zap structures.

New estimates:

    ESTIMATE     BENCHMEM       TEST
    11396        12437          TermQuery
    12244        12951          MatchQuery
    20644        20709          DisjunctionQuery (of term queries)
