### PR TITLE
MB-29923 - high scorch mem usage with items to persist

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -17,6 +17,7 @@ package scorch
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -35,16 +36,22 @@ import (
 
 var DefaultChunkFactor uint32 = 1024
 
-// Arbitrary number, need to make it configurable.
-// Lower values like 10/making persister really slow
-// doesn't work well as it is creating more files to
-// persist for in next persist iteration and spikes the # FDs.
-// Ideal value should let persister also proceed at
-// an optimum pace so that the merger can skip
-// many intermediate snapshots.
-// This needs to be based on empirical data.
-// TODO - may need to revisit this approach/value.
-var epochDistance = uint64(5)
+var DefaultPersisterNapTimeMSec int = 2000 // ms
+
+var DefaultPersisterNapUnderNumFiles int = 1000
+
+type persisterOptions struct {
+	// PersisterNapTimeMSec controls the wait/delay injected into
+	// persistence workloop to improve the chances for
+	// a healthier and heavier in-memory merging
+	PersisterNapTimeMSec int
+
+	// PersisterNapTimeMSec > 0, and the number of files is less than
+	// PersisterNapUnderNumFiles, then the persister will sleep
+	// PersisterNapTimeMSec amount of time to improve the chances for
+	// a healthier and heavier in-memory merging
+	PersisterNapUnderNumFiles int
+}
 
 type notificationChan chan struct{}
 
@@ -54,6 +61,13 @@ func (s *Scorch) persisterLoop() {
 	var persistWatchers []*epochWatcher
 	var lastPersistedEpoch, lastMergedEpoch uint64
 	var ew *epochWatcher
+	po, err := s.parsePersisterOptions()
+	if err != nil {
+		s.fireAsyncError(fmt.Errorf("persisterOptions json parsing err: %v", err))
+		s.asyncTasks.Done()
+		return
+	}
+
 OUTER:
 	for {
 		atomic.AddUint64(&s.stats.TotPersistLoopBeg, 1)
@@ -69,7 +83,7 @@ OUTER:
 			lastMergedEpoch = ew.epoch
 		}
 		lastMergedEpoch, persistWatchers = s.pausePersisterForMergerCatchUp(lastPersistedEpoch,
-			lastMergedEpoch, persistWatchers)
+			lastMergedEpoch, persistWatchers, po)
 
 		var ourSnapshot *IndexSnapshot
 		var ourPersisted []chan error
@@ -180,14 +194,31 @@ func notifyMergeWatchers(lastPersistedEpoch uint64,
 }
 
 func (s *Scorch) pausePersisterForMergerCatchUp(lastPersistedEpoch uint64, lastMergedEpoch uint64,
-	persistWatchers []*epochWatcher) (uint64, []*epochWatcher) {
+	persistWatchers []*epochWatcher, po *persisterOptions) (uint64, []*epochWatcher) {
 
 	// first, let the watchers proceed if they lag behind
 	persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
 
+	// check the merger lag by counting the segment files on disk,
+	// On finding fewer files on disk, persister takes a short pause
+	// for sufficient in-memory segments to pile up for the next
+	// memory merge cum persist loop.
+	// On finding too many files on disk, persister pause until the merger
+	// catches up to reduce the segment file count under the threshold.
+	// But if there is a memory pressue, then skip this sleep maneuver.
+	numFilesOnDisk, _ := s.diskFileStats()
+	if numFilesOnDisk < uint64(po.PersisterNapUnderNumFiles) &&
+		po.PersisterNapTimeMSec > 0 && s.paused() == 0 {
+		select {
+		case <-s.closeCh:
+		case <-time.After(time.Millisecond * time.Duration(po.PersisterNapTimeMSec)):
+		}
+		return lastMergedEpoch, persistWatchers
+	}
+
 OUTER:
-	// check for slow merger and await until the merger catch up
-	for lastPersistedEpoch > lastMergedEpoch+epochDistance {
+	for numFilesOnDisk > uint64(po.PersisterNapUnderNumFiles) &&
+		lastMergedEpoch < lastPersistedEpoch {
 		atomic.AddUint64(&s.stats.TotPersisterSlowMergerPause, 1)
 
 		select {
@@ -202,18 +233,42 @@ OUTER:
 
 		// let the watchers proceed if they lag behind
 		persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
+
+		numFilesOnDisk, _ = s.diskFileStats()
 	}
 
 	return lastMergedEpoch, persistWatchers
 }
 
-func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
-	persisted, err := s.persistSnapshotMaybeMerge(snapshot)
-	if err != nil {
-		return err
+func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
+	po := persisterOptions{
+		PersisterNapTimeMSec:      DefaultPersisterNapTimeMSec,
+		PersisterNapUnderNumFiles: DefaultPersisterNapUnderNumFiles,
 	}
-	if persisted {
-		return nil
+	if v, ok := s.config["scorchPersisterOptions"]; ok {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return &po, err
+		}
+
+		err = json.Unmarshal(b, &po)
+		if err != nil {
+			return &po, err
+		}
+	}
+	return &po, nil
+}
+
+func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
+	// perform in-memory merging only when there is no memory pressure
+	if s.paused() == 0 {
+		persisted, err := s.persistSnapshotMaybeMerge(snapshot)
+		if err != nil {
+			return err
+		}
+		if persisted {
+			return nil
+		}
 	}
 
 	return s.persistSnapshotDirect(snapshot)

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -33,6 +33,11 @@ import (
 	"github.com/blevesearch/bleve/mapping"
 )
 
+func init() {
+	// override for tests
+	DefaultPersisterNapTimeMSec = 1
+}
+
 func DestroyTest() error {
 	return os.RemoveAll("/tmp/bleve-scorch-test")
 }

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -41,6 +41,12 @@ import (
 //     go test -v -run TestScorchVersusUpsideDownBolt ./test
 //     VERBOSE=1 FOCUS=Trista go test -v -run TestScorchVersusUpsideDownBolt ./test
 //
+
+func init() {
+	// override for tests
+	scorch.DefaultPersisterNapTimeMSec = 1
+}
+
 func TestScorchVersusUpsideDownBoltAll(t *testing.T) {
 	(&VersusTest{
 		t:                    t,


### PR DESCRIPTION
This change includes,

-persister nap to favour in-memory merging
-skip in-memory merging on memory pressure
-skip persister nap on memory pressure
-checks during persister-merger wait to guard against an already advanced merger

toy build passes the tests here: http://qa.sc.couchbase.com/job/test_suite_executor/85255/console
