### PR TITLE
optimize scorch via a regexp fork that exposes SyntaxRegexp()

### DIFF
--- a/search/query/regexp.go
+++ b/search/query/regexp.go
@@ -15,8 +15,9 @@
 package query
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/couchbase/go-regexp/regexp"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/mapping"

--- a/search/query/wildcard.go
+++ b/search/query/wildcard.go
@@ -15,8 +15,9 @@
 package query
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/couchbase/go-regexp/regexp"
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/mapping"


### PR DESCRIPTION
This optimization utilizes a fork of the golang regexp package, which
exposes the (previously private) parsed *syntax.Regexp instance,
allowing the scorch codepaths to avoid a second regexp parsing.

See also: https://issues.couchbase.com/browse/MB-30264