### PR TITLE
Revert "Merge pull request #900 from abhinavdangeti/merger-overhead-doc-values"

### DIFF
--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -34,11 +34,10 @@ func init() {
 	reflectStaticSizedocValueReader = int(reflect.TypeOf(dvi).Size())
 }
 
-type docNumTermsVisitor func(docNum uint64, terms []byte) error
-
 type docValueReader struct {
 	field          string
 	curChunkNum    uint64
+	numChunks      uint64
 	chunkOffsets   []uint64
 	dvDataLoc      uint64
 	curChunkHeader []MetaData
@@ -149,34 +148,6 @@ func (di *docValueReader) loadDvChunk(chunkNumber uint64, s *SegmentBase) error 
 	di.curChunkData = s.mem[compressedDataLoc : compressedDataLoc+dataLength]
 	di.curChunkNum = chunkNumber
 	di.uncompressed = di.uncompressed[:0]
-	return nil
-}
-
-func (di *docValueReader) iterateAllDocValues(s *SegmentBase, visitor docNumTermsVisitor) error {
-	for i := 0; i < len(di.chunkOffsets); i++ {
-		err := di.loadDvChunk(uint64(i), s)
-		if err != nil {
-			return err
-		}
-
-		// uncompress the already loaded data
-		uncompressed, err := snappy.Decode(di.uncompressed[:cap(di.uncompressed)], di.curChunkData)
-		if err != nil {
-			return err
-		}
-		di.uncompressed = uncompressed
-
-		start := uint64(0)
-		for _, entry := range di.curChunkHeader {
-			err = visitor(entry.DocNum, uncompressed[start:entry.DocDvOffset])
-			if err != nil {
-				return err
-			}
-
-			start = entry.DocDvOffset
-		}
-	}
-
 	return nil
 }
 

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -180,6 +180,12 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 	tfEncoder := newChunkedIntCoder(uint64(chunkFactor), newSegDocCount-1)
 	locEncoder := newChunkedIntCoder(uint64(chunkFactor), newSegDocCount-1)
 
+	// docTermMap is keyed by docNum, where the array impl provides
+	// better memory usage behavior than a sparse-friendlier hashmap
+	// for when docs have much structural similarity (i.e., every doc
+	// has a given field)
+	var docTermMap [][]byte
+
 	var vellumBuf bytes.Buffer
 	newVellum, err := vellum.New(&vellumBuf, nil)
 	if err != nil {
@@ -196,8 +202,6 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 		var drops []*roaring.Bitmap
 		var dicts []*Dictionary
 		var itrs []vellum.Iterator
-
-		var segmentsInFocus []*SegmentBase
 
 		for segmentI, segment := range segments {
 			dict, err2 := segment.dictionary(fieldName)
@@ -218,8 +222,16 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 					}
 					dicts = append(dicts, dict)
 					itrs = append(itrs, itr)
-					segmentsInFocus = append(segmentsInFocus, segment)
 				}
+			}
+		}
+
+		if uint64(cap(docTermMap)) < newSegDocCount {
+			docTermMap = make([][]byte, newSegDocCount)
+		} else {
+			docTermMap = docTermMap[0:newSegDocCount]
+			for docNum := range docTermMap { // reset the docTermMap
+				docTermMap[docNum] = docTermMap[docNum][:0]
 			}
 		}
 
