### PR TITLE
scorch optimize loadSegment() to treat empty deleted bitmaps as nil

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -622,7 +622,9 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket) (*SegmentSnapshot, erro
 			_ = segment.Close()
 			return nil, fmt.Errorf("error reading deleted bytes: %v", err)
 		}
-		rv.deleted = deletedBitmap
+		if !deletedBitmap.IsEmpty() {
+			rv.deleted = deletedBitmap
+		}
 	}
 
 	return rv, nil


### PR DESCRIPTION
In this optimization, scorch loadSegment() will convert an empty 'deleted' roaring bitmap to nil, so that later codepaths that test for nil-ness can avoid roaring operations like AndNot() -- which helps in the case when there's no mutations (insertions-only).