### PR TITLE
Use fmt.Sprintf to generate kv pairs in test

### DIFF
--- a/mapping/field.go
+++ b/mapping/field.go
@@ -78,6 +78,8 @@ func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
 	rv.DocValues = im.DocValuesDynamic
+	rv.IncludeTermVectors = false
+	rv.IncludeInAll = false
 	return rv
 }
 
@@ -97,6 +99,8 @@ func newNumericFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
 	rv.DocValues = im.DocValuesDynamic
+	rv.IncludeTermVectors = im.IncludeTermVectorsDynamic
+	rv.IncludeInAll = im.IncludeInAllDynamic
 	return rv
 }
 
@@ -116,6 +120,8 @@ func newDateTimeFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
 	rv.DocValues = im.DocValuesDynamic
+	rv.IncludeTermVectors = im.IncludeTermVectorsDynamic
+	rv.IncludeInAll = im.IncludeInAllDynamic
 	return rv
 }
 
@@ -135,6 +141,8 @@ func newBooleanFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
 	rv.DocValues = im.DocValuesDynamic
+	rv.IncludeTermVectors = im.IncludeTermVectorsDynamic
+	rv.IncludeInAll = im.IncludeInAllDynamic
 	return rv
 }
 

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -41,18 +41,20 @@ const defaultDateTimeParser = optional.Name
 // If no mapping was determined for that type,
 // a DefaultMapping will be used.
 type IndexMappingImpl struct {
-	TypeMapping           map[string]*DocumentMapping `json:"types,omitempty"`
-	DefaultMapping        *DocumentMapping            `json:"default_mapping"`
-	TypeField             string                      `json:"type_field"`
-	DefaultType           string                      `json:"default_type"`
-	DefaultAnalyzer       string                      `json:"default_analyzer"`
-	DefaultDateTimeParser string                      `json:"default_datetime_parser"`
-	DefaultField          string                      `json:"default_field"`
-	StoreDynamic          bool                        `json:"store_dynamic"`
-	IndexDynamic          bool                        `json:"index_dynamic"`
-	DocValuesDynamic      bool                        `json:"docvalues_dynamic,omitempty"`
-	CustomAnalysis        *customAnalysis             `json:"analysis,omitempty"`
-	cache                 *registry.Cache
+	TypeMapping               map[string]*DocumentMapping `json:"types,omitempty"`
+	DefaultMapping            *DocumentMapping            `json:"default_mapping"`
+	TypeField                 string                      `json:"type_field"`
+	DefaultType               string                      `json:"default_type"`
+	DefaultAnalyzer           string                      `json:"default_analyzer"`
+	DefaultDateTimeParser     string                      `json:"default_datetime_parser"`
+	DefaultField              string                      `json:"default_field"`
+	StoreDynamic              bool                        `json:"store_dynamic"`
+	IndexDynamic              bool                        `json:"index_dynamic"`
+	IncludeTermVectorsDynamic bool                        `json:"include_term_vectors_dynamic"`
+	IncludeInAllDynamic       bool                        `json:"include_in_all_dynamic"`
+	DocValuesDynamic          bool                        `json:"docvalues_dynamic,omitempty"`
+	CustomAnalysis            *customAnalysis             `json:"analysis,omitempty"`
+	cache                     *registry.Cache
 }
 
 // AddCustomCharFilter defines a custom char filter for use in this mapping


### PR DESCRIPTION
I'm in the middle of re-implementing the latest version of BadgerDB into Bleve and I came across an issue in the this specific test in which, by the time the batch is executed, the key/value buffers have already been garbage collected and therefore, is causing the test to fail.

The solution here is to make a new buffer with `make([]byte, 5)` on each for-loop, however, I figured it's cleaner to use `fmt.Sprintf` to convert a string into the corresponding byte array.