@@ -302,11 +314,11 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 				// can optimize by copying freq/norm/loc bytes directly
 				lastDocNum, lastFreq, lastNorm, err = mergeTermFreqNormLocsByCopying(
 					term, postItr, newDocNums[itrI], newRoaring,
-					tfEncoder, locEncoder)
+					tfEncoder, locEncoder, docTermMap)
 			} else {
 				lastDocNum, lastFreq, lastNorm, bufLoc, err = mergeTermFreqNormLocs(
 					fieldsMap, term, postItr, newDocNums[itrI], newRoaring,
-					tfEncoder, locEncoder, bufLoc)
+					tfEncoder, locEncoder, docTermMap, bufLoc)
 			}
 			if err != nil {
 				return nil, 0, err
@@ -354,49 +366,27 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 
 		// update the field doc values
 		fdvEncoder := newChunkedContentCoder(uint64(chunkFactor), newSegDocCount-1, w, true)
-
-		fdvReadersAvailable := false
-		var dvIterClone *docValueReader
-		for segmentI, segment := range segmentsInFocus {
-			fieldIDPlus1 := uint16(segment.fieldsMap[fieldName])
-			if dvIter, exists := segment.fieldDvReaders[fieldIDPlus1-1]; exists &&
-				dvIter != nil {
-				fdvReadersAvailable = true
-				dvIterClone = dvIter.cloneInto(dvIterClone)
-				err = dvIterClone.iterateAllDocValues(segment, func(docNum uint64, terms []byte) error {
-					if newDocNums[segmentI][docNum] == docDropped {
-						return nil
-					}
-					err := fdvEncoder.Add(newDocNums[segmentI][docNum], terms)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
+		for docNum, docTerms := range docTermMap {
+			if len(docTerms) > 0 {
+				err = fdvEncoder.Add(uint64(docNum), docTerms)
 				if err != nil {
 					return nil, 0, err
 				}
 			}
 		}
-
-		if fdvReadersAvailable {
-			err = fdvEncoder.Close()
-			if err != nil {
-				return nil, 0, err
-			}
-
-			// persist the doc value details for this field
-			_, err = fdvEncoder.Write()
-			if err != nil {
-				return nil, 0, err
-			}
-
-			// get the field doc value offset (end)
-			fieldDvLocsEnd[fieldID] = uint64(w.Count())
-		} else {
-			fieldDvLocsStart[fieldID] = fieldNotUninverted
-			fieldDvLocsEnd[fieldID] = fieldNotUninverted
+		err = fdvEncoder.Close()
+		if err != nil {
+			return nil, 0, err
 		}
+
+		// persist the doc value details for this field
+		_, err = fdvEncoder.Write()
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// get the field doc value offset (end)
+		fieldDvLocsEnd[fieldID] = uint64(w.Count())
 
 		// reset vellum buffer and vellum builder
 		vellumBuf.Reset()
@@ -427,7 +417,8 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 
 func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *PostingsIterator,
 	newDocNums []uint64, newRoaring *roaring.Bitmap,
-	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder, bufLoc []uint64) (
+	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder, docTermMap [][]byte,
+	bufLoc []uint64) (
 	lastDocNum uint64, lastFreq uint64, lastNorm uint64, bufLocOut []uint64, err error) {
 	next, err := postItr.Next()
 	for next != nil && err == nil {
@@ -481,6 +472,9 @@ func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *Po
 			}
 		}
 
+		docTermMap[hitNewDocNum] =
+			append(append(docTermMap[hitNewDocNum], term...), termSeparator)
+
 		lastDocNum = hitNewDocNum
 		lastFreq = nextFreq
 		lastNorm = nextNorm
@@ -493,7 +487,7 @@ func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *Po
 
 func mergeTermFreqNormLocsByCopying(term []byte, postItr *PostingsIterator,
 	newDocNums []uint64, newRoaring *roaring.Bitmap,
-	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder) (
+	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder, docTermMap [][]byte) (
 	lastDocNum uint64, lastFreq uint64, lastNorm uint64, err error) {
 	nextDocNum, nextFreq, nextNorm, nextFreqNormBytes, nextLocBytes, err :=
 		postItr.nextBytes()
@@ -515,6 +509,9 @@ func mergeTermFreqNormLocsByCopying(term []byte, postItr *PostingsIterator,
 				return 0, 0, 0, err
 			}
 		}
+
+		docTermMap[hitNewDocNum] =
+			append(append(docTermMap[hitNewDocNum], term...), termSeparator)
 
 		lastDocNum = hitNewDocNum
 		lastFreq = nextFreq


### PR DESCRIPTION
This reverts commit 2d5ae21650e05d26a3876b318b860546ab970a9b, reversing
changes made to cd840e0996e29962922be75c47014fad6e857078.

The issue was a panic: runtime error: slice bounds out of range

github.com/blevesearch/bleve/index/scorch/segment/zap.(*docValueReader).loadDvChunk
    /Users/steveyen/dev/couchbase-server.vulcan/godeps/src/github.com/blevesearch/bleve/index/scorch/segment/zap/docvalues.go:149
github.com/blevesearch/bleve/index/scorch/segment/zap.(*docValueReader).iterateAllDocValues
    /Users/steveyen/dev/couchbase-server.vulcan/godeps/src/github.com/blevesearch/bleve/index/scorch/segment/zap/docvalues.go:157