### PR TITLE
optimize stored field format in zap for _id field

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Smerity/govarint"
 )
 
-const version uint32 = 8
+const version uint32 = 9
 
 const fieldNotUninverted = math.MaxUint64
 

--- a/index/scorch/segment/zap/build_test.go
+++ b/index/scorch/segment/zap/build_test.go
@@ -311,7 +311,8 @@ func buildTestAnalysisResultsMultiWithDifferentFields(includeDocA, includeDocB b
 		doc := &document.Document{
 			ID: "a",
 			Fields: []document.Field{
-				document.NewTextField("_id", []uint64{}, []byte("a")),
+				document.NewTextFieldCustom("_id", nil, []byte("a"),
+					document.IndexField|document.StoreField, nil),
 				document.NewTextField("name", []uint64{}, []byte("ABC")),
 				document.NewTextField("dept", []uint64{}, []byte("ABC dept")),
 				document.NewTextField("manages.id", []uint64{}, []byte("XYZ")),
@@ -388,7 +389,8 @@ func buildTestAnalysisResultsMultiWithDifferentFields(includeDocA, includeDocB b
 		doc := &document.Document{
 			ID: "b",
 			Fields: []document.Field{
-				document.NewTextField("_id", []uint64{}, []byte("b")),
+				document.NewTextFieldCustom("_id", nil, []byte("b"),
+					document.IndexField|document.StoreField, nil),
 				document.NewTextField("name", []uint64{}, []byte("XYZ")),
 				document.NewTextField("dept", []uint64{}, []byte("ABC dept")),
 				document.NewTextField("reportsTo.id", []uint64{}, []byte("ABC")),
@@ -468,7 +470,8 @@ func buildTestSegmentWithDefaultFieldMapping(chunkFactor uint32) (
 	doc := &document.Document{
 		ID: "a",
 		Fields: []document.Field{
-			document.NewTextField("_id", nil, []byte("a")),
+			document.NewTextFieldCustom("_id", nil, []byte("a"),
+				document.IndexField|document.StoreField, nil),
 			document.NewTextField("name", nil, []byte("wow")),
 			document.NewTextField("desc", nil, []byte("some thing")),
 			document.NewTextField("tag", []uint64{0}, []byte("cold")),

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -622,12 +622,19 @@ func mergeStoredAndRemap(segments []*SegmentBase, drops []*roaring.Bitmap,
 				return 0, nil, err
 			}
 
-			// now walk the fields in order
-			for fieldID := range fieldsInv {
-				storedFieldValues := vals[int(fieldID)]
+			// _id field special case optimizes ExternalID() lookups
+			idFieldVal := vals[uint16(0)][0]
+			_, err = metaEncoder.PutU64(uint64(len(idFieldVal)))
+			if err != nil {
+				return 0, nil, err
+			}
 
-				stf := typs[int(fieldID)]
-				spf := poss[int(fieldID)]
+			// now walk the non-"_id" fields in order
+			for fieldID := 1; fieldID < len(fieldsInv); fieldID++ {
+				storedFieldValues := vals[fieldID]
+
+				stf := typs[fieldID]
+				spf := poss[fieldID]
 
 				var err2 error
 				curr, data, err2 = persistStoredFieldValues(fieldID,
@@ -646,12 +653,19 @@ func mergeStoredAndRemap(segments []*SegmentBase, drops []*roaring.Bitmap,
 			docNumOffsets[newDocNum] = uint64(w.Count())
 
 			// write out the meta len and compressed data len
-			_, err = writeUvarints(w, uint64(len(metaBytes)), uint64(len(compressed)))
+			_, err = writeUvarints(w,
+				uint64(len(metaBytes)),
+				uint64(len(idFieldVal)+len(compressed)))
 			if err != nil {
 				return 0, nil, err
 			}
 			// now write the meta
 			_, err = w.Write(metaBytes)
+			if err != nil {
+				return 0, nil, err
+			}
+			// now write the _id field val (counted as part of the 'compressed' data)
+			_, err = w.Write(idFieldVal)
 			if err != nil {
 				return 0, nil, err
 			}

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
@@ -552,7 +551,7 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 	}
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, expectedFields, _ := buildTestSegmentWithDefaultFieldMapping(1)
+	testSeg, _, _ = buildTestSegmentWithDefaultFieldMapping(1)
 	err = PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
@@ -576,7 +575,7 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 			t.Fatalf("segment VisitableDocValueFields err: %v", err)
 		}
 
-		sort.Strings(expectedFields[1:]) // keep _id as first field
+		expectedFields := []string{"desc", "name", "tag"}
 		if !reflect.DeepEqual(fields, expectedFields) {
 			t.Errorf("expected field terms: %#v, got: %#v", expectedFields, fields)
 		}
@@ -593,7 +592,6 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 			"name": []string{"wow"},
 			"desc": []string{"some", "thing"},
 			"tag":  []string{"cold"},
-			"_id":  []string{"a"},
 		}
 		if !reflect.DeepEqual(fieldTerms, expectedFieldTerms) {
 			t.Errorf("expected field terms: %#v, got: %#v", expectedFieldTerms, fieldTerms)


### PR DESCRIPTION
NOTE: This is a zap version and file format change.

This optimization treats the _id field as a special case, where the
_id field is no longer snappy compressed along with all the other
non-"_id" stored fields.  Instead, the _id field's length and bytes
are written out early and as-is, making the _id value easier to
access.

This can be beneficial to search-related methods, such as
ExternalID(), which only require _id field information.

As part of this, we're also no longer writing out unnecessary data for
the _id field that we persist for other non-"_id" fields, such as: the
numeric fieldID (i.e., uint16(0)), the type (i.e., assumed to be 't'
as a text field), the start offset, the end len, and the
arrayPositions.

Various unit tests were corrected as part of this change in order to
more uniformly treat the _id field as having IndexingOptions as a
stored field and not having DocValues.