### PR TITLE
improve findPhrasePaths() doc comments and call signature

### DIFF
--- a/search/searcher/search_phrase_test.go
+++ b/search/searcher/search_phrase_test.go
@@ -320,7 +320,7 @@ func TestFindPhrasePaths(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actualPaths := findPhrasePaths(0, nil, test.phrase, test.tlm, nil, 0)
+		actualPaths := findPhrasePaths(test.phrase, test.tlm, 0)
 		if !reflect.DeepEqual(actualPaths, test.paths) {
 			t.Fatalf("expected: %v got %v for test %d", test.paths, actualPaths, i)
 		}
@@ -559,7 +559,7 @@ func TestFindPhrasePathsSloppy(t *testing.T) {
 		if tlmToUse == nil {
 			tlmToUse = tlm
 		}
-		actualPaths := findPhrasePaths(0, nil, test.phrase, tlmToUse, nil, test.slop)
+		actualPaths := findPhrasePaths(test.phrase, tlmToUse, test.slop)
 		if !reflect.DeepEqual(actualPaths, test.paths) {
 			t.Fatalf("expected: %v got %v for test %d", test.paths, actualPaths, i)
 		}
@@ -640,7 +640,7 @@ func TestFindPhrasePathsSloppyPalyndrome(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actualPaths := findPhrasePaths(0, nil, test.phrase, tlm, nil, test.slop)
+		actualPaths := findPhrasePaths(test.phrase, tlm, test.slop)
 		if !reflect.DeepEqual(actualPaths, test.paths) {
 			t.Fatalf("expected: %v got %v for test %d", test.paths, actualPaths, i)
 		}
@@ -736,7 +736,7 @@ func TestFindMultiPhrasePaths(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actualPaths := findPhrasePaths(0, nil, test.phrase, tlm, nil, 0)
+		actualPaths := findPhrasePaths(test.phrase, tlm, 0)
 		if !reflect.DeepEqual(actualPaths, test.paths) {
 			t.Fatalf("expected: %v got %v for test %d", test.paths, actualPaths, i)
 		}


### PR DESCRIPTION
From feedback on a previous PR, the doc comments on findPhrasePaths() was outdated.  See...

  https://github.com/blevesearch/bleve/pull/872

Additionally, the recently introduced recursive helper func allowed simplification of the params of findPhrasePaths().