### PR TITLE
scorch zap optimize FST val encoding for terms with 1 hit

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/snappy"
 )
 
-const version uint32 = 3
+const version uint32 = 4
 
 const fieldNotUninverted = math.MaxUint64
 

--- a/index/scorch/segment/zap/intcoder.go
+++ b/index/scorch/segment/zap/intcoder.go
@@ -130,3 +130,7 @@ func (c *chunkedIntCoder) Write(w io.Writer) (int, error) {
 	}
 	return tw, nil
 }
+
+func (c *chunkedIntCoder) FinalSize() int {
+	return len(c.final)
+}

--- a/index/scorch/segment/zap/merge_test.go
+++ b/index/scorch/segment/zap/merge_test.go
@@ -859,3 +859,12 @@ func TestMergeBytesWritten(t *testing.T) {
 
 	testMergeWithSelf(t, seg3, 4)
 }
+
+func TestUnder32Bits(t *testing.T) {
+	if !under32Bits(0) || !under32Bits(uint64(0x7fffffff)) {
+		t.Errorf("under32Bits bad")
+	}
+	if under32Bits(uint64(0x80000000)) || under32Bits(uint64(0x80000001)) {
+		t.Errorf("under32Bits wrong")
+	}
+}


### PR DESCRIPTION
NOTE: this is a scorch zap file format change / bump to version 4.

In this optimization, the uint64 val stored in the vellum FST (term
dictionary) now may either be a uint64 postingsOffset (same as before
this change) or a uint64 encoding of the docNum + norm (in the case
where a term appears in just a single doc).

Using aruna's testrunner test (100K docs, 30K updates), file sizes
drop from 660MB before this change to 300MB after this change.