### PR TITLE
Fix spelling and typo mistakes

### DIFF
--- a/analysis/token/snowball/snowball.go
+++ b/analysis/token/snowball/snowball.go
@@ -26,12 +26,12 @@ import (
 const Name = "stemmer_snowball"
 
 type SnowballStemmer struct {
-	langauge string
+	language string
 }
 
 func NewSnowballStemmer(language string) *SnowballStemmer {
 	return &SnowballStemmer{
-		langauge: language,
+		language: language,
 	}
 }
 

--- a/analysis/token/unique/unique.go
+++ b/analysis/token/unique/unique.go
@@ -21,7 +21,7 @@ import (
 
 const Name = "unique"
 
-// UniqueTermFilter retains only the tokens which mark the first occurence of
+// UniqueTermFilter retains only the tokens which mark the first occurrence of
 // a term. Tokens whose term appears in a preceding token are dropped.
 type UniqueTermFilter struct{}
 

--- a/cmd/bleve/cmd/zap/dict.go
+++ b/cmd/bleve/cmd/zap/dict.go
@@ -38,7 +38,7 @@ var dictCmd = &cobra.Command{
 
 		addr, err := segment.DictAddr(args[1])
 		if err != nil {
-			return fmt.Errorf("error determing address: %v", err)
+			return fmt.Errorf("error determining address: %v", err)
 		}
 		fmt.Printf("dictionary for field starts at %d (%x)\n", addr, addr)
 

--- a/cmd/bleve/cmd/zap/explore.go
+++ b/cmd/bleve/cmd/zap/explore.go
@@ -39,7 +39,7 @@ var exploreCmd = &cobra.Command{
 
 		addr, err := segment.DictAddr(args[1])
 		if err != nil {
-			return fmt.Errorf("error determing address: %v", err)
+			return fmt.Errorf("error determining address: %v", err)
 		}
 		fmt.Printf("dictionary for field starts at %d (%x)\n", addr, addr)
 

--- a/geo/parse_test.go
+++ b/geo/parse_test.go
@@ -87,7 +87,7 @@ func TestExtractGeoPoint(t *testing.T) {
 			lat:     7.5,
 			success: true,
 		},
-		// struct with lng alterante
+		// struct with lng alternate
 		{
 			in: struct {
 				Lng float64

--- a/index/scorch/README.md
+++ b/index/scorch/README.md
@@ -302,7 +302,7 @@ Map local bitsets into global number space (global meaning cross-segment but sti
 IndexSnapshot already should have mapping something like:
 0 - Offset 0
 1 - Offset 3 (because segment 0 had 3 docs)
-2 - Offset 4 (becuase segment 1 had 1 doc)
+2 - Offset 4 (because segment 1 had 1 doc)
 
 This maps to search result bitset:
 

--- a/index/scorch/segment/zap/README.md
+++ b/index/scorch/segment/zap/README.md
@@ -109,7 +109,7 @@ If you know the doc number you're interested in, this format lets you jump to th
     - remember the start position for this posting list
     - write freq/norm details offset (remembered from previous, as varint uint64)
     - write location details offset (remembered from previous, as varint uint64)
-    - write location bitmap offset (remembered from pervious, as varint uint64)
+    - write location bitmap offset (remembered from previous, as varint uint64)
     - write length of encoded roaring bitmap
     - write the serialized roaring bitmap data
 

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -94,7 +94,7 @@ func under32Bits(x uint64) bool {
 
 const docNum1HitFinished = math.MaxUint64
 
-// PostingsList is an in-memory represenation of a postings list
+// PostingsList is an in-memory representation of a postings list
 type PostingsList struct {
 	sb             *SegmentBase
 	postingsOffset uint64
@@ -733,7 +733,7 @@ func (p *Posting) Number() uint64 {
 	return p.docNum
 }
 
-// Frequency returns the frequence of occurance of this term in this doc/field
+// Frequency returns the frequencies of occurrence of this term in this doc/field
 func (p *Posting) Frequency() uint64 {
 	return p.freq
 }
@@ -743,12 +743,12 @@ func (p *Posting) Norm() float64 {
 	return float64(p.norm)
 }
 
-// Locations returns the location information for each occurance
+// Locations returns the location information for each occurrence
 func (p *Posting) Locations() []segment.Location {
 	return p.locs
 }
 
-// Location represents the location of a single occurance
+// Location represents the location of a single occurrence
 type Location struct {
 	field string
 	pos   uint64
@@ -769,22 +769,22 @@ func (l *Location) Field() string {
 	return l.field
 }
 
-// Start returns the start byte offset of this occurance
+// Start returns the start byte offset of this occurrence
 func (l *Location) Start() uint64 {
 	return l.start
 }
 
-// End returns the end byte offset of this occurance
+// End returns the end byte offset of this occurrence
 func (l *Location) End() uint64 {
 	return l.end
 }
 
-// Pos returns the 1-based phrase position of this occurance
+// Pos returns the 1-based phrase position of this occurrence
 func (l *Location) Pos() uint64 {
 	return l.pos
 }
 
-// ArrayPositions returns the array position vector associated with this occurance
+// ArrayPositions returns the array position vector associated with this occurrence
 func (l *Location) ArrayPositions() []uint64 {
 	return l.ap
 }

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -211,7 +211,7 @@ func (s *Segment) loadConfig() error {
 }
 
 func (s *SegmentBase) loadFields() error {
-	// NOTE for now we assume the fields index immediately preceeds
+	// NOTE for now we assume the fields index immediately precedes
 	// the footer, and if this changes, need to adjust accordingly (or
 	// store explicit length), where s.mem was sliced from s.mm in Open().
 	fieldsIndexEnd := uint64(len(s.mem))

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -515,7 +515,7 @@ func TestIndexAliasMulti(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// cheat and ensure that Took field matches since it invovles time
+	// cheat and ensure that Took field matches since it involves time
 	expected.Took = results.Took
 	if !reflect.DeepEqual(results, expected) {
 		t.Errorf("expected %#v, got %#v", expected, results)
@@ -599,7 +599,7 @@ func TestMultiSearchNoError(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// cheat and ensure that Took field matches since it invovles time
+	// cheat and ensure that Took field matches since it involves time
 	expected.Took = results.Took
 	if !reflect.DeepEqual(results, expected) {
 		t.Errorf("expected %#v, got %#v", expected, results)
@@ -1229,7 +1229,7 @@ func TestMultiSearchCustomSort(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// cheat and ensure that Took field matches since it invovles time
+	// cheat and ensure that Took field matches since it involves time
 	expected.Took = results.Took
 	if !reflect.DeepEqual(results, expected) {
 		t.Errorf("expected %v, got %v", expected, results)

--- a/index_test.go
+++ b/index_test.go
@@ -1509,7 +1509,7 @@ func TestSearchTimeout(t *testing.T) {
 		}
 	}()
 
-	// first run a search with an absurdly long timeout (should succeeed)
+	// first run a search with an absurdly long timeout (should succeed)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	query := NewTermQuery("water")

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -324,7 +324,7 @@ func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
 }
 
 func (dm *DocumentMapping) walkDocument(data interface{}, path []string, indexes []uint64, context *walkContext) {
-	// allow default "json" tag to be overriden
+	// allow default "json" tag to be overridden
 	structTagKey := dm.StructTagKey
 	if structTagKey == "" {
 		structTagKey = "json"

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -950,7 +950,7 @@ func TestMappingForTextMarshaler(t *testing.T) {
 		},
 	}
 
-	// first verify that when using a mapping that doesn't explicity
+	// first verify that when using a mapping that doesn't explicitly
 	// map the stuct field as text, then we traverse inside the struct
 	// and do our best
 	m := NewIndexMapping()
@@ -970,7 +970,7 @@ func TestMappingForTextMarshaler(t *testing.T) {
 		t.Errorf("expected field value to be '%s', got: '%s'", tm.Marshalable.Extra, string(doc.Fields[0].Value()))
 	}
 
-	// now verify that when a mapping explicity
+	// now verify that when a mapping explicitly
 	m = NewIndexMapping()
 	txt := NewTextFieldMapping()
 	m.DefaultMapping.AddFieldMappingsAt("Marshalable", txt)
@@ -1004,7 +1004,7 @@ func TestMappingForNilTextMarshaler(t *testing.T) {
 		Marshalable: nil,
 	}
 
-	// now verify that when a mapping explicity
+	// now verify that when a mapping explicitly
 	m := NewIndexMapping()
 	txt := NewTextFieldMapping()
 	m.DefaultMapping.AddFieldMappingsAt("Marshalable", txt)

--- a/numeric/bin.go
+++ b/numeric/bin.go
@@ -14,7 +14,7 @@ var interleaveShift = []uint{1, 2, 4, 8, 16}
 
 // Interleave the first 32 bits of each uint64
 // apdated from org.apache.lucene.util.BitUtil
-// whcih was adapted from:
+// which was adapted from:
 // http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
 func Interleave(v1, v2 uint64) uint64 {
 	v1 = (v1 | (v1 << interleaveShift[4])) & interleaveMagic[4]

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -210,7 +210,7 @@ func (s *PhraseSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch,
 	return nil, nil
 }
 
-// checkCurrMustMatch is soley concerned with determining if the DocumentMatch
+// checkCurrMustMatch is solely concerned with determining if the DocumentMatch
 // pointed to by s.currMust (which satisifies the pre-condition searcher)
 // also satisfies the phase constraints.  if so, it returns a DocumentMatch
 // for this document, otherwise nil
@@ -241,7 +241,7 @@ func (s *PhraseSearcher) checkCurrMustMatch(ctx *search.SearchContext) *search.D
 	return nil
 }
 
-// checkCurrMustMatchField is soley concerned with determining if one
+// checkCurrMustMatchField is solely concerned with determining if one
 // particular field within the currMust DocumentMatch Locations
 // satisfies the phase constraints (possibly more than once).  if so,
 // the matching field term locations are appended to the provided

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -94,7 +94,7 @@ func TestTermRangeSearch(t *testing.T) {
 			inclusiveMax: true,
 			want:         nil,
 		},
-		// max nil sees everyting after marty
+		// max nil sees everything after marty
 		{
 			min:          []byte("marty"),
 			max:          nil,
@@ -103,7 +103,7 @@ func TestTermRangeSearch(t *testing.T) {
 			inclusiveMax: true,
 			want:         []string{"1", "2", "4"},
 		},
-		// min nil sees everyting before ravi
+		// min nil sees everything before ravi
 		{
 			min:          nil,
 			max:          []byte("ravi"),


### PR DESCRIPTION
This should only be code and documentation fixes - not test data with intentional misspellings.