### PR TITLE
fix disjunction heap implementation and re-enable

### DIFF
--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -16,7 +16,6 @@ package searcher
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
@@ -30,7 +29,7 @@ var DisjunctionMaxClauseCount = 0
 // DisjunctionHeapTakeover is a compile time setting that applications can
 // adjust to control when the DisjunctionSearcher will switch from a simple
 // slice implementation to a heap implementation.
-var DisjunctionHeapTakeover = math.MaxInt64
+var DisjunctionHeapTakeover = 10
 
 func NewDisjunctionSearcher(indexReader index.IndexReader,
 	qsearchers []search.Searcher, min float64, options search.SearcherOptions) (


### PR DESCRIPTION
previously we incorreclty attempted to heap.Fix while
traversing the heap in Advance()

the fix also eliminates a full traversal of the heap
performing comparisons, by taking advantage of the fact
that heap elements are already ordered.  so in addition
to being correct, this should also be faster.