### PR TITLE
dvReader improvement

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -80,6 +80,8 @@ type IndexReader interface {
 	Document(id string) (*document.Document, error)
 	DocumentVisitFieldTerms(id IndexInternalID, fields []string, visitor DocumentFieldTermVisitor) error
 
+	DocValueReader(fields []string) (DocValueReader, error)
+
 	Fields() ([]string, error)
 
 	GetInternal(key []byte) ([]byte, error)
@@ -301,4 +303,8 @@ type OptimizableContext interface {
 	// OptimizableContext instance, the optimization preparations are
 	// finished or completed via the Finish() method.
 	Finish() error
+}
+
+type DocValueReader interface {
+	VisitDocValues(id IndexInternalID, visitor DocumentFieldTermVisitor) error
 }

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -120,19 +120,4 @@ type DocumentFieldTermVisitable interface {
 }
 
 type DocVisitState interface {
-	State() *FieldDocValueState
-	SetState(*FieldDocValueState)
-}
-
-// FieldDocValueState represents the state details,
-// which intents to save the redundant dvCache preparations
-type FieldDocValueState struct {
-	DvFieldsAllPersisted bool
-	DvFieldsPending      []string
-	DvCachePrepared      bool
-	DvSegment            DocumentFieldTermVisitable
-}
-
-func (fdvs *FieldDocValueState) CurrentSegment() DocumentFieldTermVisitable {
-	return fdvs.DvSegment
 }

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -111,10 +111,28 @@ type Location interface {
 // postings or other indexed values.
 type DocumentFieldTermVisitable interface {
 	VisitDocumentFieldTerms(localDocNum uint64, fields []string,
-		visitor index.DocumentFieldTermVisitor) error
+		visitor index.DocumentFieldTermVisitor, optional DocVisitState) (DocVisitState, error)
 
 	// VisitableDocValueFields implementation should return
 	// the list of fields which are document value persisted and
 	// therefore visitable by the above VisitDocumentFieldTerms method.
 	VisitableDocValueFields() ([]string, error)
+}
+
+type DocVisitState interface {
+	State() *FieldDocValueState
+	SetState(*FieldDocValueState)
+}
+
+// FieldDocValueState represents the state details,
+// which intents to save the redundant dvCache preparations
+type FieldDocValueState struct {
+	DvFieldsAllPersisted bool
+	DvFieldsPending      []string
+	DvCachePrepared      bool
+	DvSegment            DocumentFieldTermVisitable
+}
+
+func (fdvs *FieldDocValueState) CurrentSegment() DocumentFieldTermVisitable {
+	return fdvs.DvSegment
 }

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -581,9 +581,9 @@ func TestSegmentVisitableDocValueFieldsList(t *testing.T) {
 		}
 
 		fieldTerms := make(index.FieldTerms)
-		err = zaps.VisitDocumentFieldTerms(0, fields, func(field string, term []byte) {
+		_, err = zaps.VisitDocumentFieldTerms(0, fields, func(field string, term []byte) {
 			fieldTerms[field] = append(fieldTerms[field], string(term))
-		})
+		}, nil)
 		if err != nil {
 			t.Error(err)
 		}

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -210,3 +210,17 @@ func incrementBytes(in []byte) []byte {
 	}
 	return rv
 }
+
+func (i *IndexReader) DocValueReader(fields []string) (index.DocValueReader, error) {
+	return &DocValueReader{i: i, fields: fields}, nil
+}
+
+type DocValueReader struct {
+	i      *IndexReader
+	fields []string
+}
+
+func (dvr *DocValueReader) VisitDocValues(id index.IndexInternalID,
+	visitor index.DocumentFieldTermVisitor) error {
+	return dvr.i.DocumentVisitFieldTerms(id, dvr.fields, visitor)
+}

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -161,3 +161,16 @@ func (sr *stubReader) DumpFields() chan interface{} {
 func (sr *stubReader) Close() error {
 	return nil
 }
+
+func (sr *stubReader) DocValueReader(fields []string) (index.DocValueReader, error) {
+	return &DocValueReader{i: sr, fields: fields}, nil
+}
+
+type DocValueReader struct {
+	i      *stubReader
+	fields []string
+}
+
+func (dvr *DocValueReader) VisitDocValues(id index.IndexInternalID, visitor index.DocumentFieldTermVisitor) error {
+	return dvr.i.DocumentVisitFieldTerms(id, dvr.fields, visitor)
+}


### PR DESCRIPTION
-attempt to improve the reuse of dvReaders
-avoid the redundant dvCache prep and checks for a given segment

there is this ugly FieldDocValueState thing introduced to save the runtime dv cache preparations and checks, looking for better ways to handle this..  (thought of putting these methods to the original DocVisitState interface, but even that doesn't looked any better..) . another flip side is dvState management kind of spread across the index_snapshot and zap layer(docvalues.go)..