### PR TITLE
Scorch test refactoring

### DIFF
--- a/index/scorch/event_test.go
+++ b/index/scorch/event_test.go
@@ -22,12 +22,18 @@ import (
 )
 
 func TestEventBatchIntroductionStart(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}()
+
+	testConfig := CreateConfig(t)
 
 	var count int
 	RegistryEventCallbacks["test"] = func(e Event) {

--- a/index/scorch/event_test.go
+++ b/index/scorch/event_test.go
@@ -22,18 +22,17 @@ import (
 )
 
 func TestEventBatchIntroductionStart(t *testing.T) {
-	err := InitTest(t)
+	testConfig := CreateConfig("TestEventBatchIntroductionStart")
+	err := InitTest(testConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(testConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}()
-
-	testConfig := CreateConfig(t)
 
 	var count int
 	RegistryEventCallbacks["test"] = func(e Event) {

--- a/index/scorch/field_dict_test.go
+++ b/index/scorch/field_dict_test.go
@@ -23,12 +23,13 @@ import (
 )
 
 func TestIndexFieldDict(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexFieldDict")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
@@ -36,7 +37,7 @@ func TestIndexFieldDict(t *testing.T) {
 
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/field_dict_test.go
+++ b/index/scorch/field_dict_test.go
@@ -23,15 +23,20 @@ import (
 )
 
 func TestIndexFieldDict(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
+
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/reader_test.go
+++ b/index/scorch/reader_test.go
@@ -24,15 +24,20 @@ import (
 )
 
 func TestIndexReader(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
+
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,15 +219,19 @@ func TestIndexReader(t *testing.T) {
 }
 
 func TestIndexDocIdReader(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,15 +334,19 @@ func TestIndexDocIdReader(t *testing.T) {
 }
 
 func TestIndexDocIdOnlyReader(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/reader_test.go
+++ b/index/scorch/reader_test.go
@@ -24,12 +24,13 @@ import (
 )
 
 func TestIndexReader(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexReader")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
@@ -37,7 +38,7 @@ func TestIndexReader(t *testing.T) {
 
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,19 +220,20 @@ func TestIndexReader(t *testing.T) {
 }
 
 func TestIndexDocIdReader(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexDocIdReader")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,19 +336,20 @@ func TestIndexDocIdReader(t *testing.T) {
 }
 
 func TestIndexDocIdOnlyReader(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexDocIdOnlyReader")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -39,36 +38,18 @@ func init() {
 	DefaultPersisterNapTimeMSec = 1
 }
 
-var testNameRegexp = regexp.MustCompile(`\.(Test[\p{L}_\p{N}]*)`)
-
-func GetTestName() string {
-	pc := make([]uintptr, 32)
-	n := runtime.Callers(0, pc)
-	for i := 0; i < n; i++ {
-		name := runtime.FuncForPC(pc[i]).Name()
-		ms := testNameRegexp.FindStringSubmatch(name)
-		if ms == nil {
-			continue
-		}
-		return ms[1]
-	}
-	panic("test name could not be recovered")
+func InitTest(cfg map[string]interface{}) error {
+	return os.RemoveAll(cfg["path"].(string))
 }
 
-func InitTest(t *testing.T) error {
-	// TODO: Use t.Name() when Go 1.7 support terminates.
-	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + GetTestName())
+func DestroyTest(cfg map[string]interface{}) error {
+	return os.RemoveAll(cfg["path"].(string))
 }
 
-func DestroyTest(t *testing.T) error {
-	// TODO: Use t.Name() when Go 1.7 support terminates.
-	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + GetTestName())
-}
-
-func CreateConfig(t *testing.T) map[string]interface{} {
+func CreateConfig(name string) map[string]interface{} {
 	// TODO: Use t.Name() when Go 1.7 support terminates.
 	rv := make(map[string]interface{})
-	rv["path"] = os.TempDir() + "/bleve-scorch-test-" + GetTestName()
+	rv["path"] = os.TempDir() + "/bleve-scorch-test-" + name
 	return rv
 }
 
@@ -77,19 +58,20 @@ var testAnalyzer = &analysis.Analyzer{
 }
 
 func TestIndexOpenReopen(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexOpenReopen")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +128,7 @@ func TestIndexOpenReopen(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	idx, err = NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,19 +162,20 @@ func TestIndexOpenReopen(t *testing.T) {
 }
 
 func TestIndexInsert(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsert")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,19 +233,20 @@ func TestIndexInsert(t *testing.T) {
 }
 
 func TestIndexInsertThenDelete(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertThenDelete")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +364,7 @@ func TestIndexInsertThenDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	idx, err = NewScorch(Name, CreateConfig(t), analysisQueue) // reopen
+	idx, err = NewScorch(Name, cfg, analysisQueue) // reopen
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,19 +449,20 @@ func TestIndexInsertThenDelete(t *testing.T) {
 }
 
 func TestIndexInsertThenUpdate(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertThenUpdate")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,19 +521,20 @@ func TestIndexInsertThenUpdate(t *testing.T) {
 }
 
 func TestIndexInsertMultiple(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertMultiple")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -607,19 +593,20 @@ func TestIndexInsertMultiple(t *testing.T) {
 }
 
 func TestIndexInsertWithStore(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertWithStore")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -710,19 +697,20 @@ func TestIndexInsertWithStore(t *testing.T) {
 }
 
 func TestIndexInternalCRUD(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInternalCRUD")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -820,19 +808,20 @@ func TestIndexInternalCRUD(t *testing.T) {
 }
 
 func TestIndexBatch(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexBatch")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -942,19 +931,20 @@ func TestIndexBatch(t *testing.T) {
 }
 
 func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertUpdateDeleteWithMultipleTypesStored")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1164,19 +1154,20 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 }
 
 func TestIndexInsertFields(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexInsertFields")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1237,19 +1228,20 @@ func TestIndexInsertFields(t *testing.T) {
 }
 
 func TestIndexUpdateComposites(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexUpdateComposites")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1318,19 +1310,20 @@ func TestIndexUpdateComposites(t *testing.T) {
 }
 
 func TestIndexTermReaderCompositeFields(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexTermReaderCompositeFields")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1387,19 +1380,20 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 }
 
 func TestIndexDocumentVisitFieldTerms(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexDocumentVisitFieldTerms")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1456,19 +1450,20 @@ func TestIndexDocumentVisitFieldTerms(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestConcurrentUpdate")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1522,19 +1517,20 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestLargeField(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestLargeField")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1588,19 +1584,20 @@ This section needs additional citations for verification. Please help improve th
 There are three characteristics of liquids which are relevant to the discussion of a BLEVE:`)
 
 func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexDocumentVisitFieldTermsWithMultipleDocs")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1744,19 +1741,20 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 }
 
 func TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions(t *testing.T) {
-	err := InitTest(t)
+	cfg := CreateConfig("TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1818,18 +1816,19 @@ func TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions(t *testing.T) {
 
 func TestAllFieldWithDifferentTermVectorsEnabled(t *testing.T) {
 	// Based on https://github.com/blevesearch/bleve/issues/895 from xeizmendi
-	err := InitTest(t)
+	cfg := CreateConfig("TestAllFieldWithDifferentTermVectorsEnabled")
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
-	testConfig := CreateConfig(t)
+	testConfig := cfg
 	mp := mapping.NewIndexMapping()
 
 	keywordMapping := mapping.NewTextFieldMapping()

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -38,17 +39,36 @@ func init() {
 	DefaultPersisterNapTimeMSec = 1
 }
 
+var testNameRegexp = regexp.MustCompile(`\.(Test[\p{L}_\p{N}]*)`)
+
+func GetTestName() string {
+	pc := make([]uintptr, 32)
+	n := runtime.Callers(0, pc)
+	for i := 0; i < n; i++ {
+		name := runtime.FuncForPC(pc[i]).Name()
+		ms := testNameRegexp.FindStringSubmatch(name)
+		if ms == nil {
+			continue
+		}
+		return ms[1]
+	}
+	panic("test name could not be recovered")
+}
+
 func InitTest(t *testing.T) error {
-	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + t.Name())
+	// TODO: Use t.Name() when Go 1.7 support terminates.
+	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + GetTestName())
 }
 
 func DestroyTest(t *testing.T) error {
-	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + t.Name())
+	// TODO: Use t.Name() when Go 1.7 support terminates.
+	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + GetTestName())
 }
 
 func CreateConfig(t *testing.T) map[string]interface{} {
+	// TODO: Use t.Name() when Go 1.7 support terminates.
 	rv := make(map[string]interface{})
-	rv["path"] = os.TempDir() + "/bleve-scorch-test-" + t.Name()
+	rv["path"] = os.TempDir() + "/bleve-scorch-test-" + GetTestName()
 	return rv
 }
 

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -38,12 +38,18 @@ func init() {
 	DefaultPersisterNapTimeMSec = 1
 }
 
-func DestroyTest() error {
-	return os.RemoveAll("/tmp/bleve-scorch-test")
+func InitTest(t *testing.T) error {
+	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + t.Name())
 }
 
-var testConfig = map[string]interface{}{
-	"path": "/tmp/bleve-scorch-test",
+func DestroyTest(t *testing.T) error {
+	return os.RemoveAll(os.TempDir() + "/bleve-scorch-test-" + t.Name())
+}
+
+func CreateConfig(t *testing.T) map[string]interface{} {
+	rv := make(map[string]interface{})
+	rv["path"] = os.TempDir() + "/bleve-scorch-test-" + t.Name()
+	return rv
 }
 
 var testAnalyzer = &analysis.Analyzer{
@@ -51,15 +57,19 @@ var testAnalyzer = &analysis.Analyzer{
 }
 
 func TestIndexOpenReopen(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +126,7 @@ func TestIndexOpenReopen(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	idx, err = NewScorch(Name, testConfig, analysisQueue)
+	idx, err = NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,15 +160,19 @@ func TestIndexOpenReopen(t *testing.T) {
 }
 
 func TestIndexInsert(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,15 +230,19 @@ func TestIndexInsert(t *testing.T) {
 }
 
 func TestIndexInsertThenDelete(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +360,7 @@ func TestIndexInsertThenDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	idx, err = NewScorch(Name, testConfig, analysisQueue) // reopen
+	idx, err = NewScorch(Name, CreateConfig(t), analysisQueue) // reopen
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,15 +445,19 @@ func TestIndexInsertThenDelete(t *testing.T) {
 }
 
 func TestIndexInsertThenUpdate(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,15 +516,19 @@ func TestIndexInsertThenUpdate(t *testing.T) {
 }
 
 func TestIndexInsertMultiple(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,15 +587,19 @@ func TestIndexInsertMultiple(t *testing.T) {
 }
 
 func TestIndexInsertWithStore(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,9 +608,9 @@ func TestIndexInsertWithStore(t *testing.T) {
 		t.Fatalf("error opening index: %v", err)
 	}
 	defer func() {
-		cerr := idx.Close()
+		err := idx.Close()
 		if err != nil {
-			t.Fatal(cerr)
+			t.Fatal(err)
 		}
 	}()
 
@@ -660,15 +690,19 @@ func TestIndexInsertWithStore(t *testing.T) {
 }
 
 func TestIndexInternalCRUD(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -766,15 +800,19 @@ func TestIndexInternalCRUD(t *testing.T) {
 }
 
 func TestIndexBatch(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -884,15 +922,19 @@ func TestIndexBatch(t *testing.T) {
 }
 
 func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1102,15 +1144,19 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 }
 
 func TestIndexInsertFields(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,15 +1217,19 @@ func TestIndexInsertFields(t *testing.T) {
 }
 
 func TestIndexUpdateComposites(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1248,15 +1298,19 @@ func TestIndexUpdateComposites(t *testing.T) {
 }
 
 func TestIndexTermReaderCompositeFields(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1313,15 +1367,19 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 }
 
 func TestIndexDocumentVisitFieldTerms(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1378,15 +1436,19 @@ func TestIndexDocumentVisitFieldTerms(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1422,6 +1484,12 @@ func TestConcurrentUpdate(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer func() {
+		err := r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	doc, err := r.Document("1")
 	if err != nil {
@@ -1434,15 +1502,19 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestLargeField(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1496,15 +1568,19 @@ This section needs additional citations for verification. Please help improve th
 There are three characteristics of liquids which are relevant to the discussion of a BLEVE:`)
 
 func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1648,15 +1724,19 @@ func TestIndexDocumentVisitFieldTermsWithMultipleDocs(t *testing.T) {
 }
 
 func TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions(t *testing.T) {
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1718,6 +1798,18 @@ func TestIndexDocumentVisitFieldTermsWithMultipleFieldOptions(t *testing.T) {
 
 func TestAllFieldWithDifferentTermVectorsEnabled(t *testing.T) {
 	// Based on https://github.com/blevesearch/bleve/issues/895 from xeizmendi
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := DestroyTest(t)
+		if err != nil {
+			t.Log(err)
+		}
+	}()
+
+	testConfig := CreateConfig(t)
 	mp := mapping.NewIndexMapping()
 
 	keywordMapping := mapping.NewTextFieldMapping()
@@ -1736,7 +1828,6 @@ func TestAllFieldWithDifferentTermVectorsEnabled(t *testing.T) {
 
 	mp.DefaultMapping = docMapping
 
-	_ = os.RemoveAll(testConfig["path"].(string))
 	analysisQueue := index.NewAnalysisQueue(1)
 	idx, err := NewScorch("storeName", testConfig, analysisQueue)
 	if err != nil {
@@ -1747,8 +1838,10 @@ func TestAllFieldWithDifferentTermVectorsEnabled(t *testing.T) {
 		t.Errorf("error opening index: %v", err)
 	}
 	defer func() {
-		_ = idx.Close()
-		_ = os.RemoveAll(testConfig["path"].(string))
+		err := idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	data := map[string]string{

--- a/index/scorch/snapshot_rollback_test.go
+++ b/index/scorch/snapshot_rollback_test.go
@@ -25,17 +25,21 @@ func TestIndexRollback(t *testing.T) {
 	numSnapshotsToKeepOrig := NumSnapshotsToKeep
 	NumSnapshotsToKeep = 1000
 
+	err := InitTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		NumSnapshotsToKeep = numSnapshotsToKeepOrig
 
-		err := DestroyTest()
+		err := DestroyTest(t)
 		if err != nil {
-			t.Fatal(err)
+			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, testConfig, analysisQueue)
+	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index/scorch/snapshot_rollback_test.go
+++ b/index/scorch/snapshot_rollback_test.go
@@ -22,24 +22,25 @@ import (
 )
 
 func TestIndexRollback(t *testing.T) {
+	cfg := CreateConfig("TestIndexRollback")
 	numSnapshotsToKeepOrig := NumSnapshotsToKeep
 	NumSnapshotsToKeep = 1000
 
-	err := InitTest(t)
+	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
 		NumSnapshotsToKeep = numSnapshotsToKeepOrig
 
-		err := DestroyTest(t)
+		err := DestroyTest(cfg)
 		if err != nil {
 			t.Log(err)
 		}
 	}()
 
 	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, CreateConfig(t), analysisQueue)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Here are few changes in scorch tests:

1. Tests fail in Windows with error `snapshot_rollback_test.go:37: remove C:\Users\rvncerr\AppData\Local\Temp/bleve-scorch-test-TestIndexRollback\000000000001.zap: The process cannot access the file because it is being used by another process.` (unlike Unix, Windows can not delete file which is being used by another process). Proposed workaround - do not throw `t.Fatal(err)` if we cannot delete test files at the end of the test, but throw if we cannot delete them at the begin of new test run.
2. Execute tests in different folders. It helps in parallel execution of tests and necessary for (1) - if running test is unable to clean up the data, we can continue with the next test.
3. Using `os.TempDir()` instead of `'/tmp'`. Necessary for OS, different from Unix.
4. Some unification in tests - each test starts with the same code (`InitTest(...)`, `defer DestroyTest(...)`, `CreateConfig(...)`).
5. Bugfix in `TestConcurrentUpdate` - no code for `idx.Reader()` closing. Now added as defer function.