### PR TITLE
scorch fix document.DocValues handling and unit test

### DIFF
--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -1329,8 +1329,10 @@ func TestIndexDocumentVisitFieldTerms(t *testing.T) {
 	}()
 
 	doc := document.NewDocument("1")
-	doc.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test"), document.IndexField|document.StoreField|document.IncludeTermVectors))
-	doc.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister"), document.IndexField|document.StoreField|document.IncludeTermVectors))
+	doc.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
+	doc.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
 	err = idx.Update(doc)
 	if err != nil {
 		t.Errorf("Error updating index: %v", err)
@@ -1512,8 +1514,10 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 	}()
 
 	doc := document.NewDocument("1")
-	doc.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test"), document.IndexField|document.StoreField|document.IncludeTermVectors))
-	doc.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister"), document.IndexField|document.StoreField|document.IncludeTermVectors))
+	doc.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
+	doc.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
 
 	err = idx.Update(doc)
 	if err != nil {
@@ -1549,8 +1553,10 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 	}
 
 	doc2 := document.NewDocument("2")
-	doc2.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test2"), document.IndexField|document.StoreField|document.IncludeTermVectors))
-	doc2.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister2"), document.IndexField|document.StoreField|document.IncludeTermVectors))
+	doc2.AddField(document.NewTextFieldWithIndexingOptions("name", []uint64{}, []byte("test2"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
+	doc2.AddField(document.NewTextFieldWithIndexingOptions("title", []uint64{}, []byte("mister2"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
 	err = idx.Update(doc2)
 	if err != nil {
 		t.Errorf("Error updating index: %v", err)
@@ -1584,8 +1590,10 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 	}
 
 	doc3 := document.NewDocument("3")
-	doc3.AddField(document.NewTextFieldWithIndexingOptions("name3", []uint64{}, []byte("test3"), document.IndexField|document.StoreField|document.IncludeTermVectors))
-	doc3.AddField(document.NewTextFieldWithIndexingOptions("title3", []uint64{}, []byte("mister3"), document.IndexField|document.StoreField|document.IncludeTermVectors))
+	doc3.AddField(document.NewTextFieldWithIndexingOptions("name3", []uint64{}, []byte("test3"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors|document.DocValues))
+	doc3.AddField(document.NewTextFieldWithIndexingOptions("title3", []uint64{}, []byte("mister3"),
+		document.IndexField|document.StoreField|document.IncludeTermVectors)) // no doc values for title3
 	err = idx.Update(doc3)
 	if err != nil {
 		t.Errorf("Error updating index: %v", err)
@@ -1607,8 +1615,7 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 		t.Error(err)
 	}
 	expectedFieldTerms = index.FieldTerms{
-		"name3":  []string{"test3"},
-		"title3": []string{"mister3"},
+		"name3": []string{"test3"},
 	}
 	if !reflect.DeepEqual(fieldTerms, expectedFieldTerms) {
 		t.Errorf("expected field terms: %#v, got: %#v", expectedFieldTerms, fieldTerms)
@@ -1665,7 +1672,7 @@ func TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions(t *testing.T) {
 
 	// mix of field options, this exercises the run time/ on the fly un inverting of
 	// doc values for custom options enabled field like designation, dept.
-	options := document.IndexField | document.StoreField | document.IncludeTermVectors
+	options := document.IndexField | document.StoreField | document.IncludeTermVectors | document.DocValues
 	doc := document.NewDocument("1")
 	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))    // default doc value persisted
 	doc.AddField(document.NewTextField("title", []uint64{}, []byte("mister"))) // default doc value persisted

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -423,63 +423,14 @@ func (i *IndexSnapshot) DocumentVisitFieldTerms(id index.IndexInternalID,
 	ss := i.segment[segmentIndex]
 
 	if zaps, ok := ss.segment.(segment.DocumentFieldTermVisitable); ok {
-		// get the list of doc value persisted fields
-		pFields, err := zaps.VisitableDocValueFields()
-		if err != nil {
-			return err
-		}
-		// assort the fields for which terms look up have to
-		// be performed runtime
-		dvPendingFields := extractDvPendingFields(fields, pFields)
-		if len(dvPendingFields) == 0 {
-			// all fields are doc value persisted
-			return zaps.VisitDocumentFieldTerms(localDocNum, fields, visitor)
-		}
-
-		// concurrently trigger the runtime doc value preparations for
-		// pending fields as well as the visit of the persisted doc values
-		errCh := make(chan error, 1)
-
-		go func() {
-			defer close(errCh)
-			err := ss.cachedDocs.prepareFields(fields, ss)
-			if err != nil {
-				errCh <- err
-			}
-		}()
-
-		// visit the persisted dv while the cache preparation is in progress
-		err = zaps.VisitDocumentFieldTerms(localDocNum, fields, visitor)
-		if err != nil {
-			return err
-		}
-
-		// err out if fieldCache preparation failed
-		err = <-errCh
-		if err != nil {
-			return err
-		}
-
-		visitDocumentFieldCacheTerms(localDocNum, dvPendingFields, ss, visitor)
-		return nil
+		return zaps.VisitDocumentFieldTerms(localDocNum, fields, visitor)
 	}
 
-	return prepareCacheVisitDocumentFieldTerms(localDocNum, fields, ss, visitor)
-}
-
-func prepareCacheVisitDocumentFieldTerms(localDocNum uint64, fields []string,
-	ss *SegmentSnapshot, visitor index.DocumentFieldTermVisitor) error {
-	err := ss.cachedDocs.prepareFields(fields, ss)
+	// else fallback to the in memory fieldCache
+	err = ss.cachedDocs.prepareFields(fields, ss)
 	if err != nil {
 		return err
 	}
-
-	visitDocumentFieldCacheTerms(localDocNum, fields, ss, visitor)
-	return nil
-}
-
-func visitDocumentFieldCacheTerms(localDocNum uint64, fields []string,
-	ss *SegmentSnapshot, visitor index.DocumentFieldTermVisitor) {
 
 	for _, field := range fields {
 		if cachedFieldDocs, exists := ss.cachedDocs.cache[field]; exists {
@@ -496,21 +447,7 @@ func visitDocumentFieldCacheTerms(localDocNum uint64, fields []string,
 		}
 	}
 
-}
-
-func extractDvPendingFields(requestedFields, persistedFields []string) []string {
-	removeMap := map[string]struct{}{}
-	for _, str := range persistedFields {
-		removeMap[str] = struct{}{}
-	}
-
-	rv := make([]string, 0, len(requestedFields))
-	for _, s := range requestedFields {
-		if _, ok := removeMap[s]; !ok {
-			rv = append(rv, s)
-		}
-	}
-	return rv
+	return nil
 }
 
 func (i *IndexSnapshot) DumpAll() chan interface{} {


### PR DESCRIPTION
The unit tests were incorrectly not flipping on the document.DocValues
option.  The tests were inadvertently passing before in that the
previous implementation incorrectly would cache doc values for all
fields.

Also, the unit tests didn't have a case where some fields had the
DocValues option enabled, and other fields had it disabled -- which
led to a bug discovery, and also to a fix that rolls back part of
commit 4c256f5669.  Basically, the previous approach with a helper
goroutine would incorrectly cache all doc values for all fields no
matter what document.DocValues option was provided.