### PR TITLE
Revert "MB-30616: Revert "MB-29923 - high memory consumption in scorch""

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -17,6 +17,7 @@ package scorch
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -35,16 +36,22 @@ import (
 
 var DefaultChunkFactor uint32 = 1024
 
-// Arbitrary number, need to make it configurable.
-// Lower values like 10/making persister really slow
-// doesn't work well as it is creating more files to
-// persist for in next persist iteration and spikes the # FDs.
-// Ideal value should let persister also proceed at
-// an optimum pace so that the merger can skip
-// many intermediate snapshots.
-// This needs to be based on empirical data.
-// TODO - may need to revisit this approach/value.
-var epochDistance = uint64(5)
+var DefaultPersisterNapTimeMSec int = 2000 // ms
+
+var DefaultPersisterNapUnderNumFiles int = 1000
+
+type persisterOptions struct {
+	// PersisterNapTimeMSec controls the wait/delay injected into
+	// persistence workloop to improve the chances for
+	// a healthier and heavier in-memory merging
+	PersisterNapTimeMSec int
+
+	// PersisterNapTimeMSec > 0, and the number of files is less than
+	// PersisterNapUnderNumFiles, then the persister will sleep
+	// PersisterNapTimeMSec amount of time to improve the chances for
+	// a healthier and heavier in-memory merging
+	PersisterNapUnderNumFiles int
+}
 
 type notificationChan chan struct{}
 
@@ -54,6 +61,12 @@ func (s *Scorch) persisterLoop() {
 	var persistWatchers []*epochWatcher
 	var lastPersistedEpoch, lastMergedEpoch uint64
 	var ew *epochWatcher
+	po, err := s.parsePersisterOptions()
+	if err != nil {
+		s.fireAsyncError(fmt.Errorf("persisterOptions json parsing err: %v", err))
+		return
+	}
+
 OUTER:
 	for {
 		atomic.AddUint64(&s.stats.TotPersistLoopBeg, 1)
@@ -69,7 +82,7 @@ OUTER:
 			lastMergedEpoch = ew.epoch
 		}
 		lastMergedEpoch, persistWatchers = s.pausePersisterForMergerCatchUp(lastPersistedEpoch,
-			lastMergedEpoch, persistWatchers)
+			lastMergedEpoch, persistWatchers, po)
 
 		var ourSnapshot *IndexSnapshot
 		var ourPersisted []chan error
@@ -180,14 +193,28 @@ func notifyMergeWatchers(lastPersistedEpoch uint64,
 }
 
 func (s *Scorch) pausePersisterForMergerCatchUp(lastPersistedEpoch uint64, lastMergedEpoch uint64,
-	persistWatchers []*epochWatcher) (uint64, []*epochWatcher) {
+	persistWatchers []*epochWatcher, po *persisterOptions) (uint64, []*epochWatcher) {
 
 	// first, let the watchers proceed if they lag behind
 	persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
 
+	// check the merger lag by counting the segment files on disk,
+	// on finding fewer files on disk, persister pauses for a bit -
+	// for sufficient in-memory segments to pile up for the next
+	// memory merge and persist loop;
+	// on finding too many files on disk, persister waits until the merger
+	// catches up to reduce the segment file count to under the threshold.
+	numFilesOnDisk, _ := s.diskFileStats()
+	if numFilesOnDisk < uint64(po.PersisterNapUnderNumFiles) && po.PersisterNapTimeMSec > 0 {
+		select {
+		case <- s.closeCh:
+		case <- time.After(time.Millisecond * time.Duration(po.PersisterNapTimeMSec)):
+		}
+		return lastMergedEpoch, persistWatchers
+	}
+
 OUTER:
-	// check for slow merger and await until the merger catch up
-	for lastPersistedEpoch > lastMergedEpoch+epochDistance {
+	for numFilesOnDisk >= uint64(po.PersisterNapUnderNumFiles) {
 		atomic.AddUint64(&s.stats.TotPersisterSlowMergerPause, 1)
 
 		select {
@@ -202,9 +229,30 @@ OUTER:
 
 		// let the watchers proceed if they lag behind
 		persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
+
+		numFilesOnDisk, _ = s.diskFileStats()
 	}
 
 	return lastMergedEpoch, persistWatchers
+}
+
+func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
+	po := persisterOptions{
+		PersisterNapTimeMSec:      DefaultPersisterNapTimeMSec,
+		PersisterNapUnderNumFiles: DefaultPersisterNapUnderNumFiles,
+	}
+	if v, ok := s.config["scorchPersisterOptions"]; ok {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return &po, err
+		}
+
+		err = json.Unmarshal(b, &po)
+		if err != nil {
+			return &po, err
+		}
+	}
+	return &po, nil
 }
 
 func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -434,23 +434,30 @@ func (s *Scorch) currentSnapshot() *IndexSnapshot {
 func (s *Scorch) Stats() json.Marshaler {
 	return &s.stats
 }
-func (s *Scorch) StatsMap() map[string]interface{} {
-	m := s.stats.ToMap()
 
+func (s *Scorch) diskFileStats() (uint64, uint64) {
+	var numFilesOnDisk, numBytesUsedDisk uint64
 	if s.path != "" {
 		finfos, err := ioutil.ReadDir(s.path)
 		if err == nil {
-			var numFilesOnDisk, numBytesUsedDisk uint64
 			for _, finfo := range finfos {
 				if !finfo.IsDir() {
 					numBytesUsedDisk += uint64(finfo.Size())
 					numFilesOnDisk++
 				}
 			}
-
-			m["CurOnDiskBytes"] = numBytesUsedDisk
-			m["CurOnDiskFiles"] = numFilesOnDisk
 		}
+	}
+	return numFilesOnDisk, numBytesUsedDisk
+}
+
+func (s *Scorch) StatsMap() map[string]interface{} {
+	m := s.stats.ToMap()
+
+	numFilesOnDisk, numBytesUsedDisk := s.diskFileStats()
+	if numFilesOnDisk > 0 || numBytesUsedDisk > 0 {
+		m["CurOnDiskBytes"] = numBytesUsedDisk
+		m["CurOnDiskFiles"] = numFilesOnDisk
 	}
 
 	// TODO: consider one day removing these backwards compatible

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -33,6 +33,11 @@ import (
 	"github.com/blevesearch/bleve/mapping"
 )
 
+func init() {
+	// override for tests
+	DefaultPersisterNapTimeMSec = 1
+}
+
 func DestroyTest() error {
 	return os.RemoveAll("/tmp/bleve-scorch-test")
 }

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -41,6 +41,12 @@ import (
 //     go test -v -run TestScorchVersusUpsideDownBolt ./test
 //     VERBOSE=1 FOCUS=Trista go test -v -run TestScorchVersusUpsideDownBolt ./test
 //
+
+func init() {
+	// override for tests
+	scorch.DefaultPersisterNapTimeMSec = 1
+}
+
 func TestScorchVersusUpsideDownBoltAll(t *testing.T) {
 	(&VersusTest{
 		t:                    t,


### PR DESCRIPTION
+ Slight change to pausePersisterForMergerCatchUp

This reverts commit 1d7c871429c3e77f2532f4d59071e492abf523fb.