### PR TITLE
Dynamic document mapping should take precedence over index dynamic sp…

### DIFF
--- a/mapping/field.go
+++ b/mapping/field.go
@@ -76,7 +76,7 @@ func NewTextFieldMapping() *FieldMapping {
 func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewTextFieldMapping()
 	rv.Store = im.StoreDynamic
-	rv.Index = im.IndexDynamic
+	rv.Index = true
 	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
@@ -95,7 +95,7 @@ func NewNumericFieldMapping() *FieldMapping {
 func newNumericFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewNumericFieldMapping()
 	rv.Store = im.StoreDynamic
-	rv.Index = im.IndexDynamic
+	rv.Index = true
 	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
@@ -114,7 +114,7 @@ func NewDateTimeFieldMapping() *FieldMapping {
 func newDateTimeFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewDateTimeFieldMapping()
 	rv.Store = im.StoreDynamic
-	rv.Index = im.IndexDynamic
+	rv.Index = true
 	rv.DocValues = im.DocValuesDynamic
 	return rv
 }
@@ -133,7 +133,7 @@ func NewBooleanFieldMapping() *FieldMapping {
 func newBooleanFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewBooleanFieldMapping()
 	rv.Store = im.StoreDynamic
-	rv.Index = im.IndexDynamic
+	rv.Index = true
 	rv.DocValues = im.DocValuesDynamic
 	return rv
 }


### PR DESCRIPTION
…ecification

Explanation:
 - See discussion and issue here: https://groups.google.com/forum/#!topic/bleve/7z-Zod2ssyU
 - Currently, the check verifies that if ClosestDocumentMapping.Dynamic, then use stub for dynamic mapping field. However, we adhere to the index mappings dynamic specification. AFAIK, we should instead use the dynamic specification from the document mapping (which is always true in this case)