### PR TITLE
scorch zap optimize to avoid bitmaps for 1-hit posting lists

### DIFF
--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -341,15 +341,13 @@ func (s *SegmentBase) DocNumbers(ids []string) (*roaring.Bitmap, error) {
 			return nil, err
 		}
 
-		var postings *PostingsList
+		var postingsList *PostingsList
 		for _, id := range ids {
-			postings, err = idDict.postingsList([]byte(id), nil, postings)
+			postingsList, err = idDict.postingsList([]byte(id), nil, postingsList)
 			if err != nil {
 				return nil, err
 			}
-			if postings.postings != nil {
-				rv.Or(postings.postings)
-			}
+			postingsList.OrInto(rv)
 		}
 	}
 


### PR DESCRIPTION
This commit avoids creating roaring.Bitmap's (which would have just a
single entry) when a postings list/iterator represents a single
"1-hit" encoding.