### PR TITLE
Do not account IndexReader's size in the query RAM estimate

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -94,8 +94,6 @@ type IndexReader interface {
 	DumpFields() chan interface{}
 
 	Close() error
-
-	Size() int
 }
 
 // FieldTerms contains the terms used by a document, keyed by field

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -27,7 +27,6 @@ import (
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/scorch/segment"
-	"github.com/blevesearch/bleve/size"
 )
 
 type asynchSegmentResult struct {
@@ -88,12 +87,6 @@ func (i *IndexSnapshot) DecRef() (err error) {
 
 func (i *IndexSnapshot) Close() error {
 	return i.DecRef()
-}
-
-func (i *IndexSnapshot) Size() int {
-	// Just return the size of the pointer for estimating the overhead
-	// during Search, a reference of the IndexSnapshot serves as the reader.
-	return size.SizeOfPtr
 }
 
 func (i *IndexSnapshot) newIndexSnapshotFieldDict(field string, makeItr func(i segment.TermDictionary) segment.DictionaryIterator) (*IndexSnapshotFieldDict, error) {

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -20,7 +20,6 @@ import (
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store"
-	"github.com/blevesearch/bleve/size"
 )
 
 var reflectStaticSizeIndexReader int
@@ -34,10 +33,6 @@ type IndexReader struct {
 	index    *UpsideDownCouch
 	kvreader store.KVReader
 	docCount uint64
-}
-
-func (i *IndexReader) Size() int {
-	return reflectStaticSizeIndexReader + size.SizeOfPtr
 }
 
 func (i *IndexReader) TermFieldReader(term []byte, fieldName string, includeFreq, includeNorm, includeTermVectors bool) (index.TermFieldReader, error) {

--- a/index/upsidedown/reader.go
+++ b/index/upsidedown/reader.go
@@ -203,7 +203,7 @@ type UpsideDownCouchDocIDReader struct {
 
 func (r *UpsideDownCouchDocIDReader) Size() int {
 	sizeInBytes := reflectStaticSizeUpsideDownCouchDocIDReader +
-		r.indexReader.Size()
+		reflectStaticSizeIndexReader + size.SizeOfPtr
 
 	for _, entry := range r.only {
 		sizeInBytes += size.SizeOfString + len(entry)

--- a/search/facets_builder.go
+++ b/search/facets_builder.go
@@ -66,8 +66,7 @@ func NewFacetsBuilder(indexReader index.IndexReader) *FacetsBuilder {
 }
 
 func (fb *FacetsBuilder) Size() int {
-	sizeInBytes := reflectStaticSizeFacetsBuilder + size.SizeOfPtr +
-		fb.indexReader.Size()
+	sizeInBytes := reflectStaticSizeFacetsBuilder + size.SizeOfPtr
 
 	for k, v := range fb.facets {
 		sizeInBytes += size.SizeOfString + len(k) +

--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -62,8 +62,7 @@ func NewBooleanSearcher(indexReader index.IndexReader, mustSearcher search.Searc
 }
 
 func (s *BooleanSearcher) Size() int {
-	sizeInBytes := reflectStaticSizeBooleanSearcher + size.SizeOfPtr +
-		s.indexReader.Size()
+	sizeInBytes := reflectStaticSizeBooleanSearcher + size.SizeOfPtr
 
 	if s.mustSearcher != nil {
 		sizeInBytes += s.mustSearcher.Size()

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -101,7 +101,6 @@ func newDisjunctionSearcher(indexReader index.IndexReader,
 
 func (s *DisjunctionSearcher) Size() int {
 	sizeInBytes := reflectStaticSizeDisjunctionSearcher + size.SizeOfPtr +
-		s.indexReader.Size() +
 		s.scorer.Size()
 
 	for _, entry := range s.searchers {

--- a/search/searcher/search_match_all.go
+++ b/search/searcher/search_match_all.go
@@ -58,7 +58,6 @@ func NewMatchAllSearcher(indexReader index.IndexReader, boost float64, options s
 
 func (s *MatchAllSearcher) Size() int {
 	return reflectStaticSizeMatchAllSearcher + size.SizeOfPtr +
-		s.indexReader.Size() +
 		s.reader.Size() +
 		s.scorer.Size()
 }

--- a/search/searcher/search_match_none.go
+++ b/search/searcher/search_match_none.go
@@ -40,8 +40,7 @@ func NewMatchNoneSearcher(indexReader index.IndexReader) (*MatchNoneSearcher, er
 }
 
 func (s *MatchNoneSearcher) Size() int {
-	return reflectStaticSizeMatchNoneSearcher + size.SizeOfPtr +
-		s.indexReader.Size()
+	return reflectStaticSizeMatchNoneSearcher + size.SizeOfPtr
 }
 
 func (s *MatchNoneSearcher) Count() uint64 {

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -42,8 +42,7 @@ type PhraseSearcher struct {
 }
 
 func (s *PhraseSearcher) Size() int {
-	sizeInBytes := reflectStaticSizePhraseSearcher + size.SizeOfPtr +
-		s.indexReader.Size()
+	sizeInBytes := reflectStaticSizePhraseSearcher + size.SizeOfPtr
 
 	if s.mustSearcher != nil {
 		sizeInBytes += s.mustSearcher.Size()

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -75,7 +75,6 @@ func NewTermSearcherBytes(indexReader index.IndexReader, term []byte, field stri
 
 func (s *TermSearcher) Size() int {
 	return reflectStaticSizeTermSearcher + size.SizeOfPtr +
-		s.indexReader.Size() +
 		s.reader.Size() +
 		s.tfd.Size() +
 		s.scorer.Size()


### PR DESCRIPTION
Since its just the pointer size of the IndexReader that is being
accounted for while estimating the RAM needed to execute a
search query, get rid of the Size() API within the IndexReader.