### PR TITLE
persistSnapshotMaybeMerge() merges to directly to file

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -244,7 +244,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot) (
 		return false, nil
 	}
 
-	_, newSnapshot, newSegmentID, err := s.mergeSegmentBases(
+	newSnapshot, newSegmentID, err := s.mergeSegmentBases(
 		snapshot, sbs, sbsDrops, sbsIndexes, DefaultChunkFactor)
 	if err != nil {
 		return false, err

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -38,6 +38,16 @@ const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
 // with the provided chunkFactor.
 func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
 	chunkFactor uint32) ([][]uint64, uint64, error) {
+	segmentBases := make([]*SegmentBase, len(segments))
+	for segmenti, segment := range segments {
+		segmentBases[segmenti] = &segment.SegmentBase
+	}
+
+	return MergeSegmentBases(segmentBases, drops, path, chunkFactor)
+}
+
+func MergeSegmentBases(segmentBases []*SegmentBase, drops []*roaring.Bitmap, path string,
+	chunkFactor uint32) ([][]uint64, uint64, error) {
 	flag := os.O_RDWR | os.O_CREATE
 
 	f, err := os.OpenFile(path, flag, 0600)
@@ -48,11 +58,6 @@ func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
 	cleanup := func() {
 		_ = f.Close()
 		_ = os.Remove(path)
-	}
-
-	segmentBases := make([]*SegmentBase, len(segments))
-	for segmenti, segment := range segments {
-		segmentBases[segmenti] = &segment.SegmentBase
 	}
 
 	// buffer the output


### PR DESCRIPTION
The persister goroutine can decide to merge its incoming input
segments before persistence... and before this commit, that merging
would have been entirely in-memory, leading to a lot of memory usage.

After this change, the persistSnapshotMaybeMerge(), which calls
mergeSegmentBases(), performs the merging directly to file.