### PR TITLE
Address data race with eligibleForRemoval

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -473,19 +473,19 @@ func (s *Scorch) loadFromBolt() error {
 				continue
 			}
 			if foundRoot {
-				s.eligibleForRemoval = append(s.eligibleForRemoval, snapshotEpoch)
+				s.AddEligibleForRemoval(snapshotEpoch)
 				continue
 			}
 			snapshot := snapshots.Bucket(k)
 			if snapshot == nil {
 				log.Printf("snapshot key, but bucket missing %x, continuing", k)
-				s.eligibleForRemoval = append(s.eligibleForRemoval, snapshotEpoch)
+				s.AddEligibleForRemoval(snapshotEpoch)
 				continue
 			}
 			indexSnapshot, err := s.loadSnapshot(snapshot)
 			if err != nil {
 				log.Printf("unable to load snapshot, %v, continuing", err)
-				s.eligibleForRemoval = append(s.eligibleForRemoval, snapshotEpoch)
+				s.AddEligibleForRemoval(snapshotEpoch)
 				continue
 			}
 			indexSnapshot.epoch = snapshotEpoch


### PR DESCRIPTION
WARNING: DATA RACE
Read at 0x00c4201945c8 by goroutine 70:
  runtime.growslice()
      /usr/local/Cellar/go/1.9.3/libexec/src/runtime/slice.go:82 +0x0
  github.com/blevesearch/bleve/index/scorch.(*Scorch).AddEligibleForRemoval()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:485 +0x1bd

Previous write at 0x00c4201945c8 by goroutine 47:
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt.func1()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:476 +0x32b
  github.com/boltdb/bolt.(*DB).View()
      /Users/abhinavdangeti/Documents/go/src/github.com/boltdb/bolt/db.go:629 +0xc1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).loadFromBolt()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/persister.go:462 +0xa1
  github.com/blevesearch/bleve/index/scorch.(*Scorch).openBolt()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:172 +0x9f7
  github.com/blevesearch/bleve/index/scorch.(*Scorch).Open()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/scorch.go:121 +0x3c
  github.com/blevesearch/bleve/index/scorch.TestIndexInsertThenDelete()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/scorch_test.go:341 +0x18d3
  testing.tRunner()
      /usr/local/Cellar/go/1.9.3/libexec/src/testing/testing.go:746 +0x16c