### PR TITLE
Update golang version used for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ go:
  - 1.7.x
  - 1.8.x
  - 1.9.x
- - "1.10"
+ - 1.10.x
+ - 1.11.x
+ - tap
 
 script:
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Added go 1.11 and head as version that we use on test phase