### PR TITLE
search phrase findPhrasePaths() fix to avoid reuse of locations

### DIFF
--- a/search/searcher/search_phrase_test.go
+++ b/search/searcher/search_phrase_test.go
@@ -494,6 +494,64 @@ func TestFindPhrasePathsSloppy(t *testing.T) {
 				},
 			},
 		},
+		// test that we don't see multiple hits from the same location
+		{
+			phrase: [][]string{
+				[]string{"cat"}, []string{"dog"}, []string{"dog"},
+			},
+			slop: 1,
+			paths: []phrasePath{
+				phrasePath{
+					phrasePart{"cat", &search.Location{Pos: 1}},
+					phrasePart{"dog", &search.Location{Pos: 2}},
+					phrasePart{"dog", &search.Location{Pos: 3}},
+				},
+			},
+			tlm: search.TermLocationMap{ // cat dog dog
+				"cat": search.Locations{
+					&search.Location{Pos: 1},
+				},
+				"dog": search.Locations{
+					&search.Location{Pos: 2},
+					&search.Location{Pos: 3},
+				},
+			},
+		},
+		// test that we don't see multiple hits from the same location
+		{
+			phrase: [][]string{
+				[]string{"cat"}, []string{"dog"},
+			},
+			slop: 10,
+			paths: []phrasePath{
+				phrasePath{
+					phrasePart{"cat", &search.Location{Pos: 1}},
+					phrasePart{"dog", &search.Location{Pos: 2}},
+				},
+				phrasePath{
+					phrasePart{"cat", &search.Location{Pos: 1}},
+					phrasePart{"dog", &search.Location{Pos: 4}},
+				},
+				phrasePath{
+					phrasePart{"cat", &search.Location{Pos: 3}},
+					phrasePart{"dog", &search.Location{Pos: 2}},
+				},
+				phrasePath{
+					phrasePart{"cat", &search.Location{Pos: 3}},
+					phrasePart{"dog", &search.Location{Pos: 4}},
+				},
+			},
+			tlm: search.TermLocationMap{ // cat dog cat dog
+				"cat": search.Locations{
+					&search.Location{Pos: 1},
+					&search.Location{Pos: 3},
+				},
+				"dog": search.Locations{
+					&search.Location{Pos: 2},
+					&search.Location{Pos: 4},
+				},
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
With term locations that look like "a b b", findPhrasePaths() on a search for "a b b" with sloppiness of 1 ought to have a result like...

  a: 1, b: 2, b: 3

...but instead was incorrectly returning results like the following due to not "consuming" or ignoring previously used locations during recursion...

  a: 1, b: 2, b: 2    <-- incorrect
  a: 1, b: 2, b: 3

One followup issue is that this correctness fix allocates more interim garbage, which probably should be addressed in some future perf improvements.