### PR TITLE
reuse roaring Bitmaps and also use sync.Pool for interim data

### DIFF
--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -68,7 +68,19 @@ func (d *Dictionary) postingsListInit(rv *PostingsList, except *roaring.Bitmap) 
 	if rv == nil {
 		rv = &PostingsList{}
 	} else {
+		postings := rv.postings
+		if postings != nil {
+			postings.Clear()
+		}
+		locBitmap := rv.locBitmap
+		if locBitmap != nil {
+			locBitmap.Clear()
+		}
+
 		*rv = PostingsList{} // clear the struct
+
+		rv.postings = postings
+		rv.locBitmap = locBitmap
 	}
 	rv.sb = d.sb
 	rv.except = except

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -183,6 +183,9 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 		return nil, 0, err
 	}
 
+	newRoaring := roaring.NewBitmap()
+	newRoaringLocs := roaring.NewBitmap()
+
 	// for each field
 	for fieldID, fieldName := range fieldsInv {
 
@@ -222,8 +225,8 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 
 		var prevTerm []byte
 
-		newRoaring := roaring.NewBitmap()
-		newRoaringLocs := roaring.NewBitmap()
+		newRoaring.Clear()
+		newRoaringLocs.Clear()
 
 		var lastDocNum, lastFreq, lastNorm uint64
 
@@ -262,8 +265,8 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 				}
 			}
 
-			newRoaring = roaring.NewBitmap()
-			newRoaringLocs = roaring.NewBitmap()
+			newRoaring.Clear()
+			newRoaringLocs.Clear()
 
 			tfEncoder.Reset()
 			locEncoder.Reset()

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -334,7 +334,7 @@ func (s *interim) processDocument(docNum uint64,
 		for term, tf := range tfs {
 			pid := dict[term] - 1
 			bs := s.Postings[pid]
-			bs.AddInt(int(docNum))
+			bs.Add(uint32(docNum))
 
 			s.FreqNorms[pid] = append(s.FreqNorms[pid],
 				interimFreqNorm{
@@ -344,7 +344,7 @@ func (s *interim) processDocument(docNum uint64,
 
 			if len(tf.Locations) > 0 {
 				locBS := s.PostingsLocs[pid]
-				locBS.AddInt(int(docNum))
+				locBS.Add(uint32(docNum))
 
 				locs := s.Locs[pid]
 

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -309,19 +309,27 @@ func (s *interim) prepareDicts() {
 	if cap(s.Postings) >= numPostingsLists {
 		s.Postings = s.Postings[:numPostingsLists]
 	} else {
-		s.Postings = make([]*roaring.Bitmap, numPostingsLists)
+		postings := make([]*roaring.Bitmap, numPostingsLists)
+		copy(postings, s.Postings[:cap(s.Postings)])
 		for i := 0; i < numPostingsLists; i++ {
-			s.Postings[i] = roaring.New()
+			if postings[i] == nil {
+				postings[i] = roaring.New()
+			}
 		}
+		s.Postings = postings
 	}
 
 	if cap(s.PostingsLocs) >= numPostingsLists {
 		s.PostingsLocs = s.PostingsLocs[:numPostingsLists]
 	} else {
-		s.PostingsLocs = make([]*roaring.Bitmap, numPostingsLists)
+		postingsLocs := make([]*roaring.Bitmap, numPostingsLists)
+		copy(postingsLocs, s.PostingsLocs[:cap(s.PostingsLocs)])
 		for i := 0; i < numPostingsLists; i++ {
-			s.PostingsLocs[i] = roaring.New()
+			if postingsLocs[i] == nil {
+				postingsLocs[i] = roaring.New()
+			}
 		}
+		s.PostingsLocs = postingsLocs
 	}
 
 	// TODO: reuse this.

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -266,7 +266,9 @@ func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
 
 	locRoaringBytes := d.sb.mem[locBitmapOffset+uint64(read) : locBitmapOffset+uint64(read)+locBitmapLen]
 
-	rv.locBitmap = roaring.NewBitmap()
+	if rv.locBitmap == nil {
+		rv.locBitmap = roaring.NewBitmap()
+	}
 	_, err := rv.locBitmap.FromBuffer(locRoaringBytes)
 	if err != nil {
 		return fmt.Errorf("error loading roaring bitmap of locations with hits: %v", err)
@@ -278,7 +280,9 @@ func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
 
 	roaringBytes := d.sb.mem[postingsOffset+n : postingsOffset+n+postingsLen]
 
-	rv.postings = roaring.NewBitmap()
+	if rv.postings == nil {
+		rv.postings = roaring.NewBitmap()
+	}
 	_, err = rv.postings.FromBuffer(roaringBytes)
 	if err != nil {
 		return fmt.Errorf("error loading roaring bitmap: %v", err)


### PR DESCRIPTION
Using sync.Pool for the interim struct and its slices.  As part of that, there's an interim.cleanse() method that prepares it for reuse when returning it to the sync.Pool.

And, roaring has a Clear() API that can help a tiny bit with memory reuse.  That should get even better if a proposed Clear() optimization PR gets approved into roaring: https://github.com/RoaringBitmap/roaring/pull/156


