### PR TITLE
larger estimate for new zap segment buffer

### DIFF
--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -125,13 +125,13 @@ func (di *docValueReader) loadDvChunk(chunkNumber uint64, s *SegmentBase) error 
 	// reside for the given docNum
 	destChunkDataLoc, curChunkEnd := di.dvDataLoc, di.dvDataLoc
 	start, end := readChunkBoundary(int(chunkNumber), di.chunkOffsets)
-    if start >= end {
-        di.curChunkHeader = di.curChunkHeader[:0]
-        di.curChunkData = nil
-        di.curChunkNum = chunkNumber
-        di.uncompressed = di.uncompressed[:0]
-        return nil
-    }
+	if start >= end {
+		di.curChunkHeader = di.curChunkHeader[:0]
+		di.curChunkData = nil
+		di.curChunkNum = chunkNumber
+		di.uncompressed = di.uncompressed[:0]
+		return nil
+	}
 
 	destChunkDataLoc += start
 	curChunkEnd += end
@@ -166,9 +166,9 @@ func (di *docValueReader) iterateAllDocValues(s *SegmentBase, visitor docNumTerm
 		if err != nil {
 			return err
 		}
-        if di.curChunkData == nil || len(di.curChunkHeader) <= 0 {
-            continue
-        }
+		if di.curChunkData == nil || len(di.curChunkHeader) <= 0 {
+			continue
+		}
 
 		// uncompress the already loaded data
 		uncompressed, err := snappy.Decode(di.uncompressed[:cap(di.uncompressed)], di.curChunkData)
@@ -195,7 +195,7 @@ func (di *docValueReader) visitDocValues(docNum uint64,
 	visitor index.DocumentFieldTermVisitor) error {
 	// binary search the term locations for the docNum
 	start, end := di.getDocValueLocs(docNum)
-    if start == math.MaxUint64 || end == math.MaxUint64 || start == end {
+	if start == math.MaxUint64 || end == math.MaxUint64 || start == end {
 		return nil
 	}
 

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -29,6 +29,10 @@ import (
 	"github.com/golang/snappy"
 )
 
+var NewSegmentBufferNumResultsBump int = 100
+var NewSegmentBufferNumResultsFactor float64 = 1.0
+var NewSegmentBufferAvgBytesPerDocFactor float64 = 1.0
+
 // AnalysisResultsToSegmentBase produces an in-memory zap-encoded
 // SegmentBase from analysis results
 func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
@@ -41,8 +45,11 @@ func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
 		// size, but note that the interim instance comes from a
 		// global interimPool, so multiple scorch instances indexing
 		// different docs can lead to low quality estimates
-		avgBytesPerDoc := s.lastOutSize / s.lastNumDocs
-		br.Grow(avgBytesPerDoc * (len(results) + 1))
+		estimateAvgBytesPerDoc := int(float64(s.lastOutSize/s.lastNumDocs) *
+			NewSegmentBufferNumResultsFactor)
+		estimateNumResults := int(float64(len(results)+NewSegmentBufferNumResultsBump) *
+			NewSegmentBufferAvgBytesPerDocFactor)
+		br.Grow(estimateAvgBytesPerDoc * estimateNumResults)
 	}
 
 	s.results = results


### PR DESCRIPTION
This adds more global variable "knobs" so that apps can more easily affect the estimates for new zap segment buffer preallocation.

And, it also bumps up the default extra headroom, so that there's less buffer slice grow()'ing during indexing for less garbage creation.  This has the tradeoff that in-memory segments might have extra preallocated but unused "slop" on the ends of their preallocated slices.  The reasoning is that hopefully in-memory segments will soon be persisted, replaced by right-sized mmap()'ed slices.

Also, there's a 2nd commit here that does a 'go fmt'.