### PR TITLE
alternate disjunction searcher impl using heap

### DIFF
--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Couchbase, Inc.
+//  Copyright (c) 2018 Couchbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,39 +16,36 @@ package searcher
 
 import (
 	"fmt"
-	"math"
-	"reflect"
-	"sort"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
-	"github.com/blevesearch/bleve/search/scorer"
-	"github.com/blevesearch/bleve/size"
 )
-
-var reflectStaticSizeDisjunctionSearcher int
-
-func init() {
-	var ds DisjunctionSearcher
-	reflectStaticSizeDisjunctionSearcher = int(reflect.TypeOf(ds).Size())
-}
 
 // DisjunctionMaxClauseCount is a compile time setting that applications can
 // adjust to non-zero value to cause the DisjunctionSearcher to return an
 // error instead of exeucting searches when the size exceeds this value.
 var DisjunctionMaxClauseCount = 0
 
-type DisjunctionSearcher struct {
-	indexReader  index.IndexReader
-	searchers    OrderedSearcherList
-	numSearchers int
-	queryNorm    float64
-	currs        []*search.DocumentMatch
-	scorer       *scorer.DisjunctionQueryScorer
-	min          int
-	matching     []*search.DocumentMatch
-	matchingIdxs []int
-	initialized  bool
+// DisjunctionHeapTakeover is a compile time setting that applications can
+// adjust to control when the DisjunctionSearcher will switch from a simple
+// slice implementation to a heap implementation.
+var DisjunctionHeapTakeover = 10
+
+func NewDisjunctionSearcher(indexReader index.IndexReader,
+	qsearchers []search.Searcher, min float64, options search.SearcherOptions) (
+	search.Searcher, error) {
+	return newDisjunctionSearcher(indexReader, qsearchers, min, options, true)
+}
+
+func newDisjunctionSearcher(indexReader index.IndexReader,
+	qsearchers []search.Searcher, min float64, options search.SearcherOptions,
+	limit bool) (search.Searcher, error) {
+	if len(qsearchers) > DisjunctionHeapTakeover {
+		return newDisjunctionHeapSearcher(indexReader, qsearchers, min, options,
+			true)
+	}
+	return newDisjunctionSliceSearcher(indexReader, qsearchers, min, options,
+		true)
 }
 
 func tooManyClauses(count int) bool {
@@ -61,263 +58,4 @@ func tooManyClauses(count int) bool {
 func tooManyClausesErr() error {
 	return fmt.Errorf("TooManyClauses[maxClauseCount is set to %d]",
 		DisjunctionMaxClauseCount)
-}
-
-func NewDisjunctionSearcher(indexReader index.IndexReader,
-	qsearchers []search.Searcher, min float64, options search.SearcherOptions) (
-	*DisjunctionSearcher, error) {
-	return newDisjunctionSearcher(indexReader, qsearchers, min, options,
-		true)
-}
-
-func newDisjunctionSearcher(indexReader index.IndexReader,
-	qsearchers []search.Searcher, min float64, options search.SearcherOptions,
-	limit bool) (
-	*DisjunctionSearcher, error) {
-	if limit && tooManyClauses(len(qsearchers)) {
-		return nil, tooManyClausesErr()
-	}
-	// build the downstream searchers
-	searchers := make(OrderedSearcherList, len(qsearchers))
-	for i, searcher := range qsearchers {
-		searchers[i] = searcher
-	}
-	// sort the searchers
-	sort.Sort(sort.Reverse(searchers))
-	// build our searcher
-	rv := DisjunctionSearcher{
-		indexReader:  indexReader,
-		searchers:    searchers,
-		numSearchers: len(searchers),
-		currs:        make([]*search.DocumentMatch, len(searchers)),
-		scorer:       scorer.NewDisjunctionQueryScorer(options),
-		min:          int(min),
-		matching:     make([]*search.DocumentMatch, len(searchers)),
-		matchingIdxs: make([]int, len(searchers)),
-	}
-	rv.computeQueryNorm()
-	return &rv, nil
-}
-
-func (s *DisjunctionSearcher) Size() int {
-	sizeInBytes := reflectStaticSizeDisjunctionSearcher + size.SizeOfPtr +
-		s.scorer.Size()
-
-	for _, entry := range s.searchers {
-		sizeInBytes += entry.Size()
-	}
-
-	for _, entry := range s.currs {
-		if entry != nil {
-			sizeInBytes += entry.Size()
-		}
-	}
-
-	for _, entry := range s.matching {
-		if entry != nil {
-			sizeInBytes += entry.Size()
-		}
-	}
-
-	sizeInBytes += len(s.matchingIdxs) * size.SizeOfInt
-
-	return sizeInBytes
-}
-
-func (s *DisjunctionSearcher) computeQueryNorm() {
-	// first calculate sum of squared weights
-	sumOfSquaredWeights := 0.0
-	for _, searcher := range s.searchers {
-		sumOfSquaredWeights += searcher.Weight()
-	}
-	// now compute query norm from this
-	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
-	// finally tell all the downstream searchers the norm
-	for _, searcher := range s.searchers {
-		searcher.SetQueryNorm(s.queryNorm)
-	}
-}
-
-func (s *DisjunctionSearcher) initSearchers(ctx *search.SearchContext) error {
-	var err error
-	// get all searchers pointing at their first match
-	for i, searcher := range s.searchers {
-		if s.currs[i] != nil {
-			ctx.DocumentMatchPool.Put(s.currs[i])
-		}
-		s.currs[i], err = searcher.Next(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = s.updateMatches()
-	if err != nil {
-		return err
-	}
-
-	s.initialized = true
-	return nil
-}
-
-func (s *DisjunctionSearcher) updateMatches() error {
-	matching := s.matching[:0]
-	matchingIdxs := s.matchingIdxs[:0]
-
-	for i := 0; i < len(s.currs); i++ {
-		curr := s.currs[i]
-		if curr == nil {
-			continue
-		}
-
-		if len(matching) > 0 {
-			cmp := curr.IndexInternalID.Compare(matching[0].IndexInternalID)
-			if cmp > 0 {
-				continue
-			}
-
-			if cmp < 0 {
-				matching = matching[:0]
-				matchingIdxs = matchingIdxs[:0]
-			}
-		}
-
-		matching = append(matching, curr)
-		matchingIdxs = append(matchingIdxs, i)
-	}
-
-	s.matching = matching
-	s.matchingIdxs = matchingIdxs
-
-	return nil
-}
-
-func (s *DisjunctionSearcher) Weight() float64 {
-	var rv float64
-	for _, searcher := range s.searchers {
-		rv += searcher.Weight()
-	}
-	return rv
-}
-
-func (s *DisjunctionSearcher) SetQueryNorm(qnorm float64) {
-	for _, searcher := range s.searchers {
-		searcher.SetQueryNorm(qnorm)
-	}
-}
-
-func (s *DisjunctionSearcher) Next(ctx *search.SearchContext) (
-	*search.DocumentMatch, error) {
-	if !s.initialized {
-		err := s.initSearchers(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	var err error
-	var rv *search.DocumentMatch
-
-	found := false
-	for !found && len(s.matching) > 0 {
-		if len(s.matching) >= s.min {
-			found = true
-			// score this match
-			rv = s.scorer.Score(ctx, s.matching, len(s.matching), s.numSearchers)
-		}
-
-		// invoke next on all the matching searchers
-		for _, i := range s.matchingIdxs {
-			searcher := s.searchers[i]
-			if s.currs[i] != rv {
-				ctx.DocumentMatchPool.Put(s.currs[i])
-			}
-			s.currs[i], err = searcher.Next(ctx)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		err = s.updateMatches()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return rv, nil
-}
-
-func (s *DisjunctionSearcher) Advance(ctx *search.SearchContext,
-	ID index.IndexInternalID) (*search.DocumentMatch, error) {
-	if !s.initialized {
-		err := s.initSearchers(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// get all searchers pointing at their first match
-	var err error
-	for i, searcher := range s.searchers {
-		if s.currs[i] != nil {
-			if s.currs[i].IndexInternalID.Compare(ID) >= 0 {
-				continue
-			}
-			ctx.DocumentMatchPool.Put(s.currs[i])
-		}
-		s.currs[i], err = searcher.Advance(ctx, ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = s.updateMatches()
-	if err != nil {
-		return nil, err
-	}
-
-	return s.Next(ctx)
-}
-
-func (s *DisjunctionSearcher) Count() uint64 {
-	// for now return a worst case
-	var sum uint64
-	for _, searcher := range s.searchers {
-		sum += searcher.Count()
-	}
-	return sum
-}
-
-func (s *DisjunctionSearcher) Close() (rv error) {
-	for _, searcher := range s.searchers {
-		err := searcher.Close()
-		if err != nil && rv == nil {
-			rv = err
-		}
-	}
-	return rv
-}
-
-func (s *DisjunctionSearcher) Min() int {
-	return s.min
-}
-
-func (s *DisjunctionSearcher) DocumentMatchPoolSize() int {
-	rv := len(s.currs)
-	for _, s := range s.searchers {
-		rv += s.DocumentMatchPoolSize()
-	}
-	return rv
-}
-
-// a disjunction searcher implements the index.Optimizable interface
-// but only activates on an edge case where the disjunction is a
-// wrapper around a single Optimizable child searcher
-func (s *DisjunctionSearcher) Optimize(kind string, octx index.OptimizableContext) (
-	index.OptimizableContext, error) {
-	if len(s.searchers) == 1 {
-		o, ok := s.searchers[0].(index.Optimizable)
-		if ok {
-			return o.Optimize(kind, octx)
-		}
-	}
-
-	return octx, nil
 }

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -1,0 +1,342 @@
+//  Copyright (c) 2018 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"bytes"
+	"container/heap"
+	"math"
+	"reflect"
+
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/search/scorer"
+	"github.com/blevesearch/bleve/size"
+)
+
+var reflectStaticSizeDisjunctionHeapSearcher int
+var reflectStaticSizeSearcherCurr int
+
+func init() {
+	var dhs DisjunctionHeapSearcher
+	reflectStaticSizeDisjunctionHeapSearcher = int(reflect.TypeOf(dhs).Size())
+
+	var sc SearcherCurr
+	reflectStaticSizeSearcherCurr = int(reflect.TypeOf(sc).Size())
+}
+
+type SearcherCurr struct {
+	searcher search.Searcher
+	curr     *search.DocumentMatch
+}
+
+type DisjunctionHeapSearcher struct {
+	indexReader index.IndexReader
+
+	numSearchers int
+	scorer       *scorer.DisjunctionQueryScorer
+	min          int
+	queryNorm    float64
+	initialized  bool
+	searchers    []search.Searcher
+	heap         []*SearcherCurr
+
+	matching      []*search.DocumentMatch
+	matchingCurrs []*SearcherCurr
+}
+
+func newDisjunctionHeapSearcher(indexReader index.IndexReader,
+	searchers []search.Searcher, min float64, options search.SearcherOptions,
+	limit bool) (
+	*DisjunctionHeapSearcher, error) {
+	if limit && tooManyClauses(len(searchers)) {
+		return nil, tooManyClausesErr()
+	}
+
+	// build our searcher
+	rv := DisjunctionHeapSearcher{
+		indexReader:   indexReader,
+		searchers:     searchers,
+		numSearchers:  len(searchers),
+		scorer:        scorer.NewDisjunctionQueryScorer(options),
+		min:           int(min),
+		matching:      make([]*search.DocumentMatch, len(searchers)),
+		matchingCurrs: make([]*SearcherCurr, len(searchers)),
+		heap:          make([]*SearcherCurr, 0, len(searchers)),
+	}
+	rv.computeQueryNorm()
+	return &rv, nil
+}
+
+func (s *DisjunctionHeapSearcher) Size() int {
+	sizeInBytes := reflectStaticSizeDisjunctionHeapSearcher + size.SizeOfPtr +
+		s.scorer.Size()
+
+	for _, entry := range s.searchers {
+		sizeInBytes += entry.Size()
+	}
+
+	for _, entry := range s.matching {
+		if entry != nil {
+			sizeInBytes += entry.Size()
+		}
+	}
+
+	// for matchingCurrs and heap, just use static size * len
+	// since searchers and document matches already counted above
+	sizeInBytes += len(s.matchingCurrs) * reflectStaticSizeSearcherCurr
+	sizeInBytes += len(s.heap) * reflectStaticSizeSearcherCurr
+
+	return sizeInBytes
+}
+
+func (s *DisjunctionHeapSearcher) computeQueryNorm() {
+	// first calculate sum of squared weights
+	sumOfSquaredWeights := 0.0
+	for _, searcher := range s.searchers {
+		sumOfSquaredWeights += searcher.Weight()
+	}
+	// now compute query norm from this
+	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
+	// finally tell all the downstream searchers the norm
+	for _, searcher := range s.searchers {
+		searcher.SetQueryNorm(s.queryNorm)
+	}
+}
+
+func (s *DisjunctionHeapSearcher) initSearchers(ctx *search.SearchContext) error {
+	// alloc a single block of SearcherCurrs
+	block := make([]SearcherCurr, len(s.searchers))
+
+	// get all searchers pointing at their first match
+	for i, searcher := range s.searchers {
+		curr, err := searcher.Next(ctx)
+		if err != nil {
+			return err
+		}
+		if curr != nil {
+			block[i].searcher = searcher
+			block[i].curr = curr
+			heap.Push(s, &block[i])
+		}
+	}
+
+	err := s.updateMatches()
+	if err != nil {
+		return err
+	}
+	s.initialized = true
+	return nil
+}
+
+func (s *DisjunctionHeapSearcher) updateMatches() error {
+	matching := s.matching[:0]
+	matchingCurrs := s.matchingCurrs[:0]
+
+	if len(s.heap) > 0 {
+
+		// top of the heap is our next hit
+		next := heap.Pop(s).(*SearcherCurr)
+		matching = append(matching, next.curr)
+		matchingCurrs = append(matchingCurrs, next)
+
+		// now as long as top of heap matches, keep popping
+		for len(s.heap) > 0 && bytes.Compare(next.curr.IndexInternalID, s.heap[0].curr.IndexInternalID) == 0 {
+			next = heap.Pop(s).(*SearcherCurr)
+			matching = append(matching, next.curr)
+			matchingCurrs = append(matchingCurrs, next)
+		}
+	}
+
+	s.matching = matching
+	s.matchingCurrs = matchingCurrs
+
+	return nil
+}
+
+func (s *DisjunctionHeapSearcher) Weight() float64 {
+	var rv float64
+	for _, searcher := range s.searchers {
+		rv += searcher.Weight()
+	}
+	return rv
+}
+
+func (s *DisjunctionHeapSearcher) SetQueryNorm(qnorm float64) {
+	for _, searcher := range s.searchers {
+		searcher.SetQueryNorm(qnorm)
+	}
+}
+
+func (s *DisjunctionHeapSearcher) Next(ctx *search.SearchContext) (
+	*search.DocumentMatch, error) {
+	if !s.initialized {
+		err := s.initSearchers(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var rv *search.DocumentMatch
+	found := false
+	for !found && len(s.matching) > 0 {
+		if len(s.matching) >= s.min {
+			found = true
+			// score this match
+			rv = s.scorer.Score(ctx, s.matching, len(s.matching), s.numSearchers)
+		}
+
+		// invoke next on all the matching searchers
+		for _, matchingCurr := range s.matchingCurrs {
+			if matchingCurr.curr != rv {
+				ctx.DocumentMatchPool.Put(matchingCurr.curr)
+			}
+			curr, err := matchingCurr.searcher.Next(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if curr != nil {
+				matchingCurr.curr = curr
+				heap.Push(s, matchingCurr)
+			}
+		}
+
+		err := s.updateMatches()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rv, nil
+}
+
+func (s *DisjunctionHeapSearcher) Advance(ctx *search.SearchContext,
+	ID index.IndexInternalID) (*search.DocumentMatch, error) {
+	if !s.initialized {
+		err := s.initSearchers(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// if there is anything in matching, toss it back onto the heap
+	for _, matchingCurr := range s.matchingCurrs {
+		heap.Push(s, matchingCurr)
+	}
+	s.matching = s.matching[:0]
+	s.matchingCurrs = s.matchingCurrs[:0]
+
+	// get all searchers pointing at their first match
+	for i, searcherCurr := range s.heap {
+		if searcherCurr.searcher != nil {
+			if searcherCurr.curr.IndexInternalID.Compare(ID) >= 0 {
+				continue
+			}
+			ctx.DocumentMatchPool.Put(searcherCurr.curr)
+		}
+		curr, err := searcherCurr.searcher.Advance(ctx, ID)
+		if err != nil {
+			return nil, err
+		}
+		searcherCurr.curr = curr
+		heap.Fix(s, i)
+	}
+	// now remove any nil values (at top of heap)
+	for len(s.heap) > 0 && s.heap[0].curr == nil {
+		heap.Pop(s)
+	}
+
+	err := s.updateMatches()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Next(ctx)
+}
+
+func (s *DisjunctionHeapSearcher) Count() uint64 {
+	// for now return a worst case
+	var sum uint64
+	for _, searcher := range s.searchers {
+		sum += searcher.Count()
+	}
+	return sum
+}
+
+func (s *DisjunctionHeapSearcher) Close() (rv error) {
+	for _, searcher := range s.searchers {
+		err := searcher.Close()
+		if err != nil && rv == nil {
+			rv = err
+		}
+	}
+	return rv
+}
+
+func (s *DisjunctionHeapSearcher) Min() int {
+	return s.min
+}
+
+func (s *DisjunctionHeapSearcher) DocumentMatchPoolSize() int {
+	rv := len(s.searchers)
+	for _, s := range s.searchers {
+		rv += s.DocumentMatchPoolSize()
+	}
+	return rv
+}
+
+// a disjunction searcher implements the index.Optimizable interface
+// but only activates on an edge case where the disjunction is a
+// wrapper around a single Optimizable child searcher
+func (s *DisjunctionHeapSearcher) Optimize(kind string, octx index.OptimizableContext) (
+	index.OptimizableContext, error) {
+	if len(s.searchers) == 1 {
+		o, ok := s.searchers[0].(index.Optimizable)
+		if ok {
+			return o.Optimize(kind, octx)
+		}
+	}
+
+	return octx, nil
+}
+
+// heap impl
+
+func (s *DisjunctionHeapSearcher) Len() int { return len(s.heap) }
+
+func (s *DisjunctionHeapSearcher) Less(i, j int) bool {
+	if s.heap[i].curr == nil {
+		return true
+	} else if s.heap[j].curr == nil {
+		return false
+	}
+	return bytes.Compare(s.heap[i].curr.IndexInternalID, s.heap[j].curr.IndexInternalID) < 0
+}
+
+func (s *DisjunctionHeapSearcher) Swap(i, j int) {
+	s.heap[i], s.heap[j] = s.heap[j], s.heap[i]
+}
+
+func (s *DisjunctionHeapSearcher) Push(x interface{}) {
+	s.heap = append(s.heap, x.(*SearcherCurr))
+}
+
+func (s *DisjunctionHeapSearcher) Pop() interface{} {
+	old := s.heap
+	n := len(old)
+	x := old[n-1]
+	s.heap = old[0 : n-1]
+	return x
+}

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -1,0 +1,298 @@
+//  Copyright (c) 2018 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"math"
+	"reflect"
+	"sort"
+
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/search/scorer"
+	"github.com/blevesearch/bleve/size"
+)
+
+var reflectStaticSizeDisjunctionSliceSearcher int
+
+func init() {
+	var ds DisjunctionSliceSearcher
+	reflectStaticSizeDisjunctionSliceSearcher = int(reflect.TypeOf(ds).Size())
+}
+
+type DisjunctionSliceSearcher struct {
+	indexReader  index.IndexReader
+	searchers    OrderedSearcherList
+	numSearchers int
+	queryNorm    float64
+	currs        []*search.DocumentMatch
+	scorer       *scorer.DisjunctionQueryScorer
+	min          int
+	matching     []*search.DocumentMatch
+	matchingIdxs []int
+	initialized  bool
+}
+
+func newDisjunctionSliceSearcher(indexReader index.IndexReader,
+	qsearchers []search.Searcher, min float64, options search.SearcherOptions,
+	limit bool) (
+	*DisjunctionSliceSearcher, error) {
+	if limit && tooManyClauses(len(qsearchers)) {
+		return nil, tooManyClausesErr()
+	}
+	// build the downstream searchers
+	searchers := make(OrderedSearcherList, len(qsearchers))
+	for i, searcher := range qsearchers {
+		searchers[i] = searcher
+	}
+	// sort the searchers
+	sort.Sort(sort.Reverse(searchers))
+	// build our searcher
+	rv := DisjunctionSliceSearcher{
+		indexReader:  indexReader,
+		searchers:    searchers,
+		numSearchers: len(searchers),
+		currs:        make([]*search.DocumentMatch, len(searchers)),
+		scorer:       scorer.NewDisjunctionQueryScorer(options),
+		min:          int(min),
+		matching:     make([]*search.DocumentMatch, len(searchers)),
+		matchingIdxs: make([]int, len(searchers)),
+	}
+	rv.computeQueryNorm()
+	return &rv, nil
+}
+
+func (s *DisjunctionSliceSearcher) Size() int {
+	sizeInBytes := reflectStaticSizeDisjunctionSliceSearcher + size.SizeOfPtr +
+		s.scorer.Size()
+
+	for _, entry := range s.searchers {
+		sizeInBytes += entry.Size()
+	}
+
+	for _, entry := range s.currs {
+		if entry != nil {
+			sizeInBytes += entry.Size()
+		}
+	}
+
+	for _, entry := range s.matching {
+		if entry != nil {
+			sizeInBytes += entry.Size()
+		}
+	}
+
+	sizeInBytes += len(s.matchingIdxs) * size.SizeOfInt
+
+	return sizeInBytes
+}
+
+func (s *DisjunctionSliceSearcher) computeQueryNorm() {
+	// first calculate sum of squared weights
+	sumOfSquaredWeights := 0.0
+	for _, searcher := range s.searchers {
+		sumOfSquaredWeights += searcher.Weight()
+	}
+	// now compute query norm from this
+	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
+	// finally tell all the downstream searchers the norm
+	for _, searcher := range s.searchers {
+		searcher.SetQueryNorm(s.queryNorm)
+	}
+}
+
+func (s *DisjunctionSliceSearcher) initSearchers(ctx *search.SearchContext) error {
+	var err error
+	// get all searchers pointing at their first match
+	for i, searcher := range s.searchers {
+		if s.currs[i] != nil {
+			ctx.DocumentMatchPool.Put(s.currs[i])
+		}
+		s.currs[i], err = searcher.Next(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.updateMatches()
+	if err != nil {
+		return err
+	}
+
+	s.initialized = true
+	return nil
+}
+
+func (s *DisjunctionSliceSearcher) updateMatches() error {
+	matching := s.matching[:0]
+	matchingIdxs := s.matchingIdxs[:0]
+
+	for i := 0; i < len(s.currs); i++ {
+		curr := s.currs[i]
+		if curr == nil {
+			continue
+		}
+
+		if len(matching) > 0 {
+			cmp := curr.IndexInternalID.Compare(matching[0].IndexInternalID)
+			if cmp > 0 {
+				continue
+			}
+
+			if cmp < 0 {
+				matching = matching[:0]
+				matchingIdxs = matchingIdxs[:0]
+			}
+		}
+
+		matching = append(matching, curr)
+		matchingIdxs = append(matchingIdxs, i)
+	}
+
+	s.matching = matching
+	s.matchingIdxs = matchingIdxs
+
+	return nil
+}
+
+func (s *DisjunctionSliceSearcher) Weight() float64 {
+	var rv float64
+	for _, searcher := range s.searchers {
+		rv += searcher.Weight()
+	}
+	return rv
+}
+
+func (s *DisjunctionSliceSearcher) SetQueryNorm(qnorm float64) {
+	for _, searcher := range s.searchers {
+		searcher.SetQueryNorm(qnorm)
+	}
+}
+
+func (s *DisjunctionSliceSearcher) Next(ctx *search.SearchContext) (
+	*search.DocumentMatch, error) {
+	if !s.initialized {
+		err := s.initSearchers(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var err error
+	var rv *search.DocumentMatch
+
+	found := false
+	for !found && len(s.matching) > 0 {
+		if len(s.matching) >= s.min {
+			found = true
+			// score this match
+			rv = s.scorer.Score(ctx, s.matching, len(s.matching), s.numSearchers)
+		}
+
+		// invoke next on all the matching searchers
+		for _, i := range s.matchingIdxs {
+			searcher := s.searchers[i]
+			if s.currs[i] != rv {
+				ctx.DocumentMatchPool.Put(s.currs[i])
+			}
+			s.currs[i], err = searcher.Next(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = s.updateMatches()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return rv, nil
+}
+
+func (s *DisjunctionSliceSearcher) Advance(ctx *search.SearchContext,
+	ID index.IndexInternalID) (*search.DocumentMatch, error) {
+	if !s.initialized {
+		err := s.initSearchers(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// get all searchers pointing at their first match
+	var err error
+	for i, searcher := range s.searchers {
+		if s.currs[i] != nil {
+			if s.currs[i].IndexInternalID.Compare(ID) >= 0 {
+				continue
+			}
+			ctx.DocumentMatchPool.Put(s.currs[i])
+		}
+		s.currs[i], err = searcher.Advance(ctx, ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = s.updateMatches()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Next(ctx)
+}
+
+func (s *DisjunctionSliceSearcher) Count() uint64 {
+	// for now return a worst case
+	var sum uint64
+	for _, searcher := range s.searchers {
+		sum += searcher.Count()
+	}
+	return sum
+}
+
+func (s *DisjunctionSliceSearcher) Close() (rv error) {
+	for _, searcher := range s.searchers {
+		err := searcher.Close()
+		if err != nil && rv == nil {
+			rv = err
+		}
+	}
+	return rv
+}
+
+func (s *DisjunctionSliceSearcher) Min() int {
+	return s.min
+}
+
+func (s *DisjunctionSliceSearcher) DocumentMatchPoolSize() int {
+	rv := len(s.currs)
+	for _, s := range s.searchers {
+		rv += s.DocumentMatchPoolSize()
+	}
+	return rv
+}
+
+// a disjunction searcher implements the index.Optimizable interface
+// but only activates on an edge case where the disjunction is a
+// wrapper around a single Optimizable child searcher
+func (s *DisjunctionSliceSearcher) Optimize(kind string, octx index.OptimizableContext) (
+	index.OptimizableContext, error) {
+	if len(s.searchers) == 1 {
+		o, ok := s.searchers[0].(index.Optimizable)
+		if ok {
+			return o.Optimize(kind, octx)
+		}
+	}
+
+	return octx, nil
+}


### PR DESCRIPTION
introduce an alternate disjunction searcher implementation that
uses a heap to track searchers.  when you have a disjunction
of many other searchers, this should be more efficient by
performing much fewer key comparisions.

currently a cut-over from slice to heap is set at 10,
this can be adjusted by setting the package-level variable
named DisjunctionHeapTakeover