### PR TITLE
WIP-example-disable-recent-optimizations

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -218,6 +218,8 @@ var DefaultMinSegmentsForInMemoryMerge = 2
 // persist the in-memory zap segments if there are enough of them
 func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot) (
 	bool, error) {
+	return false, nil // #A DISABLE IN-MEMORY MERGING FOR PERSISTER
+
 	// collect the in-memory zap segments (SegmentBase instances)
 	var sbs []*zap.SegmentBase
 	var sbsDrops []*roaring.Bitmap

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -309,7 +309,7 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 
 			postItr = postings.iterator(postItr)
 
-			if fieldsSame {
+			if false && fieldsSame { // #1 DISABLE OPTIMIZATION TO COPY FREQ-NORM-LOC BYTES
 				// can optimize by copying freq/norm/loc bytes directly
 				lastDocNum, lastFreq, lastNorm, err = mergeTermFreqNormLocsByCopying(
 					term, postItr, newDocNums[itrI], newRoaring, newRoaringLocs,
@@ -513,7 +513,7 @@ func writePostings(postings, postingLocs *roaring.Bitmap,
 		return 0, nil
 	}
 
-	if use1HitEncoding != nil {
+	if false && use1HitEncoding != nil { // #2 DISABLE 1-HIT ENCODING OPTIMIZATION
 		encodeAs1Hit, docNum1Hit, normBits1Hit := use1HitEncoding(termCardinality)
 		if encodeAs1Hit {
 			return FSTValEncode1Hit(docNum1Hit, normBits1Hit), nil
@@ -594,7 +594,7 @@ func mergeStoredAndRemap(segments []*SegmentBase, drops []*roaring.Bitmap,
 		// optimize when the field mapping is the same across all
 		// segments and there are no deletions, via byte-copying
 		// of stored docs bytes directly to the writer
-		if fieldsSame && (dropsI == nil || dropsI.GetCardinality() == 0) {
+		if false && fieldsSame && (dropsI == nil || dropsI.GetCardinality() == 0) { // #3 DISABLE COPY-STORED-DOCS OPTIMIZATION
 			err := segment.copyStoredDocs(newDocNum, docNumOffsets, w)
 			if err != nil {
 				return 0, nil, err

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -61,7 +61,7 @@ func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
 		s.FieldsMap, s.FieldsInv, uint64(len(results)),
 		storedIndexOffset, fieldsIndexOffset, fdvIndexOffset, dictOffsets)
 
-	if err == nil && s.reset() == nil {
+	if false && err == nil && s.reset() == nil { // #4 DISABLE INTERIM REUSE OPTIMIZATION
 		s.lastNumDocs = len(results)
 		s.lastOutSize = len(br.Bytes())
 		interimPool.Put(s)


### PR DESCRIPTION
DO NOT MERGE

hi @abhinavdangeti -- these are some example one-liner changes of disabling various recent scorch optimizations.  I've kinda numbered them with my guesstimates of which ones might be more fruitful than others.

You might try them all in one-shot, and if that seems to help, then have to try further runs to see which individual one's are the root cause.

