### PR TITLE
higher disk usage in DGM 

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -270,15 +270,15 @@ func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
 
 func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 	// perform in-memory merging only when there is no memory pressure
-	if s.paused() == 0 {
-		persisted, err := s.persistSnapshotMaybeMerge(snapshot)
-		if err != nil {
-			return err
-		}
-		if persisted {
-			return nil
-		}
+	//if s.paused() == 0 {
+	persisted, err := s.persistSnapshotMaybeMerge(snapshot)
+	if err != nil {
+		return err
 	}
+	if persisted {
+		return nil
+	}
+	//}
 
 	return s.persistSnapshotDirect(snapshot)
 }

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -269,8 +269,6 @@ func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
 }
 
 func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
-	// perform in-memory merging only when there is no memory pressure
-	//if s.paused() == 0 {
 	persisted, err := s.persistSnapshotMaybeMerge(snapshot)
 	if err != nil {
 		return err
@@ -278,7 +276,6 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 	if persisted {
 		return nil
 	}
-	//}
 
 	return s.persistSnapshotDirect(snapshot)
 }


### PR DESCRIPTION
MB-31405 - higher disk usage in DGM
Always perform in-memory segment merging before
persisting segments, esp even when the memory pressure
is applied.