### PR TITLE
optimize scorch with sync.Pool of zap Dict/PostingsList/Iterator

### DIFF
--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -91,6 +91,8 @@ func (e *EmptyDictionary) OnlyIterator(onlyTerms [][]byte,
 	return &EmptyDictionaryIterator{}
 }
 
+func (e *EmptyDictionary) Recycle() {}
+
 type EmptyDictionaryIterator struct{}
 
 func (e *EmptyDictionaryIterator) Next() (*index.DictEntry, error) {
@@ -116,6 +118,8 @@ func (e *EmptyPostingsList) Count() uint64 {
 	return 0
 }
 
+func (e *EmptyPostingsList) Recycle() {}
+
 type EmptyPostingsIterator struct{}
 
 func (e *EmptyPostingsIterator) Next() (Posting, error) {
@@ -125,3 +129,5 @@ func (e *EmptyPostingsIterator) Next() (Posting, error) {
 func (e *EmptyPostingsIterator) Size() int {
 	return 0
 }
+
+func (e *EmptyPostingsIterator) Recycle() {}

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"sync"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index/scorch/segment"
@@ -112,6 +113,8 @@ type PostingsList struct {
 // represents an immutable, empty postings list
 var emptyPostingsList = &PostingsList{}
 
+var postingsListPool = sync.Pool{New: func() interface{} { return &PostingsList{} }}
+
 func (p *PostingsList) Size() int {
 	sizeInBytes := reflectStaticSizePostingsList + size.SizeOfPtr
 
@@ -155,38 +158,9 @@ func (p *PostingsList) Iterator(includeFreq, includeNorm, includeLocs bool,
 func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 	rv *PostingsIterator) *PostingsIterator {
 	if rv == nil {
-		rv = &PostingsIterator{}
+		rv = postingsIteratorPool.Get().(*PostingsIterator)
 	} else {
-		freqNormReader := rv.freqNormReader
-		if freqNormReader != nil {
-			freqNormReader.Reset([]byte(nil))
-		}
-
-		locReader := rv.locReader
-		if locReader != nil {
-			locReader.Reset([]byte(nil))
-		}
-
-		freqChunkOffsets := rv.freqChunkOffsets[:0]
-		locChunkOffsets := rv.locChunkOffsets[:0]
-
-		nextLocs := rv.nextLocs[:0]
-		nextSegmentLocs := rv.nextSegmentLocs[:0]
-
-		buf := rv.buf
-
-		*rv = PostingsIterator{} // clear the struct
-
-		rv.freqNormReader = freqNormReader
-		rv.locReader = locReader
-
-		rv.freqChunkOffsets = freqChunkOffsets
-		rv.locChunkOffsets = locChunkOffsets
-
-		rv.nextLocs = nextLocs
-		rv.nextSegmentLocs = nextSegmentLocs
-
-		rv.buf = buf
+		rv.Clear()
 	}
 
 	rv.postings = p
@@ -322,6 +296,14 @@ func (rv *PostingsList) init1Hit(fstVal uint64) error {
 	return nil
 }
 
+func (rv *PostingsList) Recycle() {
+	if rv != emptyPostingsList {
+		*rv = PostingsList{}
+		// TODO: can we also recycle the roaring bitmaps?
+		postingsListPool.Put(rv)
+	}
+}
+
 // PostingsIterator provides a way to iterate through the postings list
 type PostingsIterator struct {
 	postings *PostingsList
@@ -356,6 +338,8 @@ type PostingsIterator struct {
 }
 
 var emptyPostingsIterator = &PostingsIterator{}
+
+var postingsIteratorPool = sync.Pool{New: func() interface{} { return &PostingsIterator{} }}
 
 func (i *PostingsIterator) Size() int {
 	sizeInBytes := reflectStaticSizePostingsIterator + size.SizeOfPtr +
@@ -709,6 +693,47 @@ func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, 
 	}
 
 	return uint64(n), true, nil
+}
+
+func (rv *PostingsIterator) Clear() {
+	freqNormReader := rv.freqNormReader
+	if freqNormReader != nil {
+		freqNormReader.Reset([]byte(nil))
+	}
+
+	locReader := rv.locReader
+	if locReader != nil {
+		locReader.Reset([]byte(nil))
+	}
+
+	freqChunkOffsets := rv.freqChunkOffsets[:0]
+	locChunkOffsets := rv.locChunkOffsets[:0]
+
+	nextLocs := rv.nextLocs[:0]
+	nextSegmentLocs := rv.nextSegmentLocs[:0]
+
+	buf := rv.buf
+
+	*rv = PostingsIterator{} // clear the struct
+
+	rv.freqNormReader = freqNormReader
+	rv.locReader = locReader
+
+	rv.freqChunkOffsets = freqChunkOffsets
+	rv.locChunkOffsets = locChunkOffsets
+
+	rv.nextLocs = nextLocs
+	rv.nextSegmentLocs = nextSegmentLocs
+
+	rv.buf = buf
+}
+
+func (i *PostingsIterator) Recycle() {
+	if i != emptyPostingsIterator {
+		i.Clear()
+
+		postingsIteratorPool.Put(i)
+	}
 }
 
 // Posting is a single entry in a postings list

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -250,11 +250,10 @@ func (s *SegmentBase) Dictionary(field string) (segment.TermDictionary, error) {
 func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 	fieldIDPlus1 := sb.fieldsMap[field]
 	if fieldIDPlus1 > 0 {
-		rv = &Dictionary{
-			sb:      sb,
-			field:   field,
-			fieldID: fieldIDPlus1 - 1,
-		}
+		rv = dictionaryPool.Get().(*Dictionary)
+		rv.sb = sb
+		rv.field = field
+		rv.fieldID = fieldIDPlus1 - 1
 
 		dictStart := sb.dictLocs[rv.fieldID]
 		if dictStart > 0 {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -471,13 +471,13 @@ func (i *IndexSnapshot) allocTermFieldReaderDicts(field string) (tfr *IndexSnaps
 	return &IndexSnapshotTermFieldReader{}
 }
 
-func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) {
+func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) bool {
 	i.parent.rootLock.RLock()
 	obsolete := i.parent.root != i
 	i.parent.rootLock.RUnlock()
 	if obsolete {
 		// if we're not the current root (mutations happened), don't bother recycling
-		return
+		return false
 	}
 
 	i.m2.Lock()
@@ -486,6 +486,8 @@ func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader
 	}
 	i.fieldTFRs[tfr.field] = append(i.fieldTFRs[tfr.field], tfr)
 	i.m2.Unlock()
+
+	return true
 }
 
 func docNumberToBytes(buf []byte, in uint64) []byte {

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -115,6 +115,13 @@ type Stats struct {
 	MaxMemMergeZapTime      uint64
 	TotMemMergeSegments     uint64
 	TotMemorySegmentsAtRoot uint64
+
+	TotTermFieldReadersGarbaged uint64
+	TotTermFieldReadersRecycled uint64
+
+	TotTermDictionariesRecycled  uint64
+	TotPostingsListsRecycled     uint64
+	TotPostingsIteratorsRecycled uint64
 }
 
 // atomically populates the returned map


### PR DESCRIPTION
Some searches like prefix searches can generate many term field
readers per search request, and in the face of ongoing mutations,
scorch will not recycle those term field readers.

This change adds sync pooling or recycling of the constituent parts of
a scorch TermFieldReader, which hopefully reduces some garbage and
takes some pressure off the memory allocator.