### PR TITLE
minor code cleanups

### DIFF
--- a/analysis/token/camelcase/parser.go
+++ b/analysis/token/camelcase/parser.go
@@ -46,11 +46,11 @@ type Parser struct {
 	index     int
 }
 
-func NewParser(len, position, index int) *Parser {
+func NewParser(length, position, index int) *Parser {
 	return &Parser{
-		bufferLen: len,
-		buffer:    make([]rune, 0, len),
-		tokens:    make([]*analysis.Token, 0, len),
+		bufferLen: length,
+		buffer:    make([]rune, 0, length),
+		tokens:    make([]*analysis.Token, 0, length),
 		position:  position,
 		index:     index,
 	}

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -517,6 +517,7 @@ func isMemorySegment(s *SegmentSnapshot) bool {
 	switch s.segment.(type) {
 	case *zap.SegmentBase:
 		return true
+	default:
+		return false
 	}
-	return false
 }

--- a/search/collector/heap.go
+++ b/search/collector/heap.go
@@ -25,9 +25,9 @@ type collectStoreHeap struct {
 	compare collectorCompare
 }
 
-func newStoreHeap(cap int, compare collectorCompare) *collectStoreHeap {
+func newStoreHeap(capacity int, compare collectorCompare) *collectStoreHeap {
 	rv := &collectStoreHeap{
-		heap:    make(search.DocumentMatchCollection, 0, cap),
+		heap:    make(search.DocumentMatchCollection, 0, capacity),
 		compare: compare,
 	}
 	heap.Init(rv)

--- a/search/collector/list.go
+++ b/search/collector/list.go
@@ -25,7 +25,7 @@ type collectStoreList struct {
 	compare collectorCompare
 }
 
-func newStoreList(cap int, compare collectorCompare) *collectStoreList {
+func newStoreList(capacity int, compare collectorCompare) *collectStoreList {
 	rv := &collectStoreList{
 		results: list.New(),
 		compare: compare,
@@ -34,8 +34,7 @@ func newStoreList(cap int, compare collectorCompare) *collectStoreList {
 	return rv
 }
 
-func (c *collectStoreList) AddNotExceedingSize(doc *search.DocumentMatch,
-	size int) *search.DocumentMatch {
+func (c *collectStoreList) AddNotExceedingSize(doc *search.DocumentMatch, size int) *search.DocumentMatch {
 	c.add(doc)
 	if c.len() > size {
 		return c.removeLast()

--- a/search/collector/slice.go
+++ b/search/collector/slice.go
@@ -21,9 +21,9 @@ type collectStoreSlice struct {
 	compare collectorCompare
 }
 
-func newStoreSlice(cap int, compare collectorCompare) *collectStoreSlice {
+func newStoreSlice(capacity int, compare collectorCompare) *collectStoreSlice {
 	rv := &collectStoreSlice{
-		slice:   make(search.DocumentMatchCollection, 0, cap),
+		slice:   make(search.DocumentMatchCollection, 0, capacity),
 		compare: compare,
 	}
 	return rv

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -296,32 +296,28 @@ func expandQuery(m mapping.IndexMapping, query Query) (Query, error) {
 	}
 
 	expand = func(query Query) (Query, error) {
-		switch query.(type) {
+		switch q := query.(type) {
 		case *QueryStringQuery:
-			q := query.(*QueryStringQuery)
 			parsed, err := parseQuerySyntax(q.Query)
 			if err != nil {
 				return nil, fmt.Errorf("could not parse '%s': %s", q.Query, err)
 			}
 			return expand(parsed)
 		case *ConjunctionQuery:
-			q := *query.(*ConjunctionQuery)
 			children, err := expandSlice(q.Conjuncts)
 			if err != nil {
 				return nil, err
 			}
 			q.Conjuncts = children
-			return &q, nil
+			return q, nil
 		case *DisjunctionQuery:
-			q := *query.(*DisjunctionQuery)
 			children, err := expandSlice(q.Disjuncts)
 			if err != nil {
 				return nil, err
 			}
 			q.Disjuncts = children
-			return &q, nil
+			return q, nil
 		case *BooleanQuery:
-			q := *query.(*BooleanQuery)
 			var err error
 			q.Must, err = expand(q.Must)
 			if err != nil {
@@ -335,7 +331,7 @@ func expandQuery(m mapping.IndexMapping, query Query) (Query, error) {
 			if err != nil {
 				return nil, err
 			}
-			return &q, nil
+			return q, nil
 		default:
 			return query, nil
 		}


### PR DESCRIPTION
Small cleanups found by [go-critic](https://github.com/go-critic/go-critic)
Rules: `builtinShadow`, `typeSwitchVar`, `singleCaseSwitch`.

go-critic log:
```
check-package: github.com/blevesearch/bleve/index/scorch/introducer.go:517:2: singleCaseSwitch: should rewrite switch statement to if statement

check-package: github.com/blevesearch/bleve/search/collector/heap.go:28:19: builtinShadow: shadowing of predeclared identifier: cap
check-package: github.com/blevesearch/bleve/search/collector/list.go:28:19: builtinShadow: shadowing of predeclared identifier: cap
check-package: github.com/blevesearch/bleve/search/collector/slice.go:24:20: builtinShadow: shadowing of predeclared identifier: cap
check-package: github.com/blevesearch/bleve/analysis/token/camelcase/parser.go:49:16: builtinShadow: shadowing of predeclared identifier: len

check-package: github.com/blevesearch/bleve/search/query/query.go:299:3: typeSwitchVar: case 0 can benefit from type switch with assignment
check-package: github.com/blevesearch/bleve/search/query/query.go:299:3: typeSwitchVar: case 1 can benefit from type switch with assignment
check-package: github.com/blevesearch/bleve/search/query/query.go:299:3: typeSwitchVar: case 2 can benefit from type switch with assignment
check-package: github.com/blevesearch/bleve/search/query/query.go:299:3: typeSwitchVar: case 3 can benefit from type switch with assignment
```