### PR TITLE
fix geo searches hitting max clause limit

### DIFF
--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -42,10 +42,10 @@ func newDisjunctionSearcher(indexReader index.IndexReader,
 	limit bool) (search.Searcher, error) {
 	if len(qsearchers) > DisjunctionHeapTakeover {
 		return newDisjunctionHeapSearcher(indexReader, qsearchers, min, options,
-			true)
+			limit)
 	}
 	return newDisjunctionSliceSearcher(indexReader, qsearchers, min, options,
-		true)
+		limit)
 }
 
 func tooManyClauses(count int) bool {


### PR DESCRIPTION
geo queries are supposed to execute without considering the max
disjunction clauses limit, but a recent refactoring introduced
this bug, causing them to run with the limit enforced.