### PR TITLE
Scorch optimize via vellum.FST.Reader() API

### DIFF
--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -28,10 +28,11 @@ import (
 
 // Dictionary is the zap representation of the term dictionary
 type Dictionary struct {
-	sb      *SegmentBase
-	field   string
-	fieldID uint16
-	fst     *vellum.FST
+	sb        *SegmentBase
+	field     string
+	fieldID   uint16
+	fst       *vellum.FST
+	fstReader *vellum.Reader
 }
 
 // PostingsList returns the postings list for the specified term
@@ -46,14 +47,14 @@ func (d *Dictionary) PostingsList(term []byte, except *roaring.Bitmap,
 }
 
 func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *PostingsList) (*PostingsList, error) {
-	if d.fst == nil {
+	if d.fstReader == nil {
 		if rv == nil || rv == emptyPostingsList {
 			return emptyPostingsList, nil
 		}
 		return d.postingsListInit(rv, except), nil
 	}
 
-	postingsOffset, exists, err := d.fst.Get(term)
+	postingsOffset, exists, err := d.fstReader.Get(term)
 	if err != nil {
 		return nil, fmt.Errorf("vellum err: %v", err)
 	}

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -266,6 +266,10 @@ func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 				if err != nil {
 					return nil, fmt.Errorf("dictionary field %s vellum err: %v", field, err)
 				}
+				rv.fstReader, err = rv.fst.Reader()
+				if err != nil {
+					return nil, fmt.Errorf("dictionary field %s vellum reader err: %v", field, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
    + This change sets up a vellum.Reader (which carries a prealloc'ed
      fstState) for the term dictionaries.
    + However the Reader cannot be used concurrently, so rather than
      re-using a fieldDicts initialized for the IndexSnapshot, re-use
      one that is set up for TermFieldReaders which are recycled.