### PR TITLE
scorch optimize conjunctions via push-down to roaring.And()

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -272,3 +272,19 @@ func (b *Batch) Reset() {
 	b.IndexOps = make(map[string]*document.Document)
 	b.InternalOps = make(map[string][]byte)
 }
+
+// Optimizable represents an optional interface that implementable by
+// optimizable resources (e.g., TermFieldReaders, Searchers).  These
+// optimizable resources are provided the same OptimizableContext
+// instance, so that they can coordinate via dynamic interface
+// casting.
+type Optimizable interface {
+	Optimize(kind string, octx OptimizableContext) (OptimizableContext, error)
+}
+
+type OptimizableContext interface {
+	// Once all the optimzable resources have been provided the same
+	// OptimizableContext instance, the optimization preparations are
+	// finished or completed via the Finish() method.
+	Finish() error
+}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -1,0 +1,93 @@
+//  Copyright (c) 2018 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorch
+
+import (
+	"fmt"
+
+	"github.com/RoaringBitmap/roaring"
+
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/scorch/segment/zap"
+)
+
+func (s *IndexSnapshotTermFieldReader) Optimize(kind string, octx index.OptimizableContext) (
+	index.OptimizableContext, error) {
+	if kind != "conjunction" {
+		return octx, nil
+	}
+
+	if octx == nil {
+		octx = &OptimizeTFRConjunction{snapshot: s.snapshot}
+	}
+
+	o, ok := octx.(*OptimizeTFRConjunction)
+	if !ok {
+		return octx, nil
+	}
+
+	if o.snapshot != s.snapshot {
+		return nil, fmt.Errorf("tried to optimize across different snapshots")
+	}
+
+	o.tfrs = append(o.tfrs, s)
+
+	return o, nil
+}
+
+type OptimizeTFRConjunction struct {
+	snapshot *IndexSnapshot
+
+	tfrs []*IndexSnapshotTermFieldReader
+}
+
+func (o *OptimizeTFRConjunction) Finish() error {
+	if len(o.tfrs) <= 1 {
+		return nil
+	}
+
+	for i := range o.snapshot.segment {
+		itr0, ok := o.tfrs[0].iterators[i].(*zap.PostingsIterator)
+		if !ok || itr0.ActualBM == nil {
+			continue
+		}
+
+		itr1, ok := o.tfrs[1].iterators[i].(*zap.PostingsIterator)
+		if !ok || itr1.ActualBM == nil {
+			continue
+		}
+
+		bm := roaring.And(itr0.ActualBM, itr1.ActualBM)
+
+		for _, tfr := range o.tfrs[2:] {
+			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			if !ok || itr.ActualBM == nil {
+				continue
+			}
+
+			bm.And(itr.ActualBM)
+		}
+
+		for _, tfr := range o.tfrs {
+			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			if ok && itr.ActualBM != nil {
+				itr.ActualBM = bm
+				itr.Actual = bm.Iterator()
+			}
+		}
+	}
+
+	return nil
+}

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -306,3 +306,18 @@ func (s *DisjunctionSearcher) DocumentMatchPoolSize() int {
 	}
 	return rv
 }
+
+// a disjunction searcher implements the index.Optimizable interface
+// but only activates on an edge case where the disjunction is a
+// wrapper around a single Optimizable child searcher
+func (s *DisjunctionSearcher) Optimize(kind string, octx index.OptimizableContext) (
+	index.OptimizableContext, error) {
+	if len(s.searchers) == 1 {
+		o, ok := s.searchers[0].(index.Optimizable)
+		if ok {
+			return o.Optimize(kind, octx)
+		}
+	}
+
+	return octx, nil
+}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -137,3 +137,13 @@ func (s *TermSearcher) Min() int {
 func (s *TermSearcher) DocumentMatchPoolSize() int {
 	return 1
 }
+
+func (s *TermSearcher) Optimize(kind string, octx index.OptimizableContext) (
+	index.OptimizableContext, error) {
+	o, ok := s.reader.(index.Optimizable)
+	if ok {
+		return o.Optimize(kind, octx)
+	}
+
+	return octx, nil
+}


### PR DESCRIPTION
This change pushes down conjunction information to indexers for
potential TermFieldReader optimizations.  The scorch indexer can
optimize this situation by constructing a more selective roaring
"actual" bitmap for any PostingsIterator's that are part of the
conjunction.

On a bleve-query microbenchmark, dev macbook, with a scorch index of
50K en-wiki docs, using a repeated, single-threaded conjunction query
of several relatively high-frequency terms (query-string of "+text:see
+text:also +text:where +text:http"), perf was ~265 queries/sec before
this change, and ~310 queries/sec after this change.