### PR TITLE
search_phrase findPhrasePaths() fix on slice reuse

### DIFF
--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -288,7 +288,7 @@ func findPhrasePaths(prevPos uint64, ap search.ArrayPositions, phraseTerms [][]s
 
 	// no more terms
 	if len(phraseTerms) < 1 {
-		return []phrasePath{p}
+		return []phrasePath{append(phrasePath(nil), p...)}
 	}
 
 	car := phraseTerms[0]
@@ -320,7 +320,7 @@ func findPhrasePaths(prevPos uint64, ap search.ArrayPositions, phraseTerms [][]s
 				dist = editDistance(prevPos+1, loc.Pos)
 			}
 
-			// if enough slop reamining, continue recursively
+			// if enough slop remaining, continue recursively
 			if prevPos == 0 || (remainingSlop-dist) >= 0 {
 				// this location works, add it to the path (but not for empty term)
 				px := append(p, phrasePart{term: carTerm, loc: loc})


### PR DESCRIPTION
With term locations laid out like "a b c d d", findPhrasePaths() on a search for "a b c d" with sloppiness of 1 ought to have returned a result like...

  a: 1, b: 2, c: 3, d: 4
  a: 1, b: 2, c: 3, d: 5

...but instead was incorrectly returning results like this due to a subtle slice memory reuse issue...

  a: 1, b: 2, c: 3, d: 5
  a: 1, b: 2, c: 3, d: 5

This correctness fix, however, has a cost of generating even more interim allocations / garbage, so that'll probably need to be addressed in some future PR.