### PR TITLE
scorch PostingsList() takes []byte, not string

### DIFF
--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -59,7 +59,7 @@ func (e *EmptySegment) DecRef() error {
 
 type EmptyDictionary struct{}
 
-func (e *EmptyDictionary) PostingsList(term string,
+func (e *EmptyDictionary) PostingsList(term []byte,
 	except *roaring.Bitmap, prealloc PostingsList) (PostingsList, error) {
 	return &EmptyPostingsList{}, nil
 }

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -43,7 +43,7 @@ type Segment interface {
 }
 
 type TermDictionary interface {
-	PostingsList(term string, except *roaring.Bitmap, prealloc PostingsList) (PostingsList, error)
+	PostingsList(term []byte, except *roaring.Bitmap, prealloc PostingsList) (PostingsList, error)
 
 	Iterator() DictionaryIterator
 	PrefixIterator(prefix string) DictionaryIterator

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -35,14 +35,14 @@ type Dictionary struct {
 }
 
 // PostingsList returns the postings list for the specified term
-func (d *Dictionary) PostingsList(term string, except *roaring.Bitmap,
+func (d *Dictionary) PostingsList(term []byte, except *roaring.Bitmap,
 	prealloc segment.PostingsList) (segment.PostingsList, error) {
 	var preallocPL *PostingsList
 	pl, ok := prealloc.(*PostingsList)
 	if ok && pl != nil {
 		preallocPL = pl
 	}
-	return d.postingsList([]byte(term), except, preallocPL)
+	return d.postingsList(term, except, preallocPL)
 }
 
 func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *PostingsList) (*PostingsList, error) {

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -76,7 +76,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err := dict.PostingsList("a", nil, nil)
+	postingsList, err := dict.PostingsList([]byte("a"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err = dict.PostingsList("wow", nil, nil)
+	postingsList, err = dict.PostingsList([]byte("wow"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err = dict.PostingsList("wow", nil, nil)
+	postingsList, err = dict.PostingsList([]byte("wow"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err = dict.PostingsList("dark", nil, nil)
+	postingsList, err = dict.PostingsList([]byte("dark"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +358,7 @@ func TestOpenMulti(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err := dict.PostingsList("thing", nil, nil)
+	postingsList, err := dict.PostingsList([]byte("thing"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestOpenMulti(t *testing.T) {
 	}
 
 	// look for term 'thing' excluding doc 'a'
-	postingsListExcluding, err := dict.PostingsList("thing", exclude, nil)
+	postingsListExcluding, err := dict.PostingsList([]byte("thing"), exclude, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestOpenMultiWithTwoChunks(t *testing.T) {
 		t.Fatal("got nil dict, expected non-nil")
 	}
 
-	postingsList, err := dict.PostingsList("thing", nil, nil)
+	postingsList, err := dict.PostingsList([]byte("thing"), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +492,7 @@ func TestOpenMultiWithTwoChunks(t *testing.T) {
 	}
 
 	// look for term 'thing' excluding doc 'a'
-	postingsListExcluding, err := dict.PostingsList("thing", exclude, nil)
+	postingsListExcluding, err := dict.PostingsList([]byte("thing"), exclude, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -429,10 +429,8 @@ func (i *IndexSnapshot) TermFieldReader(term []byte, field string, includeFreq,
 	}
 	rv.dicts = dicts
 
-	termStr := string(term)
-
 	for i := range i.segment {
-		pl, err := dicts[i].PostingsList(termStr, nil, rv.postings[i])
+		pl, err := dicts[i].PostingsList(term, nil, rv.postings[i])
 		if err != nil {
 			return nil, err
 		}

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -32,7 +32,7 @@ type SegmentDictionarySnapshot struct {
 	d segment.TermDictionary
 }
 
-func (s *SegmentDictionarySnapshot) PostingsList(term string, except *roaring.Bitmap,
+func (s *SegmentDictionarySnapshot) PostingsList(term []byte, except *roaring.Bitmap,
 	prealloc segment.PostingsList) (segment.PostingsList, error) {
 	// TODO: if except is non-nil, perhaps need to OR it with s.s.deleted?
 	return s.d.PostingsList(term, s.s.deleted, prealloc)
@@ -179,7 +179,7 @@ func (cfd *cachedFieldDocs) prepareFields(field string, ss *SegmentSnapshot) {
 	next, err := dictItr.Next()
 	for err == nil && next != nil {
 		var err1 error
-		postings, err1 = dict.PostingsList(next.Term, nil, postings)
+		postings, err1 = dict.PostingsList([]byte(next.Term), nil, postings)
 		if err1 != nil {
 			cfd.err = err1
 			return


### PR DESCRIPTION
This change avoids more mem allocations / conversions.

Note, this change does have a tradeoff, though...

One the one hand, conversions are reduced while creating PostingsLists(), which is important for the low-frequency term search scenario...

But, on the other hand, populating the SegmentSnapshot.cachedDocs information via cachedDocs.prepareFields() now picks up an additional conversion in this PR, which may affect the cachedDocs initialization phase of DocumentVisitFieldTerms().