### PR TITLE
MB-29576 - Indexing blocked on scorch

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -202,6 +202,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 	s.nextSnapshotEpoch++
 	rootPrev := s.root
 	s.root = newSnapshot
+	atomic.StoreUint64(&s.stats.CurRootEpoch, s.root.epoch)
 	// release lock
 	s.rootLock.Unlock()
 
@@ -265,6 +266,7 @@ func (s *Scorch) introducePersist(persist *persistIntroduction) {
 	s.rootLock.Lock()
 	rootPrev := s.root
 	s.root = newIndexSnapshot
+	atomic.StoreUint64(&s.stats.CurRootEpoch, s.root.epoch)
 	s.rootLock.Unlock()
 
 	if rootPrev != nil {
@@ -369,6 +371,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	s.nextSnapshotEpoch++
 	rootPrev := s.root
 	s.root = newSnapshot
+	atomic.StoreUint64(&s.stats.CurRootEpoch, s.root.epoch)
 	// release lock
 	s.rootLock.Unlock()
 
@@ -430,6 +433,8 @@ func (s *Scorch) revertToSnapshot(revertTo *snapshotReversion) error {
 	// swap in new snapshot
 	rootPrev := s.root
 	s.root = newSnapshot
+
+	atomic.StoreUint64(&s.stats.CurRootEpoch, s.root.epoch)
 	// release lock
 	s.rootLock.Unlock()
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -72,6 +72,8 @@ OUTER:
 				}
 				lastEpochMergePlanned = ourSnapshot.epoch
 
+				atomic.StoreUint64(&s.stats.LastMergedEpoch, ourSnapshot.epoch)
+
 				s.fireEvent(EventKindMergerProgress, time.Since(startTime))
 			}
 			_ = ourSnapshot.DecRef()

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -109,6 +109,8 @@ OUTER:
 				continue OUTER
 			}
 
+			atomic.StoreUint64(&s.stats.LastPersistedEpoch, ourSnapshot.epoch)
+
 			lastPersistedEpoch = ourSnapshot.epoch
 			for _, ew := range persistWatchers {
 				close(ew.notifyCh)

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -33,6 +33,10 @@ type Stats struct {
 	TotBatchIntroTime uint64
 	MaxBatchIntroTime uint64
 
+	CurRootEpoch       uint64
+	LastPersistedEpoch uint64
+	LastMergedEpoch    uint64
+
 	TotOnErrors uint64
 
 	TotAnalysisTime uint64


### PR DESCRIPTION
More stats to keep track of last merged, persisted and current root epoch.
Haven't added any extra in-memory merging events, thinking that the in-line persistence call would trigger another progress event during it's introduction.