### PR TITLE
minor code cleanups

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -217,14 +217,14 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 			if len(roster) > 0 {
 				rosterScore := scoreSegments(roster, o)
 
-				if len(bestRoster) <= 0 || rosterScore < bestRosterScore {
+				if len(bestRoster) == 0 || rosterScore < bestRosterScore {
 					bestRoster = roster
 					bestRosterScore = rosterScore
 				}
 			}
 		}
 
-		if len(bestRoster) <= 0 {
+		if len(bestRoster) == 0 {
 			return rv, nil
 		}
 

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -757,7 +757,7 @@ func (s *Scorch) removeOldBoltSnapshots() (numRemoved int, err error) {
 	s.eligibleForRemoval = newEligible
 	s.rootLock.Unlock()
 
-	if len(epochsToRemove) <= 0 {
+	if len(epochsToRemove) == 0 {
 		return 0, nil
 	}
 

--- a/index/scorch/segment/zap/docvalues.go
+++ b/index/scorch/segment/zap/docvalues.go
@@ -176,7 +176,7 @@ func (di *docValueReader) iterateAllDocValues(s *SegmentBase, visitor docNumTerm
 		if err != nil {
 			return err
 		}
-		if di.curChunkData == nil || len(di.curChunkHeader) <= 0 {
+		if di.curChunkData == nil || len(di.curChunkHeader) == 0 {
 			continue
 		}
 

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -654,7 +654,7 @@ func (i *IndexSnapshot) DumpFields() chan interface{} {
 
 // subtractStrings returns set a minus elements of set b.
 func subtractStrings(a, b []string) []string {
-	if len(b) <= 0 {
+	if len(b) == 0 {
 		return a
 	}
 

--- a/index/scorch/snapshot_index_dict.go
+++ b/index/scorch/snapshot_index_dict.go
@@ -52,7 +52,7 @@ func (i *IndexSnapshotFieldDict) Pop() interface{} {
 }
 
 func (i *IndexSnapshotFieldDict) Next() (*index.DictEntry, error) {
-	if len(i.cursors) <= 0 {
+	if len(i.cursors) == 0 {
 		return nil, nil
 	}
 	i.entry = i.cursors[0].curr

--- a/index/store/metrics/metrics_test.go
+++ b/index/store/metrics/metrics_test.go
@@ -57,7 +57,7 @@ func TestMetricsStore(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected WriteJSON to be unmarshallable")
 	}
-	if len(m) <= 0 {
+	if len(m) == 0 {
 		t.Errorf("expected some entries")
 	}
 

--- a/index/upsidedown/row.go
+++ b/index/upsidedown/row.go
@@ -584,7 +584,7 @@ func (tfr *TermFrequencyRow) parseK(key []byte) error {
 
 func (tfr *TermFrequencyRow) parseKDoc(key []byte, term []byte) error {
 	tfr.doc = key[3+len(term)+1:]
-	if len(tfr.doc) <= 0 {
+	if len(tfr.doc) == 0 {
 		return fmt.Errorf("invalid term frequency key, empty docid")
 	}
 

--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -775,7 +775,7 @@ func (udc *UpsideDownCouch) termVectorsFromTokenFreq(field uint16, tf *analysis.
 }
 
 func (udc *UpsideDownCouch) termFieldVectorsFromTermVectors(in []*TermVector) []*index.TermFieldVector {
-	if len(in) <= 0 {
+	if len(in) == 0 {
 		return nil
 	}
 

--- a/search/scorer/scorer_term_test.go
+++ b/search/scorer/scorer_term_test.go
@@ -157,7 +157,7 @@ func TestTermScorer(t *testing.T) {
 		}
 		actual := scorer.Score(ctx, test.termMatch)
 		actual.Complete(nil)
-		if len(actual.FieldTermLocations) <= 0 {
+		if len(actual.FieldTermLocations) == 0 {
 			actual.FieldTermLocations = nil
 		}
 

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -253,7 +253,7 @@ func testVersusSearches(vt *VersusTest, searchTemplates []string, idxA, idxB ble
 		// definitely find at least one document.
 		"bodyWord": func(i int) string {
 			body := vt.Bodies[vt.CurAttempt%len(vt.Bodies)]
-			if len(body) <= 0 {
+			if len(body) == 0 {
 				return ""
 			}
 			return body[i%len(body)]
@@ -324,10 +324,10 @@ func testVersusSearches(vt *VersusTest, searchTemplates []string, idxA, idxB ble
 			hitsB := hitsById(resB)
 			for id, hitA := range hitsA {
 				hitB := hitsB[id]
-				if len(hitA.FieldTermLocations) <= 0 {
+				if len(hitA.FieldTermLocations) == 0 {
 					hitA.FieldTermLocations = nil
 				}
-				if len(hitB.FieldTermLocations) <= 0 {
+				if len(hitB.FieldTermLocations) == 0 {
 					hitB.FieldTermLocations = nil
 				}
 				if !reflect.DeepEqual(hitA, hitB) {
@@ -338,10 +338,10 @@ func testVersusSearches(vt *VersusTest, searchTemplates []string, idxA, idxB ble
 			}
 			for id, hitB := range hitsB {
 				hitA := hitsA[id]
-				if len(hitA.FieldTermLocations) <= 0 {
+				if len(hitA.FieldTermLocations) == 0 {
 					hitA.FieldTermLocations = nil
 				}
-				if len(hitB.FieldTermLocations) <= 0 {
+				if len(hitB.FieldTermLocations) == 0 {
 					hitB.FieldTermLocations = nil
 				}
 				if !reflect.DeepEqual(hitA, hitB) {


### PR DESCRIPTION
Simplify len check(it cannot be less than zero 😉 )
Follow up of https://github.com/blevesearch/bleve/pull/995

gocritic log:
```
check-package: github.com/blevesearch/bleve/search/scorer/scorer_term_test.go:160:6: sloppyLen: len(actual.FieldTermLocations) <= 0 can be len(actual.FieldTermLocations) == 0
check-package: github.com/blevesearch/bleve/index/upsidedown/row.go:587:5: sloppyLen: len(tfr.doc) <= 0 can be len(tfr.doc) == 0
check-package: github.com/blevesearch/bleve/index/upsidedown/upsidedown.go:778:5: sloppyLen: len(in) <= 0 can be len(in) == 0
check-package: github.com/blevesearch/bleve/index/store/metrics/metrics_test.go:60:5: sloppyLen: len(m) <= 0 can be len(m) == 0
check-package: github.com/blevesearch/bleve/index/scorch/mergeplan/merge_plan.go:220:8: sloppyLen: len(bestRoster) <= 0 can be len(bestRoster) == 0
check-package: github.com/blevesearch/bleve/index/scorch/mergeplan/merge_plan.go:227:6: sloppyLen: len(bestRoster) <= 0 can be len(bestRoster) == 0
check-package: github.com/blevesearch/bleve/index/scorch/segment/zap/docvalues.go:179:32: sloppyLen: len(di.curChunkHeader) <= 0 can be len(di.curChunkHeader) == 0
check-package: github.com/blevesearch/bleve/index/scorch/persister.go:760:5: sloppyLen: len(epochsToRemove) <= 0 can be len(epochsToRemove) == 0
check-package: github.com/blevesearch/bleve/index/scorch/snapshot_index.go:657:5: sloppyLen: len(b) <= 0 can be len(b) == 0
check-package: github.com/blevesearch/bleve/index/scorch/snapshot_index_dict.go:55:5: sloppyLen: len(i.cursors) <= 0 can be len(i.cursors) == 0
check-package: github.com/blevesearch/bleve/test/versus_test.go:256:7: sloppyLen: len(body) <= 0 can be len(body) == 0
check-package: github.com/blevesearch/bleve/test/versus_test.go:327:8: sloppyLen: len(hitA.FieldTermLocations) <= 0 can be len(hitA.FieldTermLocations) == 0
check-package: github.com/blevesearch/bleve/test/versus_test.go:330:8: sloppyLen: len(hitB.FieldTermLocations) <= 0 can be len(hitB.FieldTermLocations) == 0
check-package: github.com/blevesearch/bleve/test/versus_test.go:341:8: sloppyLen: len(hitA.FieldTermLocations) <= 0 can be len(hitA.FieldTermLocations) == 0
check-package: github.com/blevesearch/bleve/test/versus_test.go:344:8: sloppyLen: len(hitB.FieldTermLocations) <= 0 can be len(hitB.FieldTermLocations) == 0
```