### PR TITLE
add IndexAdvanced to the index interface

### DIFF
--- a/index.go
+++ b/index.go
@@ -199,6 +199,10 @@ type Index interface {
 	// requests. See Index interface documentation for details about mapping
 	// rules.
 	Index(id string, data interface{}) error
+	// IndexAdvanced takes a document.Document object skips the mapping and
+	// indexes it without further analysis.
+	IndexAdvanced(doc *document.Document) error
+
 	Delete(id string) error
 
 	NewBatch() *Batch

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -69,6 +69,22 @@ func (i *indexAliasImpl) Index(id string, data interface{}) error {
 	return i.indexes[0].Index(id, data)
 }
 
+func (i *indexAliasImpl) IndexAdvanced(doc *document.Document) error {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+
+	if !i.open {
+		return ErrorIndexClosed
+	}
+
+	err := i.isAliasToSingleIndex()
+	if err != nil {
+		return err
+	}
+
+	return i.indexes[0].IndexAdvanced(doc)
+}
+
 func (i *indexAliasImpl) Delete(id string) error {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -1253,6 +1253,10 @@ func (i *stubIndex) Index(id string, data interface{}) error {
 	return i.err
 }
 
+func (i *stubIndex) IndexAdvanced(doc *document.Document) error {
+	return i.err
+}
+
 func (i *stubIndex) Delete(id string) error {
 	return i.err
 }


### PR DESCRIPTION
It seemed odd that this was on the Batch and the indexImpl, but not part of the Index interface itself.