### PR TITLE
Return FieldArrayPositions along with Fields in DocumentMatch

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -578,7 +578,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 									}
 								}
 								if value != nil {
-									hit.AddFieldValue(docF.Name(), value)
+									hit.AddFieldValue(docF.Name(), value, docF.ArrayPositions())
 								}
 							}
 						}

--- a/search/search.go
+++ b/search/search.go
@@ -97,7 +97,7 @@ type DocumentMatch struct {
 
 	// Fields contains the values for document fields listed in
 	// SearchRequest.Fields. Text fields are returned as strings, numeric
-	// fields as float64s, boolean fiels as bools, and date fields as
+	// fields as float64s, boolean fields as bools, and date fields as
 	// time.RFC3339 formatted strings.
 	// If there is more than one value for a field,
 	// Fields will return a []interface{}, and the client will have to cast each
@@ -106,7 +106,7 @@ type DocumentMatch struct {
 
 	// FieldArrayPositions is a companion map to Fields which returns the array positions
 	// corresponding to each element in Fields.
-	FieldArrayPositions map[string][]ArrayPositions
+	FieldArrayPositions map[string][]ArrayPositions `json:"field_array_positions,omitempty"`
 
 	// if we load the document for this hit, remember it so we dont load again
 	Document *document.Document `json:"-"`


### PR DESCRIPTION
We use Bleve internally. For our use case, when we received fields from a search result, we also needed to know exactly which element had which field value (for documents with nested arrays in them). 

This patch returns `FieldArrayPositions` in the DocumentMatch, which basically is a companion array to `Fields` which returns the array positions of the corresponding element. We did it this way so that we didn't break any clients of the existing struct. We've been using this patch internally for a while now, and it's worked for us, so we're sending this PR out in case you folks upstream think it would be useful. 