### PR TITLE
cachedDocs.visitDoc() check whether docs map is ready for use

### DIFF
--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -293,6 +293,10 @@ func (c *cachedDocs) visitDoc(localDocNum uint64,
 
 	for _, field := range fields {
 		if cachedFieldDocs, exists := c.cache[field]; exists {
+			c.m.Unlock()
+			<-cachedFieldDocs.readyCh
+			c.m.Lock()
+
 			if tlist, exists := cachedFieldDocs.docs[localDocNum]; exists {
 				for {
 					i := bytes.Index(tlist, TermSeparatorSplitSlice)


### PR DESCRIPTION
Before this change, the cachedDocs.visitDoc() method was accessing the
docs map before the readyCh was closed.  Without this check, another
goroutine that's executing the cachedFieldDocs.prepareField() method
might be concurrently populating and modifying the docs map.

See also: https://issues.couchbase.com/browse/MB-29844