### PR TITLE
Optimization for reducing merger overhead from doc-values

### DIFF
--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -34,10 +34,11 @@ func init() {
 	reflectStaticSizedocValueReader = int(reflect.TypeOf(dvi).Size())
 }
 
+type docNumTermsVisitor func(docNum uint64, terms []byte) error
+
 type docValueReader struct {
 	field          string
 	curChunkNum    uint64
-	numChunks      uint64
 	chunkOffsets   []uint64
 	dvDataLoc      uint64
 	curChunkHeader []MetaData
@@ -148,6 +149,34 @@ func (di *docValueReader) loadDvChunk(chunkNumber uint64, s *SegmentBase) error 
 	di.curChunkData = s.mem[compressedDataLoc : compressedDataLoc+dataLength]
 	di.curChunkNum = chunkNumber
 	di.uncompressed = di.uncompressed[:0]
+	return nil
+}
+
+func (di *docValueReader) iterateAllDocValues(s *SegmentBase, visitor docNumTermsVisitor) error {
+	for i := 0; i < len(di.chunkOffsets); i++ {
+		err := di.loadDvChunk(uint64(i), s)
+		if err != nil {
+			return err
+		}
+
+		// uncompress the already loaded data
+		uncompressed, err := snappy.Decode(di.uncompressed[:cap(di.uncompressed)], di.curChunkData)
+		if err != nil {
+			return err
+		}
+		di.uncompressed = uncompressed
+
+		start := uint64(0)
+		for _, entry := range di.curChunkHeader {
+			err = visitor(entry.DocNum, uncompressed[start:entry.DocDvOffset])
+			if err != nil {
+				return err
+			}
+
+			start = entry.DocDvOffset
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Part3: Getting rid of docTermMap during the merge operation,
       instead fetch all valid docNums and their corresponding
       values from the segmentBases via docValueReaders.