### PR TITLE
fix MB-28719 and MB-28781 invalid/missing field in scorch

### DIFF
--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -135,7 +135,7 @@ func (s *interim) reset() (err error) {
 	s.chunkFactor = 0
 	s.w = nil
 	s.FieldsMap = nil
-	s.FieldsInv = s.FieldsInv[:0]
+	s.FieldsInv = nil
 	for i := range s.Dicts {
 		s.Dicts[i] = nil
 	}


### PR DESCRIPTION
Use of sync.Pool to reuse the interm structure relied on resetting
the fieldsInv slice.  However, actual segments continued to use
this same fieldsInv slice after returning it to the pool. Simple
fix is to nil out fieldsInv slice in reset method and let the
newly built segment keep the one from the interim struct.