### PR TITLE
MB-28847: Account for bytes of an allocated buffer while building new segment

### DIFF
--- a/index/scorch/segment/zap/build_test.go
+++ b/index/scorch/segment/zap/build_test.go
@@ -26,7 +26,7 @@ import (
 func TestBuild(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	sb, err := buildTestSegment()
+	sb, _, err := buildTestSegment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestBuild(t *testing.T) {
 	}
 }
 
-func buildTestSegment() (*SegmentBase, error) {
+func buildTestSegment() (*SegmentBase, uint64, error) {
 	doc := &document.Document{
 		ID: "a",
 		Fields: []document.Field{
@@ -125,19 +125,19 @@ func buildTestSegment() (*SegmentBase, error) {
 	return AnalysisResultsToSegmentBase(results, 1024)
 }
 
-func buildTestSegmentMulti() (*SegmentBase, error) {
+func buildTestSegmentMulti() (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMulti()
 
 	return AnalysisResultsToSegmentBase(results, 1024)
 }
 
-func buildTestSegmentMultiWithChunkFactor(chunkFactor uint32) (*SegmentBase, error) {
+func buildTestSegmentMultiWithChunkFactor(chunkFactor uint32) (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMulti()
 
 	return AnalysisResultsToSegmentBase(results, chunkFactor)
 }
 
-func buildTestSegmentMultiWithDifferentFields(includeDocA, includeDocB bool) (*SegmentBase, error) {
+func buildTestSegmentMultiWithDifferentFields(includeDocA, includeDocB bool) (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMultiWithDifferentFields(includeDocA, includeDocB)
 
 	return AnalysisResultsToSegmentBase(results, 1024)
@@ -550,7 +550,7 @@ func buildTestSegmentWithDefaultFieldMapping(chunkFactor uint32) (
 		}
 	}
 
-	sb, err := AnalysisResultsToSegmentBase(results, chunkFactor)
+	sb, _, err := AnalysisResultsToSegmentBase(results, chunkFactor)
 
 	return sb, fields, err
 }

--- a/index/scorch/segment/zap/dict_test.go
+++ b/index/scorch/segment/zap/dict_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/blevesearch/bleve/index"
 )
 
-func buildTestSegmentForDict() (*SegmentBase, error) {
+func buildTestSegmentForDict() (*SegmentBase, uint64, error) {
 	doc := &document.Document{
 		ID: "a",
 		Fields: []document.Field{
@@ -105,7 +105,7 @@ func TestDictionary(t *testing.T) {
 
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegmentForDict()
+	testSeg, _, _ := buildTestSegmentForDict()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)

--- a/index/scorch/segment/zap/merge_test.go
+++ b/index/scorch/segment/zap/merge_test.go
@@ -33,13 +33,13 @@ func TestMerge(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch2.zap")
 	_ = os.RemoveAll("/tmp/scorch3.zap")
 
-	testSeg, _ := buildTestSegmentMulti()
+	testSeg, _, _ := buildTestSegmentMulti()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testSeg2, _ := buildTestSegmentMulti2()
+	testSeg2, _, _ := buildTestSegmentMulti2()
 	err = PersistSegmentBase(testSeg2, "/tmp/scorch2.zap")
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +120,7 @@ func TestMergeWithEmptySegmentsFirst(t *testing.T) {
 func testMergeWithEmptySegments(t *testing.T, before bool, numEmptySegments int) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegmentMulti()
+	testSeg, _, _ := buildTestSegmentMulti()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatal(err)
@@ -147,7 +147,7 @@ func testMergeWithEmptySegments(t *testing.T, before bool, numEmptySegments int)
 
 		_ = os.RemoveAll("/tmp/" + fname)
 
-		emptySegment, _ := AnalysisResultsToSegmentBase([]*index.AnalysisResult{}, 1024)
+		emptySegment, _, _ := AnalysisResultsToSegmentBase([]*index.AnalysisResult{}, 1024)
 		err = PersistSegmentBase(emptySegment, "/tmp/"+fname)
 		if err != nil {
 			t.Fatal(err)
@@ -461,7 +461,7 @@ func testMergeAndDrop(t *testing.T, docsToDrop []*roaring.Bitmap) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 	_ = os.RemoveAll("/tmp/scorch2.zap")
 
-	testSeg, _ := buildTestSegmentMulti()
+	testSeg, _, _ := buildTestSegmentMulti()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatal(err)
@@ -477,7 +477,7 @@ func testMergeAndDrop(t *testing.T, docsToDrop []*roaring.Bitmap) {
 		}
 	}()
 
-	testSeg2, _ := buildTestSegmentMulti2()
+	testSeg2, _, _ := buildTestSegmentMulti2()
 	err = PersistSegmentBase(testSeg2, "/tmp/scorch2.zap")
 	if err != nil {
 		t.Fatal(err)
@@ -564,7 +564,7 @@ func testMergeWithUpdates(t *testing.T, segmentDocIds [][]string, docsToDrop []*
 
 		_ = os.RemoveAll("/tmp/" + fname)
 
-		testSeg, _ := buildTestSegmentMultiHelper(docIds)
+		testSeg, _, _ := buildTestSegmentMultiHelper(docIds)
 		err := PersistSegmentBase(testSeg, "/tmp/"+fname)
 		if err != nil {
 			t.Fatal(err)
@@ -615,11 +615,11 @@ func testMergeAndDropSegments(t *testing.T, segsToMerge []*Segment, docsToDrop [
 	testMergeWithSelf(t, segm.(*Segment), expectedNumDocs)
 }
 
-func buildTestSegmentMulti2() (*SegmentBase, error) {
+func buildTestSegmentMulti2() (*SegmentBase, uint64, error) {
 	return buildTestSegmentMultiHelper([]string{"c", "d"})
 }
 
-func buildTestSegmentMultiHelper(docIds []string) (*SegmentBase, error) {
+func buildTestSegmentMultiHelper(docIds []string) (*SegmentBase, uint64, error) {
 	doc := &document.Document{
 		ID: "c",
 		Fields: []document.Field{
@@ -785,13 +785,13 @@ func TestMergeBytesWritten(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch2.zap")
 	_ = os.RemoveAll("/tmp/scorch3.zap")
 
-	testSeg, _ := buildTestSegmentMulti()
+	testSeg, _, _ := buildTestSegmentMulti()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testSeg2, _ := buildTestSegmentMulti2()
+	testSeg2, _, _ := buildTestSegmentMulti2()
 	err = PersistSegmentBase(testSeg2, "/tmp/scorch2.zap")
 	if err != nil {
 		t.Fatal(err)

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -32,7 +32,7 @@ import (
 // AnalysisResultsToSegmentBase produces an in-memory zap-encoded
 // SegmentBase from analysis results
 func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
-	chunkFactor uint32) (*SegmentBase, error) {
+	chunkFactor uint32) (*SegmentBase, uint64, error) {
 	s := interimPool.Get().(*interim)
 
 	var br bytes.Buffer
@@ -52,7 +52,7 @@ func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
 	storedIndexOffset, fieldsIndexOffset, fdvIndexOffset, dictOffsets,
 		err := s.convert()
 	if err != nil {
-		return nil, err
+		return nil, uint64(0), err
 	}
 
 	sb, err := InitSegmentBase(br.Bytes(), s.w.Sum32(), chunkFactor,
@@ -65,7 +65,7 @@ func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
 		interimPool.Put(s)
 	}
 
-	return sb, err
+	return sb, uint64(len(br.Bytes())), err
 }
 
 var interimPool = sync.Pool{New: func() interface{} { return &interim{} }}

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -28,7 +28,7 @@ import (
 func TestOpen(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegment()
+	testSeg, _, _ := buildTestSegment()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
@@ -328,7 +328,7 @@ func TestOpen(t *testing.T) {
 func TestOpenMulti(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegmentMulti()
+	testSeg, _, _ := buildTestSegmentMulti()
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
@@ -428,7 +428,7 @@ func TestOpenMulti(t *testing.T) {
 func TestOpenMultiWithTwoChunks(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegmentMultiWithChunkFactor(1)
+	testSeg, _, _ := buildTestSegmentMultiWithChunkFactor(1)
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
@@ -523,7 +523,7 @@ func TestOpenMultiWithTwoChunks(t *testing.T) {
 func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, _ := buildTestSegmentMultiWithChunkFactor(1)
+	testSeg, _, _ := buildTestSegmentMultiWithChunkFactor(1)
 	err := PersistSegmentBase(testSeg, "/tmp/scorch.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
@@ -603,7 +603,7 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 func TestSegmentDocsWithNonOverlappingFields(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch.zap")
 
-	testSeg, err := buildTestSegmentMultiWithDifferentFields(true, true)
+	testSeg, _, err := buildTestSegmentMultiWithDifferentFields(true, true)
 	if err != nil {
 		t.Fatalf("error building segment: %v", err)
 	}
@@ -653,13 +653,13 @@ func TestMergedSegmentDocsWithNonOverlappingFields(t *testing.T) {
 	_ = os.RemoveAll("/tmp/scorch2.zap")
 	_ = os.RemoveAll("/tmp/scorch3.zap")
 
-	testSeg1, _ := buildTestSegmentMultiWithDifferentFields(true, false)
+	testSeg1, _, _ := buildTestSegmentMultiWithDifferentFields(true, false)
 	err := PersistSegmentBase(testSeg1, "/tmp/scorch1.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)
 	}
 
-	testSeg2, _ := buildTestSegmentMultiWithDifferentFields(false, true)
+	testSeg2, _, _ := buildTestSegmentMultiWithDifferentFields(false, true)
 	err = PersistSegmentBase(testSeg2, "/tmp/scorch2.zap")
 	if err != nil {
 		t.Fatalf("error persisting segment: %v", err)


### PR DESCRIPTION
Account for these bytes in the memory used by the scorch index.