### PR TITLE
optimize scorch to only recycle current TermFieldReaders

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -472,6 +472,14 @@ func (i *IndexSnapshot) allocTermFieldReaderDicts(field string) (tfr *IndexSnaps
 }
 
 func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) {
+	i.parent.rootLock.RLock()
+	obsolete := i.parent.root != i
+	i.parent.rootLock.RUnlock()
+	if obsolete {
+		// if we're not the current root (mutations happened), don't bother recycling
+		return
+	}
+
 	i.m2.Lock()
 	if i.fieldTFRs == nil {
 		i.fieldTFRs = map[string][]*IndexSnapshotTermFieldReader{}


### PR DESCRIPTION
When scorch is finished using a TermFieldReader, if the indexSnapshot
that it belongs to is obsolete (not the current indexSnapshot), then
don't recycle the TermFieldReader so that GC can take care of it
sooner.

This can matter in a scenario of ongoing mutations (the current
indexSnapshot keeps on changing) when there are searches (like prefix
& wildcard/regexp) that might involve lots (hundreds or more) of terms
per search request, meaning lots of TermFieldReaders can be in play.

See also: https://issues.couchbase.com/browse/MB-29923