### PR TITLE
optimize scorch DictionaryIterator.Next() to reuse DictEntry's

### DIFF
--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -151,10 +151,11 @@ func (d *Dictionary) RangeIterator(start, end string) segment.DictionaryIterator
 
 // DictionaryIterator is an iterator for term dictionary
 type DictionaryIterator struct {
-	d   *Dictionary
-	itr vellum.Iterator
-	err error
-	tmp PostingsList
+	d     *Dictionary
+	itr   vellum.Iterator
+	err   error
+	tmp   PostingsList
+	entry index.DictEntry
 }
 
 // Next returns the next entry in the dictionary
@@ -169,10 +170,8 @@ func (i *DictionaryIterator) Next() (*index.DictEntry, error) {
 	if i.err != nil {
 		return nil, i.err
 	}
-	rv := &index.DictEntry{
-		Term:  string(term),
-		Count: i.tmp.Count(),
-	}
+	i.entry.Term = string(term)
+	i.entry.Count = i.tmp.Count()
 	i.err = i.itr.Next()
-	return rv, nil
+	return &i.entry, nil
 }

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -140,7 +140,7 @@ func (i *IndexSnapshot) newIndexSnapshotFieldDict(field string, makeItr func(i s
 			if next != nil {
 				rv.cursors = append(rv.cursors, &segmentDictCursor{
 					itr:  asr.dictItr,
-					curr: next,
+					curr: *next,
 				})
 			}
 		}

--- a/index/scorch/snapshot_index_dict.go
+++ b/index/scorch/snapshot_index_dict.go
@@ -23,12 +23,13 @@ import (
 
 type segmentDictCursor struct {
 	itr  segment.DictionaryIterator
-	curr *index.DictEntry
+	curr index.DictEntry
 }
 
 type IndexSnapshotFieldDict struct {
 	snapshot *IndexSnapshot
 	cursors  []*segmentDictCursor
+	entry    index.DictEntry
 }
 
 func (i *IndexSnapshotFieldDict) Len() int { return len(i.cursors) }
@@ -54,7 +55,7 @@ func (i *IndexSnapshotFieldDict) Next() (*index.DictEntry, error) {
 	if len(i.cursors) <= 0 {
 		return nil, nil
 	}
-	rv := i.cursors[0].curr
+	i.entry = i.cursors[0].curr
 	next, err := i.cursors[0].itr.Next()
 	if err != nil {
 		return nil, err
@@ -64,12 +65,12 @@ func (i *IndexSnapshotFieldDict) Next() (*index.DictEntry, error) {
 		heap.Pop(i)
 	} else {
 		// modified heap, fix it
-		i.cursors[0].curr = next
+		i.cursors[0].curr = *next
 		heap.Fix(i, 0)
 	}
 	// look for any other entries with the exact same term
-	for len(i.cursors) > 0 && i.cursors[0].curr.Term == rv.Term {
-		rv.Count += i.cursors[0].curr.Count
+	for len(i.cursors) > 0 && i.cursors[0].curr.Term == i.entry.Term {
+		i.entry.Count += i.cursors[0].curr.Count
 		next, err := i.cursors[0].itr.Next()
 		if err != nil {
 			return nil, err
@@ -79,12 +80,12 @@ func (i *IndexSnapshotFieldDict) Next() (*index.DictEntry, error) {
 			heap.Pop(i)
 		} else {
 			// modified heap, fix it
-			i.cursors[0].curr = next
+			i.cursors[0].curr = *next
 			heap.Fix(i, 0)
 		}
 	}
 
-	return rv, nil
+	return &i.entry, nil
 }
 
 func (i *IndexSnapshotFieldDict) Close() error {


### PR DESCRIPTION
Optimize DictionaryIterator to reuse a index.DictEntry instance rather than
allocating a new instance on every Next().  This follows an approach
used by upsidedown's dictionary iterators to avoid mem allocations.