### PR TITLE
MB-30616: Revert "MB-29923 - high memory consumption in scorch"

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -434,30 +434,23 @@ func (s *Scorch) currentSnapshot() *IndexSnapshot {
 func (s *Scorch) Stats() json.Marshaler {
 	return &s.stats
 }
+func (s *Scorch) StatsMap() map[string]interface{} {
+	m := s.stats.ToMap()
 
-func (s *Scorch) diskFileStats() (uint64, uint64) {
-	var numFilesOnDisk, numBytesUsedDisk uint64
 	if s.path != "" {
 		finfos, err := ioutil.ReadDir(s.path)
 		if err == nil {
+			var numFilesOnDisk, numBytesUsedDisk uint64
 			for _, finfo := range finfos {
 				if !finfo.IsDir() {
 					numBytesUsedDisk += uint64(finfo.Size())
 					numFilesOnDisk++
 				}
 			}
+
+			m["CurOnDiskBytes"] = numBytesUsedDisk
+			m["CurOnDiskFiles"] = numFilesOnDisk
 		}
-	}
-	return numFilesOnDisk, numBytesUsedDisk
-}
-
-func (s *Scorch) StatsMap() map[string]interface{} {
-	m := s.stats.ToMap()
-
-	numFilesOnDisk, numBytesUsedDisk := s.diskFileStats()
-	if numFilesOnDisk > 0 || numBytesUsedDisk > 0 {
-		m["CurOnDiskBytes"] = numBytesUsedDisk
-		m["CurOnDiskFiles"] = numFilesOnDisk
 	}
 
 	// TODO: consider one day removing these backwards compatible

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -33,11 +33,6 @@ import (
 	"github.com/blevesearch/bleve/mapping"
 )
 
-func init() {
-	// override for tests
-	DefaultPersisterNapTimeMSec = 1
-}
-
 func DestroyTest() error {
 	return os.RemoveAll("/tmp/bleve-scorch-test")
 }

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -41,12 +41,6 @@ import (
 //     go test -v -run TestScorchVersusUpsideDownBolt ./test
 //     VERBOSE=1 FOCUS=Trista go test -v -run TestScorchVersusUpsideDownBolt ./test
 //
-
-func init() {
-	// override for tests
-	scorch.DefaultPersisterNapTimeMSec = 1
-}
-
 func TestScorchVersusUpsideDownBoltAll(t *testing.T) {
 	(&VersusTest{
 		t:                    t,


### PR DESCRIPTION
Noticed operational deadlocks by stalling the persister to
allow more in-memory merges.

This reverts commit 84502bf2c73fd9a85477d7018220e0af6a69374e.