### PR TITLE
MB-30776: [Scorch] Merger's enumerator to not skip empty terms

### DIFF
--- a/index/scorch/segment/zap/enumerator.go
+++ b/index/scorch/segment/zap/enumerator.go
@@ -46,26 +46,27 @@ func newEnumerator(itrs []vellum.Iterator) (*enumerator, error) {
 	for i, itr := range rv.itrs {
 		rv.currKs[i], rv.currVs[i] = itr.Current()
 	}
-	rv.updateMatches()
-	if rv.lowK == nil {
+	rv.updateMatches(false)
+	if rv.lowK == nil && len(rv.lowIdxs) == 0 {
 		return rv, vellum.ErrIteratorDone
 	}
 	return rv, nil
 }
 
 // updateMatches maintains the low key matches based on the currKs
-func (m *enumerator) updateMatches() {
+func (m *enumerator) updateMatches(skipEmptyKey bool) {
 	m.lowK = nil
 	m.lowIdxs = m.lowIdxs[:0]
 	m.lowCurr = 0
 
 	for i, key := range m.currKs {
-		if key == nil {
+		if (key == nil && m.currVs[i] == 0) || // in case of empty iterator
+			(len(key) == 0 && skipEmptyKey) { // skip empty keys
 			continue
 		}
 
 		cmp := bytes.Compare(key, m.lowK)
-		if cmp < 0 || m.lowK == nil {
+		if cmp < 0 || len(m.lowIdxs) == 0 {
 			// reached a new low
 			m.lowK = key
 			m.lowIdxs = m.lowIdxs[:0]
@@ -102,9 +103,10 @@ func (m *enumerator) Next() error {
 			}
 			m.currKs[vi], m.currVs[vi] = m.itrs[vi].Current()
 		}
-		m.updateMatches()
+		// can skip any empty keys encountered at this point
+		m.updateMatches(true)
 	}
-	if m.lowK == nil {
+	if m.lowK == nil && len(m.lowIdxs) == 0 {
 		return vellum.ErrIteratorDone
 	}
 	return nil

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -243,10 +243,6 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 		}
 
 		finishTerm := func(term []byte) error {
-			if term == nil {
-				return nil
-			}
-
 			tfEncoder.Close()
 			locEncoder.Close()
 
@@ -283,17 +279,16 @@ func persistMergedRest(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 			if !bytes.Equal(prevTerm, term) {
 				// if the term changed, write out the info collected
 				// for the previous term
-				err2 := finishTerm(prevTerm)
-				if err2 != nil {
-					return nil, 0, err2
+				err = finishTerm(prevTerm)
+				if err != nil {
+					return nil, 0, err
 				}
 			}
 
-			var err2 error
-			postings, err2 = dicts[itrI].postingsListFromOffset(
+			postings, err = dicts[itrI].postingsListFromOffset(
 				postingsOffset, drops[itrI], postings)
-			if err2 != nil {
-				return nil, 0, err2
+			if err != nil {
+				return nil, 0, err
 			}
 
 			postItr = postings.iterator(true, true, true, postItr)


### PR DESCRIPTION
Fixes: #967