### PR TITLE
Revert "scorch zap replace locsBitmap w/ 1 bit from freq-norm varint …

### DIFF
--- a/cmd/bleve/cmd/zap/explore.go
+++ b/cmd/bleve/cmd/zap/explore.go
@@ -81,6 +81,10 @@ var exploreCmd = &cobra.Command{
 					locAddr, read = binary.Uvarint(data[postingsAddr+n : postingsAddr+n+binary.MaxVarintLen64])
 					n += uint64(read)
 
+					var locBitmapAddr uint64
+					locBitmapAddr, read = binary.Uvarint(data[postingsAddr+n : postingsAddr+n+binary.MaxVarintLen64])
+					n += uint64(read)
+
 					var postingListLen uint64
 					postingListLen, read = binary.Uvarint(data[postingsAddr+n : postingsAddr+n+binary.MaxVarintLen64])
 					n += uint64(read)
@@ -126,6 +130,8 @@ var exploreCmd = &cobra.Command{
 						fmt.Printf("loc chunk: %d, len %d(%x), start at %d (%x) end %d (%x)\n", k, offset, offset, running2, running2, running2+offset, running2+offset)
 						running2 += offset
 					}
+
+					fmt.Printf("Loc Bitmap at: %d (%x)\n", locBitmapAddr, locBitmapAddr)
 
 				} else {
 					fmt.Printf("dictionary does not contain term '%s'\n", args[2])

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Smerity/govarint"
 )
 
-const version uint32 = 7
+const version uint32 = 6
 
 const fieldNotUninverted = math.MaxUint64
 

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -72,10 +72,15 @@ func (d *Dictionary) postingsListInit(rv *PostingsList, except *roaring.Bitmap) 
 		if postings != nil {
 			postings.Clear()
 		}
+		locBitmap := rv.locBitmap
+		if locBitmap != nil {
+			locBitmap.Clear()
+		}
 
 		*rv = PostingsList{} // clear the struct
 
 		rv.postings = postings
+		rv.locBitmap = locBitmap
 	}
 	rv.sb = d.sb
 	rv.except = except


### PR DESCRIPTION
…encoding"

Testing with the cbft application led to cbft process exits...

  AsyncError exit()... error reading location field: EOF --
  main.initBleveOptions.func1() at init_bleve.go:85

This reverts commit 621b58dd8341232c01653db36372f0e0361bc90f.