### PR TITLE
Fix to boolean searcher's Advance()

### DIFF
--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -332,31 +332,38 @@ func (s *BooleanSearcher) Advance(ctx *search.SearchContext, ID index.IndexInter
 	}
 
 	var err error
+	// Advance nested searcher(s) only if the cursor is trailing the lookup ID
 	if s.mustSearcher != nil {
-		if s.currMust != nil {
-			ctx.DocumentMatchPool.Put(s.currMust)
-		}
-		s.currMust, err = s.mustSearcher.Advance(ctx, ID)
-		if err != nil {
-			return nil, err
+		if s.currMust == nil || s.currMust.IndexInternalID.Compare(ID) < 0 {
+			if s.currMust != nil {
+				ctx.DocumentMatchPool.Put(s.currMust)
+			}
+			s.currMust, err = s.mustSearcher.Advance(ctx, ID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if s.shouldSearcher != nil {
-		if s.currShould != nil {
-			ctx.DocumentMatchPool.Put(s.currShould)
-		}
-		s.currShould, err = s.shouldSearcher.Advance(ctx, ID)
-		if err != nil {
-			return nil, err
+		if s.currShould == nil || s.currShould.IndexInternalID.Compare(ID) < 0 {
+			if s.currShould != nil {
+				ctx.DocumentMatchPool.Put(s.currShould)
+			}
+			s.currShould, err = s.shouldSearcher.Advance(ctx, ID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if s.mustNotSearcher != nil {
-		if s.currMustNot != nil {
-			ctx.DocumentMatchPool.Put(s.currMustNot)
-		}
-		s.currMustNot, err = s.mustNotSearcher.Advance(ctx, ID)
-		if err != nil {
-			return nil, err
+		if s.currMustNot == nil || s.currMustNot.IndexInternalID.Compare(ID) < 0 {
+			if s.currMustNot != nil {
+				ctx.DocumentMatchPool.Put(s.currMustNot)
+			}
+			s.currMustNot, err = s.mustNotSearcher.Advance(ctx, ID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/search_test.go
+++ b/search_test.go
@@ -17,12 +17,21 @@ package bleve
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/blevesearch/bleve/analysis"
+	"github.com/blevesearch/bleve/analysis/analyzer/custom"
+	"github.com/blevesearch/bleve/analysis/token/lowercase"
+	"github.com/blevesearch/bleve/analysis/tokenizer/single"
+	"github.com/blevesearch/bleve/analysis/tokenizer/whitespace"
+	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/search/query"
 )
 
 func TestSearchResultString(t *testing.T) {
@@ -412,5 +421,124 @@ func TestMemoryNeededForSearchResult(t *testing.T) {
 	estimate := MemoryNeededForSearchResult(req)
 	if estimate != uint64(expect) {
 		t.Errorf("estimate not what is expected: %v != %v", estimate, expect)
+	}
+}
+
+// https://github.com/blevesearch/bleve/issues/954
+func TestNestedBooleanSearchers(t *testing.T) {
+	defer func() {
+		err := os.RemoveAll("testidx")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// create an index with a custom analyzer
+	idxMapping := NewIndexMapping()
+	if err := idxMapping.AddCustomAnalyzer("3xbla", map[string]interface{}{
+		"type":          custom.Name,
+		"tokenizer":     whitespace.Name,
+		"token_filters": []interface{}{lowercase.Name, "stop_en"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	idxMapping.DefaultAnalyzer = "3xbla"
+	idx, err := New("testidx", idxMapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create and insert documents as a batch
+	batch := idx.NewBatch()
+	matches := 0
+	for i := 0; i < 100; i++ {
+		hostname := fmt.Sprintf("planner_hostname_%d", i%5)
+		metadata := map[string]string{"region": fmt.Sprintf("planner_us-east-%d", i%5)}
+
+		// Expected matches
+		if (hostname == "planner_hostname_1" || hostname == "planner_hostname_2") &&
+			metadata["region"] == "planner_us-east-1" {
+			matches++
+		}
+
+		doc := document.NewDocument(strconv.Itoa(i))
+		doc.Fields = []document.Field{
+			document.NewTextFieldCustom("hostname", []uint64{}, []byte(hostname),
+				document.IndexField,
+				&analysis.Analyzer{
+					Tokenizer: single.NewSingleTokenTokenizer(),
+					TokenFilters: []analysis.TokenFilter{
+						lowercase.NewLowerCaseFilter(),
+					},
+				},
+			),
+		}
+		for k, v := range metadata {
+			doc.AddField(document.NewTextFieldWithIndexingOptions(
+				fmt.Sprintf("metadata.%s", k), []uint64{}, []byte(v), document.IndexField))
+		}
+		doc.CompositeFields = []*document.CompositeField{
+			document.NewCompositeFieldWithIndexingOptions(
+				"_all", true, []string{"text"}, []string{},
+				document.IndexField|document.IncludeTermVectors),
+		}
+
+		if err = batch.IndexAdvanced(doc); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err = idx.Batch(batch); err != nil {
+		t.Fatal(err)
+	}
+
+	que, err := query.ParseQuery([]byte(
+		`{
+			"conjuncts": [
+			{
+				"must": {
+					"conjuncts": [
+					{
+						"disjuncts": [
+						{
+							"match": "planner_hostname_1",
+							"field": "hostname"
+						},
+						{
+							"match": "planner_hostname_2",
+							"field": "hostname"
+						}
+						]
+					}
+					]
+				}
+			},
+			{
+				"must": {
+					"conjuncts": [
+					{
+						"match": "planner_us-east-1",
+						"field": "metadata.region"
+					}
+					]
+				}
+			}
+			]
+		}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := NewSearchRequest(que)
+	req.Size = 100
+	req.Fields = []string{"hostname", "metadata.region"}
+	searchResults, err := idx.Search(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matches != len(searchResults.Hits) {
+		t.Fatalf("Unexpected result set, %v != %v", matches, len(searchResults.Hits))
 	}
 }


### PR DESCRIPTION
+ Advance nested searchers within a boolean searcher only if
  the cursor is trailing the ID being looked up.
+ Unit test
+ Fixes blevesearch#954

Here's an example bug scenario with nested boolean searchers ..

    conjunctionSearcher [a]
        => booleanSearcher [b]
            Must => conjunctionSearcher [d]
                => disjunctionSearcher [f]
                    => disjunctionSearcher
                        => termSearcher
                    => disjunctionSearcher
                        => termSearcher
        => booleanSearcher [c]
            Must => conjunctionSearcher [e]
                => termSearcher

    Consider there to be docs ranging from 1 to 100 in the index
    and these are the expected matches, for the query:
    1, 11, 16, 21,..

    On the first Next() call by the collector ..
        [d]
            - initSearchers .. sets local cursor of [f] to 1
            - moves local cursor of disjunction cursor to 11

        [b]
            - init: local cursor of [d] set to 1
            - moves [d]’s local cursor of [f] to 12
            - moves local cursor of [d] to 11

        [c]
            - init: local cursor of [e] set to 1
            - moves local cursor of [e] to 11

        [a]
            - initSearchers: sets local cursors of [b], [c] to 1
            - moves [b]’s local cursor of [d] to 12
            - moves [d]’s local cursor of [f] to 16
            - moves [c]’s local cursor of [e] to 16
            - updates local cursor of [b] to 11
            - updates local cursor of [c] to 11

    (Note that at this point [b]’s local cursor to [d] and [c]’s
     local cursor to [e] are pointing to different documents,
     owing to the different nesting of searchers underneath)

    On the second Next() call by the collector ..
        [a] .. maxID: 11
            - moves [b]’s local cursor of [d] to 16
                - moves [d]’s local cursor of [f] to 17
            - moves [c]’s local cursor of [e] to 21
            - updates local cursor of [b] to 12
            - updates local cursor of [c] to 16

    On the third Next() call by the collector ..
        [a] .. maxID: 16
            - sees that maxID 16 > 12 (cursor position of [b])
            - invokes advanceChild([b]) ..
                --> this causes [b]’s local cursor to move from
                    16 to 17 and this prevents the match:16 from
                    being collected.