### PR TITLE
PostingsIterator.nextDocNum() maintains allNChunk correctly

### DIFF
--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -316,11 +316,9 @@ func (rv *PostingsList) init1Hit(fstVal uint64) error {
 
 // PostingsIterator provides a way to iterate through the postings list
 type PostingsIterator struct {
-	postings  *PostingsList
-	all       roaring.IntIterable
-	offset    int
-	locoffset int
-	actual    roaring.IntIterable
+	postings *PostingsList
+	all      roaring.IntIterable
+	actual   roaring.IntIterable
 
 	currChunk         uint32
 	currChunkFreqNorm []byte
@@ -584,16 +582,12 @@ func (i *PostingsIterator) nextDocNum() (uint64, bool, error) {
 	nChunk := n / i.postings.sb.chunkFactor
 	allNChunk := allN / i.postings.sb.chunkFactor
 
-	// n is the next actual hit (excluding some postings)
-	// allN is the next hit in the full postings
-	// if they don't match, adjust offsets to factor in item we're skipping over
-	// incr the all iterator, and check again
+	// n is the next actual hit (excluding some postings), and
+	// allN is the next hit in the full postings, and
+	// if they don't match, move 'all' forwards until they do
 	for allN != n {
-		// in different chunks, reset offsets
-		if allNChunk != nChunk {
-			i.locoffset = 0
-			i.offset = 0
-		} else {
+		// in the same chunk, so move the freq/norm/loc decoders forward
+		if allNChunk == nChunk {
 			if i.currChunk != nChunk || i.currChunkFreqNorm == nil {
 				err := i.loadChunk(int(nChunk))
 				if err != nil {
@@ -614,9 +608,6 @@ func (i *PostingsIterator) nextDocNum() (uint64, bool, error) {
 					}
 				}
 			}
-
-			// in same chunk, need to account for offsets
-			i.offset++
 		}
 
 		allN = i.all.Next()

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -620,6 +620,7 @@ func (i *PostingsIterator) nextDocNum() (uint64, bool, error) {
 		}
 
 		allN = i.all.Next()
+		allNChunk = allN / i.postings.sb.chunkFactor
 	}
 
 	if i.currChunk != nChunk || i.currChunkFreqNorm == nil {


### PR DESCRIPTION
This PR might fix issues around document updates & deletions in scorch indexes and around freq/norm/locations handling, with a change to PostingsIterator.nextDocNum() that keeps the allNChunk variable in-sync with the allN variable.

Also, this PR removes some unused fields from PostingsIterator (offset & locoffset).