### PR TITLE
scorch renamed dvIterator to dvReader

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -136,11 +136,11 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkFactor uint32,
 		fieldsIndexOffset: fieldsIndexOffset,
 		docValueOffset:    docValueOffset,
 		dictLocs:          dictLocs,
-		fieldDvIterMap:    make(map[uint16]*docValueIterator),
+		fieldDvReaders:    make(map[uint16]*docValueReader),
 	}
 	sb.updateSize()
 
-	err := sb.loadDvIterators()
+	err := sb.loadDvReaders()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is just a mechanical rename, as the structure wasn't actually iterating, but instead allowed for random access reading by docNum of doc values.