### PR TITLE
Overall performance regression in throughput/latency observed with recent sync pool optimizations 

### DIFF
--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -91,8 +91,6 @@ func (e *EmptyDictionary) OnlyIterator(onlyTerms [][]byte,
 	return &EmptyDictionaryIterator{}
 }
 
-func (e *EmptyDictionary) Recycle() {}
-
 type EmptyDictionaryIterator struct{}
 
 func (e *EmptyDictionaryIterator) Next() (*index.DictEntry, error) {
@@ -118,8 +116,6 @@ func (e *EmptyPostingsList) Count() uint64 {
 	return 0
 }
 
-func (e *EmptyPostingsList) Recycle() {}
-
 type EmptyPostingsIterator struct{}
 
 func (e *EmptyPostingsIterator) Next() (Posting, error) {
@@ -129,5 +125,3 @@ func (e *EmptyPostingsIterator) Next() (Posting, error) {
 func (e *EmptyPostingsIterator) Size() int {
 	return 0
 }
-
-func (e *EmptyPostingsIterator) Recycle() {}

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -229,14 +229,10 @@ func (d *Dictionary) OnlyIterator(onlyTerms [][]byte,
 }
 
 func (d *Dictionary) Recycle() {
-	if d.fst != nil {
-		_ = d.fst.Close()
-	}
-	if d.fstReader != nil {
-		d.fstReader.Close()
-	}
-
 	*d = Dictionary{} // clear fields
+
+	// TODO: need vellum API's to allow for recycled or prealloc'ed FST's
+
 	dictionaryPool.Put(d)
 }
 

--- a/index/scorch/segment/zap/dict.go
+++ b/index/scorch/segment/zap/dict.go
@@ -17,7 +17,6 @@ package zap
 import (
 	"bytes"
 	"fmt"
-	"sync"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/index"
@@ -33,8 +32,6 @@ type Dictionary struct {
 	fst       *vellum.FST
 	fstReader *vellum.Reader
 }
-
-var dictionaryPool = sync.Pool{New: func() interface{} { return &Dictionary{} }}
 
 // PostingsList returns the postings list for the specified term
 func (d *Dictionary) PostingsList(term []byte, except *roaring.Bitmap,
@@ -82,7 +79,7 @@ func (d *Dictionary) postingsListFromOffset(postingsOffset uint64, except *roari
 
 func (d *Dictionary) postingsListInit(rv *PostingsList, except *roaring.Bitmap) *PostingsList {
 	if rv == nil || rv == emptyPostingsList {
-		rv = postingsListPool.Get().(*PostingsList)
+		rv = &PostingsList{}
 	} else {
 		postings := rv.postings
 		if postings != nil {
@@ -226,14 +223,6 @@ func (d *Dictionary) OnlyIterator(onlyTerms [][]byte,
 	}
 
 	return rv
-}
-
-func (d *Dictionary) Recycle() {
-	*d = Dictionary{} // clear fields
-
-	// TODO: need vellum API's to allow for recycled or prealloc'ed FST's
-
-	dictionaryPool.Put(d)
 }
 
 // DictionaryIterator is an iterator for term dictionary

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -250,10 +250,11 @@ func (s *SegmentBase) Dictionary(field string) (segment.TermDictionary, error) {
 func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 	fieldIDPlus1 := sb.fieldsMap[field]
 	if fieldIDPlus1 > 0 {
-		rv = dictionaryPool.Get().(*Dictionary)
-		rv.sb = sb
-		rv.field = field
-		rv.fieldID = fieldIDPlus1 - 1
+		rv = &Dictionary{
+			sb:      sb,
+			field:   field,
+			fieldID: fieldIDPlus1 - 1,
+		}
 
 		dictStart := sb.dictLocs[rv.fieldID]
 		if dictStart > 0 {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -471,13 +471,13 @@ func (i *IndexSnapshot) allocTermFieldReaderDicts(field string) (tfr *IndexSnaps
 	return &IndexSnapshotTermFieldReader{}
 }
 
-func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) bool {
+func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) {
 	i.parent.rootLock.RLock()
 	obsolete := i.parent.root != i
 	i.parent.rootLock.RUnlock()
 	if obsolete {
 		// if we're not the current root (mutations happened), don't bother recycling
-		return false
+		return
 	}
 
 	i.m2.Lock()
@@ -486,8 +486,6 @@ func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader
 	}
 	i.fieldTFRs[tfr.field] = append(i.fieldTFRs[tfr.field], tfr)
 	i.m2.Unlock()
-
-	return true
 }
 
 func docNumberToBytes(buf []byte, in uint64) []byte {

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -178,43 +178,8 @@ func (i *IndexSnapshotTermFieldReader) Count() uint64 {
 
 func (i *IndexSnapshotTermFieldReader) Close() error {
 	if i.snapshot != nil {
-		stats := &i.snapshot.parent.stats
-
-		atomic.AddUint64(&stats.TotTermSearchersFinished, uint64(1))
-
-		if i.snapshot.recycleTermFieldReader(i) {
-			atomic.AddUint64(&stats.TotTermFieldReadersRecycled, uint64(1))
-		} else {
-			atomic.AddUint64(&stats.TotTermFieldReadersGarbaged, uint64(1))
-
-			// the snapshot couldn't recycle the TFR (it was too
-			// obsolete), so recycle its constituent parts
-
-			for _, x := range i.iterators {
-				recycle(x)
-			}
-			atomic.AddUint64(&stats.TotPostingsIteratorsRecycled, uint64(len(i.iterators)))
-
-			for _, x := range i.postings {
-				recycle(x)
-			}
-			atomic.AddUint64(&stats.TotPostingsListsRecycled, uint64(len(i.postings)))
-
-			for _, x := range i.dicts {
-				recycle(x)
-			}
-			atomic.AddUint64(&stats.TotTermDictionariesRecycled, uint64(len(i.dicts)))
-		}
+		atomic.AddUint64(&i.snapshot.parent.stats.TotTermSearchersFinished, uint64(1))
+		i.snapshot.recycleTermFieldReader(i)
 	}
 	return nil
-}
-
-type Recycler interface {
-	Recycle()
-}
-
-func recycle(x interface{}) {
-	if r, ok := x.(Recycler); ok {
-		r.Recycle()
-	}
 }

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -115,13 +115,6 @@ type Stats struct {
 	MaxMemMergeZapTime      uint64
 	TotMemMergeSegments     uint64
 	TotMemorySegmentsAtRoot uint64
-
-	TotTermFieldReadersGarbaged uint64
-	TotTermFieldReadersRecycled uint64
-
-	TotTermDictionariesRecycled  uint64
-	TotPostingsListsRecycled     uint64
-	TotPostingsIteratorsRecycled uint64
 }
 
 // atomically populates the returned map


### PR DESCRIPTION
Reverting:
- commit 15e5f6d3059089149b59cd47c5a5b069d3e21d59
  Author: abhinavdangeti <abhinav@couchbase.com>
  Date:   Thu Sep 6 11:28:37 2018 -0700

    Invvoke fst/reader's Close() to reuse via sync pool on recycle

- commit 38f239cf70326c6983e7e09a22a4a3769969f6a6
Author: Steve Yen <steve.yen@gmail.com>
Date:   Thu Aug 23 08:59:55 2018 -0700

    optimize scorch with sync.Pool of zap Dict/PostingsList/Iterator

    Some searches like prefix searches can generate many term field
    readers per search request, and in the face of ongoing mutations,
    scorch will not recycle those term field readers.

    This change adds sync pooling or recycling of the constituent parts of
    a scorch TermFieldReader, which hopefully reduces some garbage and
    takes some pressure off the memory allocator.