### PR TITLE
fixes #895 - scorch zap file format updated w/ # bytes of locations

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -20,7 +20,7 @@ import (
 	"os"
 )
 
-const Version uint32 = 9
+const Version uint32 = 10
 
 const Type string = "zap"
 


### PR DESCRIPTION
NOTE: This is a zap file format change.

In the case of a composite field (i.e., _all field), the component
fields might have differing configurations for IncludeTermVectors.
This can mean the freq can sometimes be > numberOfLocations, where the
previous code incorrectly assumed freq == numberOfLocations.

By encoding the # of bytes used for locations data, the loops
performing readLocation() will be able to read the correct # of
locations.

And, encoding the # of bytes used for locations data instead of the
count of locations allows for an optimization of no longer reading
unneeded locations data when skipping ahead.

This fixes issue https://github.com/blevesearch/bleve/issues/895
reported by @xeizmendi.