### PR TITLE
Address data race with size of cachedDocs

### DIFF
--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -16,6 +16,7 @@ package scorch
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index/scorch/segment"
@@ -230,7 +231,7 @@ func (c *cachedDocs) prepareFields(wantedFields []string, ss *SegmentSnapshot) e
 }
 
 func (c *cachedDocs) Size() int {
-	return int(c.size)
+	return int(atomic.LoadUint64(&c.size))
 }
 
 func (c *cachedDocs) updateSizeLOCKED() {
@@ -243,5 +244,5 @@ func (c *cachedDocs) updateSizeLOCKED() {
 			}
 		}
 	}
-	c.size = uint64(sizeInBytes)
+	atomic.StoreUint64(&c.size, uint64(sizeInBytes))
 }


### PR DESCRIPTION
WARNING: DATA RACE
Read at 0x00c420901b50 by goroutine 240:
  github.com/blevesearch/bleve/index/scorch.(*SegmentSnapshot).Size()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_segment.go:233 +0xbb
  github.com/blevesearch/bleve/index/scorch.(*IndexSnapshot).updateSize()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_index.go:108 +0x102
  github.com/blevesearch/bleve/index/scorch.(*Scorch).introduceMerge()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/introducer.go:354 +0x131e
  github.com/blevesearch/bleve/index/scorch.(*Scorch).mainLoop()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/introducer.go:66 +0x82d

Previous write at 0x00c420901b50 by goroutine 103:
  github.com/blevesearch/bleve/index/scorch.(*cachedDocs).updateSizeLOCKED()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_segment.go:246 +0x203
  github.com/blevesearch/bleve/index/scorch.(*cachedDocs).prepareFields()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_segment.go:226 +0x5fb
  github.com/blevesearch/bleve/index/scorch.(*IndexSnapshot).DocumentVisitFieldTerms.func1()
      /Users/abhinavdangeti/Documents/go/src/github.com/blevesearch/bleve/index/scorch/snapshot_index.go:456 +0x9f