### PR TITLE
fix 1-hit scorch optimization freq/norm & added scorch regexp test

### DIFF
--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -188,7 +188,10 @@ func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 
 		rv.buf = buf
 	}
+
 	rv.postings = p
+	rv.includeFreqNorm = includeFreq || includeNorm
+	rv.includeLocs = includeLocs
 
 	if p.normBits1Hit != 0 {
 		// "1-hit" encoding
@@ -211,7 +214,6 @@ func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 	var read int
 
 	// prepare the freq chunk details
-	rv.includeFreqNorm = includeFreq || includeNorm
 	if rv.includeFreqNorm {
 		var numFreqChunks uint64
 		numFreqChunks, read = binary.Uvarint(p.sb.mem[p.freqOffset+n : p.freqOffset+n+binary.MaxVarintLen64])
@@ -229,7 +231,6 @@ func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 	}
 
 	// prepare the loc chunk details
-	rv.includeLocs = includeLocs
 	if rv.includeLocs {
 		n = 0
 		var numLocChunks uint64

--- a/search/searcher/base_test.go
+++ b/search/searcher/base_test.go
@@ -15,6 +15,7 @@
 package searcher
 
 import (
+	"io/ioutil"
 	"math"
 	"regexp"
 
@@ -22,6 +23,7 @@ import (
 	regexpTokenizer "github.com/blevesearch/bleve/analysis/tokenizer/regexp"
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/scorch"
 	"github.com/blevesearch/bleve/index/store/gtreap"
 	"github.com/blevesearch/bleve/index/upsidedown"
 )
@@ -29,9 +31,12 @@ import (
 var twoDocIndex index.Index //= upside_down.NewUpsideDownCouch(inmem.MustOpen())
 
 func init() {
+	twoDocIndex = initTwoDocUpsideDown()
+}
+
+func initTwoDocUpsideDown() index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
-	var err error
-	twoDocIndex, err = upsidedown.NewUpsideDownCouch(
+	twoDocIndex, err := upsidedown.NewUpsideDownCouch(
 		gtreap.Name,
 		map[string]interface{}{
 			"path": "",
@@ -39,7 +44,27 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = twoDocIndex.Open()
+	initTwoDocs(twoDocIndex)
+	return twoDocIndex
+}
+
+func initTwoDocScorch() index.Index {
+	analysisQueue := index.NewAnalysisQueue(1)
+	dir, _ := ioutil.TempDir("", "scorchTwoDoc")
+	twoDocIndex, err := scorch.NewScorch(
+		scorch.Name,
+		map[string]interface{}{
+			"path": dir,
+		}, analysisQueue)
+	if err != nil {
+		panic(err)
+	}
+	initTwoDocs(twoDocIndex)
+	return twoDocIndex
+}
+
+func initTwoDocs(twoDocIndex index.Index) {
+	err := twoDocIndex.Open()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The "1-hit" encoding optimization for scorch was incorrectly returning
from the postings list iterator constructor too early, before setting
the includeFreqNorm & includeLocs flags.

This was caught while refactoring the existing regexp searcher unit
test from upside-down to also test scorch.