### PR TITLE
scorch optimize ExternalID() with Segment.DocID() API

### DIFF
--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -29,6 +29,10 @@ func (e *EmptySegment) VisitDocument(num uint64, visitor DocumentFieldValueVisit
 	return nil
 }
 
+func (e *EmptySegment) DocID(num uint64) ([]byte, error) {
+	return nil, nil
+}
+
 func (e *EmptySegment) Count() uint64 {
 	return 0
 }

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -28,6 +28,9 @@ type Segment interface {
 	Dictionary(field string) (TermDictionary, error)
 
 	VisitDocument(num uint64, visitor DocumentFieldValueVisitor) error
+
+	DocID(num uint64) ([]byte, error)
+
 	Count() uint64
 
 	DocNumbers([]string) (*roaring.Bitmap, error)

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -357,24 +357,15 @@ func (i *IndexSnapshot) ExternalID(id index.IndexInternalID) (string, error) {
 	}
 	segmentIndex, localDocNum := i.segmentIndexAndLocalDocNumFromGlobal(docNum)
 
-	var found bool
-	var rv string
-	err = i.segment[segmentIndex].VisitDocument(localDocNum, func(field string, typ byte, value []byte, pos []uint64) bool {
-		if field == "_id" {
-			found = true
-			rv = string(value)
-			return false
-		}
-		return true
-	})
+	v, err := i.segment[segmentIndex].DocID(localDocNum)
 	if err != nil {
 		return "", err
 	}
-
-	if found {
-		return rv, nil
+	if v == nil {
+		return "", fmt.Errorf("document number %d not found", docNum)
 	}
-	return "", fmt.Errorf("document number %d not found", docNum)
+
+	return string(v), nil
 }
 
 func (i *IndexSnapshot) InternalID(id string) (rv index.IndexInternalID, err error) {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -101,6 +101,10 @@ func (s *SegmentSnapshot) VisitDocument(num uint64, visitor segment.DocumentFiel
 	return s.segment.VisitDocument(num, visitor)
 }
 
+func (s *SegmentSnapshot) DocID(num uint64) ([]byte, error) {
+	return s.segment.DocID(num)
+}
+
 func (s *SegmentSnapshot) Count() uint64 {
 
 	rv := s.segment.Count()


### PR DESCRIPTION
The previous implementation of ExternalID(), which used the generic
VisitDocument() API to access the _id field (with extra closure
allocations), has now been replaced in this optimization by invoking a
new Segment.DocID() method.