### PR TITLE
Travis-CI reports sporadic failures on TestRegexpSearchScorch

### DIFF
--- a/cmd/bleve/cmd/zap/docvalue.go
+++ b/cmd/bleve/cmd/zap/docvalue.go
@@ -196,6 +196,10 @@ var docvalueCmd = &cobra.Command{
 		}
 		curChunkSize := chunkLens[docInChunk]
 
+		if curChunkSize == 0 {
+			return nil
+		}
+
 		// read the number of docs reside in the chunk
 		numDocs := uint64(0)
 		numDocs, nread = binary.Uvarint(data[destChunkDataLoc : destChunkDataLoc+binary.MaxVarintLen64])

--- a/geo/geohash.go
+++ b/geo/geohash.go
@@ -1,0 +1,174 @@
+// The code here was obtained from:
+//   https://github.com/mmcloughlin/geohash
+
+// The MIT License (MIT)
+// Copyright (c) 2015 Michael McLoughlin
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package geo
+
+import (
+	"math"
+)
+
+// encoding encapsulates an encoding defined by a given base32 alphabet.
+type encoding struct {
+	enc string
+	dec [256]byte
+}
+
+// newEncoding constructs a new encoding defined by the given alphabet,
+// which must be a 32-byte string.
+func newEncoding(encoder string) *encoding {
+	e := new(encoding)
+	e.enc = encoder
+	for i := 0; i < len(e.dec); i++ {
+		e.dec[i] = 0xff
+	}
+	for i := 0; i < len(encoder); i++ {
+		e.dec[encoder[i]] = byte(i)
+	}
+	return e
+}
+
+// Decode string into bits of a 64-bit word. The string s may be at most 12
+// characters.
+func (e *encoding) decode(s string) uint64 {
+	x := uint64(0)
+	for i := 0; i < len(s); i++ {
+		x = (x << 5) | uint64(e.dec[s[i]])
+	}
+	return x
+}
+
+// Encode bits of 64-bit word into a string.
+func (e *encoding) encode(x uint64) string {
+	b := [12]byte{}
+	for i := 0; i < 12; i++ {
+		b[11-i] = e.enc[x&0x1f]
+		x >>= 5
+	}
+	return string(b[:])
+}
+
+// Base32Encoding with the Geohash alphabet.
+var base32encoding = newEncoding("0123456789bcdefghjkmnpqrstuvwxyz")
+
+// BoundingBox returns the region encoded by the given string geohash.
+func geoBoundingBox(hash string) geoBox {
+	bits := uint(5 * len(hash))
+	inthash := base32encoding.decode(hash)
+	return geoBoundingBoxIntWithPrecision(inthash, bits)
+}
+
+// Box represents a rectangle in latitude/longitude space.
+type geoBox struct {
+	minLat float64
+	maxLat float64
+	minLng float64
+	maxLng float64
+}
+
+// Round returns a point inside the box, making an effort to round to minimal
+// precision.
+func (b geoBox) round() (lat, lng float64) {
+	x := maxDecimalPower(b.maxLat - b.minLat)
+	lat = math.Ceil(b.minLat/x) * x
+	x = maxDecimalPower(b.maxLng - b.minLng)
+	lng = math.Ceil(b.minLng/x) * x
+	return
+}
+
+// precalculated for performance
+var exp232 = math.Exp2(32)
+
+// errorWithPrecision returns the error range in latitude and longitude for in
+// integer geohash with bits of precision.
+func errorWithPrecision(bits uint) (latErr, lngErr float64) {
+	b := int(bits)
+	latBits := b / 2
+	lngBits := b - latBits
+	latErr = math.Ldexp(180.0, -latBits)
+	lngErr = math.Ldexp(360.0, -lngBits)
+	return
+}
+
+// minDecimalPlaces returns the minimum number of decimal places such that
+// there must exist an number with that many places within any range of width
+// r. This is intended for returning minimal precision coordinates inside a
+// box.
+func maxDecimalPower(r float64) float64 {
+	m := int(math.Floor(math.Log10(r)))
+	return math.Pow10(m)
+}
+
+// Encode the position of x within the range -r to +r as a 32-bit integer.
+func encodeRange(x, r float64) uint32 {
+	p := (x + r) / (2 * r)
+	return uint32(p * exp232)
+}
+
+// Decode the 32-bit range encoding X back to a value in the range -r to +r.
+func decodeRange(X uint32, r float64) float64 {
+	p := float64(X) / exp232
+	x := 2*r*p - r
+	return x
+}
+
+// Squash the even bitlevels of X into a 32-bit word. Odd bitlevels of X are
+// ignored, and may take any value.
+func squash(X uint64) uint32 {
+	X &= 0x5555555555555555
+	X = (X | (X >> 1)) & 0x3333333333333333
+	X = (X | (X >> 2)) & 0x0f0f0f0f0f0f0f0f
+	X = (X | (X >> 4)) & 0x00ff00ff00ff00ff
+	X = (X | (X >> 8)) & 0x0000ffff0000ffff
+	X = (X | (X >> 16)) & 0x00000000ffffffff
+	return uint32(X)
+}
+
+// Deinterleave the bits of X into 32-bit words containing the even and odd
+// bitlevels of X, respectively.
+func deinterleave(X uint64) (uint32, uint32) {
+	return squash(X), squash(X >> 1)
+}
+
+// BoundingBoxIntWithPrecision returns the region encoded by the integer
+// geohash with the specified precision.
+func geoBoundingBoxIntWithPrecision(hash uint64, bits uint) geoBox {
+	fullHash := hash << (64 - bits)
+	latInt, lngInt := deinterleave(fullHash)
+	lat := decodeRange(latInt, 90)
+	lng := decodeRange(lngInt, 180)
+	latErr, lngErr := errorWithPrecision(bits)
+	return geoBox{
+		minLat: lat,
+		maxLat: lat + latErr,
+		minLng: lng,
+		maxLng: lng + lngErr,
+	}
+}
+
+// ----------------------------------------------------------------------
+
+// Decode the string geohash to a (lat, lng) point.
+func GeoHashDecode(hash string) (lat, lng float64) {
+	box := geoBoundingBox(hash)
+	return box.round()
+}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -37,8 +37,26 @@ import (
 
 var DefaultChunkFactor uint32 = 1024
 
-var DefaultPersisterNapTimeMSec int = 2000 // ms
+// DefaultPersisterNapTimeMSec is kept to zero as this helps in direct
+// persistence of segments with the default safe batch option.
+// If the default safe batch option results in high number of
+// files on disk, then users may initialise this configuration parameter
+// with higher values so that the persister will nap a bit within it's
+// work loop to favour better in-memory merging of segments to result
+// in fewer segment files on disk. But that may come with an indexing
+// performance overhead.
+// Unsafe batch users are advised to override this to higher value
+// for better performance especially with high data density.
+var DefaultPersisterNapTimeMSec int = 0 // ms
 
+// DefaultPersisterNapUnderNumFiles helps in controlling the pace of
+// persister. At times of a slow merger progress with heavy file merging
+// operations, its better to pace down the persister for letting the merger
+// to catch up within a range defined by this parameter.
+// Fewer files on disk (as per the merge plan) would result in keeping the
+// file handle usage under limit, faster disk merger and a healthier index.
+// Its been observed that such a loosely sync'ed introducer-persister-merger
+// trio results in better overall performance.
 var DefaultPersisterNapUnderNumFiles int = 1000
 
 var DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64

--- a/index/scorch/segment/zap/README.md
+++ b/index/scorch/segment/zap/README.md
@@ -1,5 +1,7 @@
 # zap file format
 
+Advanced ZAP File Format Documentation is [here](zap.md).
+
 The file is written in the reverse order that we typically access data.  This helps us write in one pass since later sections of the file require file offsets of things we've already written.
 
 Current usage:
@@ -90,16 +92,6 @@ If you know the doc number you're interested in, this format lets you jump to th
 
 If you know the doc number you're interested in, this format lets you jump to the correct chunk (docNum/chunkFactor) directly and then seek within that chunk until you find it.
 
-## bitmaps of hits with location info
-
-- for each posting list
-  - preparation phase:
-    - encode roaring bitmap (inidicating which hits have location details indexed) posting list to bytes (so we know the length)
-  - file writing phase:
-    - remember the start position for this bitmap
-    - write length of encoded roaring bitmap
-    - write the serialized roaring bitmap data
-
 ## postings list section
 
 - for each posting list
@@ -109,7 +101,6 @@ If you know the doc number you're interested in, this format lets you jump to th
     - remember the start position for this posting list
     - write freq/norm details offset (remembered from previous, as varint uint64)
     - write location details offset (remembered from previous, as varint uint64)
-    - write location bitmap offset (remembered from previous, as varint uint64)
     - write length of encoded roaring bitmap
     - write the serialized roaring bitmap data
 

--- a/index/scorch/segment/zap/zap.md
+++ b/index/scorch/segment/zap/zap.md
@@ -1,0 +1,177 @@
+# ZAP File Format 
+
+## Legend
+
+### Sections
+
+    |========|
+    |        | section
+    |========|
+    
+### Fixed-size fields
+
+    |--------|        |----|        |--|        |-|
+    |        | uint64 |    | uint32 |  | uint16 | | uint8
+    |--------|        |----|        |--|        |-|
+
+### Varints
+
+    |~~~~~~~~|
+    |        | varint(up to uint64)
+    |~~~~~~~~|
+
+### Arbitary-length fields
+
+    |--------...---|
+    |              | arbitrary-length field (string, vellum, roaring bitmap)
+    |--------...---|
+
+### Chunked data
+
+	[--------]
+	[        ]
+	[--------]
+
+## Overview
+
+Footer sectrion describes the configuration of particular ZAP file. The format of footer is version-dependent, so it is necessary to check `V` field before the parsing.
+
+            |==================================================|
+            | Stored Fields                                    |
+            |==================================================|
+    |-----> | Stored Fields Index                              |
+    |       |==================================================|   
+    |       | Dictionaries + Postings + DocValues              | 
+    |       |==================================================|
+    | |---> | DocValues Index                                  |
+    | |     |==================================================|   
+    | |     | Fields                                           |
+    | |     |==================================================|
+    | | |-> | Fields Index                                     |
+    | | |   |========|========|========|========|====|====|====|
+    | | |   |     D# |     SF |      F |    FDV | CF |  V | CC | (Footer)
+    | | |   |========|====|===|====|===|====|===|====|====|====|
+    | | |                 |        |        |
+    |-+-+-----------------|        |        |
+      | |--------------------------|        |
+      |-------------------------------------|
+
+     D#. Number of Docs.
+     SF. Stored Fields Index Offset.
+      F. Field Index Offset.
+    FDV. Field DocValue Offset.
+     CF. Chunk Factor.
+      V. Version.
+     CC. CRC32.
+
+## Stored Fields
+
+Stored Fields Index is `D#` consecutive 64-bit unsigned integers - offsets, where relevant Stored Fields Data records are located.
+
+    0                                [SF]                   [SF + D# * 8]
+    | Stored Fields                  | Stored Fields Index              |
+    |================================|==================================|
+    |                                |                                  |
+    |       |--------------------|   ||--------|--------|. . .|--------||
+    |   |-> | Stored Fields Data |   ||      0 |      1 |     | D# - 1 ||
+    |   |   |--------------------|   ||--------|----|---|. . .|--------||
+    |   |                            |              |                   |
+    |===|============================|==============|===================|
+        |                                           |
+        |-------------------------------------------|
+
+Stored Fields Data is an arbitrary size record, which consists of metadata and [Snappy](https://github.com/golang/snappy)-compressed data.
+
+    Stored Fields Data
+    |~~~~~~~~|~~~~~~~~|~~~~~~~~...~~~~~~~~|~~~~~~~~...~~~~~~~~|
+    |    MDS |    CDS |                MD |                CD |
+    |~~~~~~~~|~~~~~~~~|~~~~~~~~...~~~~~~~~|~~~~~~~~...~~~~~~~~|
+    
+    MDS. Metadata size.
+    CDS. Compressed data size.
+    MD. Metadata.
+    CD. Snappy-compressed data.
+
+## Fields
+
+Fields Index section located between addresses `F` and `len(file) - len(footer)` and consist of `uint64` values (`F1`, `F2`, ...) which are offsets to records in Fields section. We have `F# = (len(file) - len(footer) - F) / sizeof(uint64)` fields.
+
+
+    (...)                            [F]                       [F + F#]
+    | Fields                         | Fields Index.                  |
+    |================================|================================|
+    |                                |                                |
+    |   |~~~~~~~~|~~~~~~~~|---...---|||--------|--------|...|--------||
+    ||->|   Dict | Length |    Name |||      0 |      1 |   | F# - 1 ||
+    ||  |~~~~~~~~|~~~~~~~~|---...---|||--------|----|---|...|--------||
+    ||                               |              |                 |
+    ||===============================|==============|=================|
+     |                                              |
+     |----------------------------------------------|
+        
+
+## Dictionaries + Postings
+
+Each of fields has its own dictionary, encoded in [Vellum](https://github.com/couchbase/vellum) format. Dictionary consists of pairs `(term, offset)`, where `offset` indicates the position of postings (list of documents) for this particular term.
+
+	|================================================================|- Dictionaries + 
+	|                                                                |   Postings +
+	|                                                                |    DocValues
+	|    Freq/Norm (chunked)                                         |
+	|    [~~~~~~|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]                      |
+	| |->[ Freq | Norm (float32 under varint) ]                      |
+	| |  [~~~~~~|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]                      |
+	| |                                                              |
+	| |------------------------------------------------------------| |
+	|    Location Details (chunked)                                | |
+	|    [~~~~~~|~~~~~|~~~~~~~|~~~~~|~~~~~~|~~~~~~~~|~~~~~]        | |
+	| |->[ Size | Pos | Start | End | Arr# | ArrPos | ... ]        | |
+	| |  [~~~~~~|~~~~~|~~~~~~~|~~~~~|~~~~~~|~~~~~~~~|~~~~~]        | |
+	| |                                                            | |
+	| |----------------------|                                     | |
+	|          Postings List |                                     | |
+	|         |~~~~~~~~|~~~~~|~~|~~~~~~~~|-----------...--|        | |
+	|      |->|    F/N |     LD | Length | ROARING BITMAP |        | |
+	|      |  |~~~~~|~~|~~~~~~~~|~~~~~~~~|-----------...--|        | |
+	|      |        |----------------------------------------------| |
+	|      |--------------------------------------|                  |
+	|          Dictionary                         |                  |
+	|         |~~~~~~~~|--------------------------|-...-|            |
+	|      |->| Length | VELLUM DATA : (TERM -> OFFSET) |            |
+	|      |  |~~~~~~~~|----------------------------...-|            |
+	|      |                                                         |
+	|======|=========================================================|- DocValues Index
+	|      |                                                         |
+	|======|=========================================================|- Fields
+	|      |                                                         |
+	| |~~~~|~~~|~~~~~~~~|---...---|                                  |
+	| |   Dict | Length |    Name |                                  |
+	| |~~~~~~~~|~~~~~~~~|---...---|                                  |
+	|                                                                |
+	|================================================================|
+
+## DocValues
+
+DocValues Index is `F#` pairs of varints, one pair per field. Each pair of varints indicates start and end point of DocValues slice.
+
+	|================================================================|
+	|     |------...--|                                              |
+	|  |->| DocValues |<-|                                           |
+	|  |  |------...--|  |                                           |
+	|==|=================|===========================================|- DocValues Index
+	||~|~~~~~~~~~|~~~~~~~|~~|           |~~~~~~~~~~~~~~|~~~~~~~~~~~~||
+	|| DV1 START | DV1 STOP | . . . . . | DV(F#) START | DV(F#) END ||
+	||~~~~~~~~~~~|~~~~~~~~~~|           |~~~~~~~~~~~~~~|~~~~~~~~~~~~||
+	|================================================================|
+
+DocValues is chunked Snappy-compressed values for each document and field.
+
+    [~~~~~~~~~~~~~~~|~~~~~~|~~~~~~~~~|-...-|~~~~~~|~~~~~~~~~|--------------------...-]
+    [ Doc# in Chunk | Doc1 | Offset1 | ... | DocN | OffsetN | SNAPPY COMPRESSED DATA ]
+    [~~~~~~~~~~~~~~~|~~~~~~|~~~~~~~~~|-...-|~~~~~~|~~~~~~~~~|--------------------...-]
+
+Last 16 bytes are description of chunks.
+
+    |~~~~~~~~~~~~...~|----------------|----------------|
+    |   Chunk Sizes  | Chunk Size Arr |         Chunk# |
+    |~~~~~~~~~~~~...~|----------------|----------------|

--- a/index/scorch/segment/zap/zap.md
+++ b/index/scorch/segment/zap/zap.md
@@ -20,7 +20,7 @@
     |        | varint(up to uint64)
     |~~~~~~~~|
 
-### Arbitary-length fields
+### Arbitrary-length fields
 
     |--------...---|
     |              | arbitrary-length field (string, vellum, roaring bitmap)
@@ -34,7 +34,7 @@
 
 ## Overview
 
-Footer sectrion describes the configuration of particular ZAP file. The format of footer is version-dependent, so it is necessary to check `V` field before the parsing.
+Footer section describes the configuration of particular ZAP file. The format of footer is version-dependent, so it is necessary to check `V` field before the parsing.
 
             |==================================================|
             | Stored Fields                                    |

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -424,7 +424,11 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		if subDocMapping != nil {
 			// index by explicit mapping
 			for _, fieldMapping := range subDocMapping.Fields {
-				fieldMapping.processString(propertyValueString, pathString, path, indexes, context)
+				if fieldMapping.Type == "geopoint" {
+					fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
+				} else {
+					fieldMapping.processString(propertyValueString, pathString, path, indexes, context)
+				}
 			}
 		} else if closestDocMapping.Dynamic {
 			// automatic indexing behavior

--- a/search/searcher/base_test.go
+++ b/search/searcher/base_test.go
@@ -15,7 +15,6 @@
 package searcher
 
 import (
-	"io/ioutil"
 	"math"
 	"regexp"
 
@@ -48,9 +47,8 @@ func initTwoDocUpsideDown() index.Index {
 	return twoDocIndex
 }
 
-func initTwoDocScorch() index.Index {
+func initTwoDocScorch(dir string) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
-	dir, _ := ioutil.TempDir("", "scorchTwoDoc")
 	twoDocIndex, err := scorch.NewScorch(
 		scorch.Name,
 		map[string]interface{}{

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -55,7 +55,7 @@ func tooManyClauses(count int) bool {
 	return false
 }
 
-func tooManyClausesErr() error {
-	return fmt.Errorf("TooManyClauses[maxClauseCount is set to %d]",
-		DisjunctionMaxClauseCount)
+func tooManyClausesErr(count int) error {
+	return fmt.Errorf("TooManyClauses[%d > maxClauseCount, which is set to %d]",
+		count, DisjunctionMaxClauseCount)
 }

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -62,7 +62,7 @@ func newDisjunctionHeapSearcher(indexReader index.IndexReader,
 	limit bool) (
 	*DisjunctionHeapSearcher, error) {
 	if limit && tooManyClauses(len(searchers)) {
-		return nil, tooManyClausesErr()
+		return nil, tooManyClausesErr(len(searchers))
 	}
 
 	// build our searcher

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -50,7 +50,7 @@ func newDisjunctionSliceSearcher(indexReader index.IndexReader,
 	limit bool) (
 	*DisjunctionSliceSearcher, error) {
 	if limit && tooManyClauses(len(qsearchers)) {
-		return nil, tooManyClausesErr()
+		return nil, tooManyClausesErr(len(qsearchers))
 	}
 	// build the downstream searchers
 	searchers := make(OrderedSearcherList, len(qsearchers))

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -71,7 +71,7 @@ func findFuzzyCandidateTerms(indexReader index.IndexReader, term string,
 		for err == nil && tfd != nil {
 			rv = append(rv, tfd.Term)
 			if tooManyClauses(len(rv)) {
-				return nil, tooManyClausesErr()
+				return nil, tooManyClausesErr(len(rv))
 			}
 			tfd, err = fieldDict.Next()
 		}
@@ -103,7 +103,7 @@ func findFuzzyCandidateTerms(indexReader index.IndexReader, term string,
 		if !exceeded && ld <= fuzziness {
 			rv = append(rv, tfd.Term)
 			if tooManyClauses(len(rv)) {
-				return nil, tooManyClausesErr()
+				return nil, tooManyClausesErr(len(rv))
 			}
 		}
 		tfd, err = fieldDict.Next()

--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -23,7 +23,7 @@ func NewMultiTermSearcher(indexReader index.IndexReader, terms []string,
 	field string, boost float64, options search.SearcherOptions, limit bool) (
 	search.Searcher, error) {
 	if limit && tooManyClauses(len(terms)) {
-		return nil, tooManyClausesErr()
+		return nil, tooManyClausesErr(len(terms))
 	}
 
 	qsearchers := make([]search.Searcher, len(terms))
@@ -51,7 +51,7 @@ func NewMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byte,
 	field string, boost float64, options search.SearcherOptions, limit bool) (
 	search.Searcher, error) {
 	if limit && tooManyClauses(len(terms)) {
-		return nil, tooManyClausesErr()
+		return nil, tooManyClausesErr(len(terms))
 	}
 
 	qsearchers := make([]search.Searcher, len(terms))

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -68,7 +68,7 @@ func NewNumericRangeSearcher(indexReader index.IndexReader,
 		return nil, err
 	}
 	if tooManyClauses(len(terms)) {
-		return nil, tooManyClausesErr()
+		return nil, tooManyClausesErr(len(terms))
 	}
 
 	return NewMultiTermSearcherBytes(indexReader, terms, field, boost, options,

--- a/search/searcher/search_regexp.go
+++ b/search/searcher/search_regexp.go
@@ -110,7 +110,7 @@ func findRegexpCandidateTerms(indexReader index.IndexReader,
 		if matchPos != nil && matchPos[0] == 0 && matchPos[1] == len(tfd.Term) {
 			rv = append(rv, tfd.Term)
 			if tooManyClauses(len(rv)) {
-				return rv, tooManyClausesErr()
+				return rv, tooManyClausesErr(len(rv))
 			}
 		}
 		tfd, err = fieldDict.Next()

--- a/search/searcher/search_regexp_test.go
+++ b/search/searcher/search_regexp_test.go
@@ -17,6 +17,8 @@ package searcher
 import (
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 
@@ -37,13 +39,19 @@ func TestRegexpStringSearchUpsideDown(t *testing.T) {
 }
 
 func TestRegexpSearchScorch(t *testing.T) {
-	twoDocIndex := initTwoDocScorch()
+	dir, _ := ioutil.TempDir("", "scorchTwoDoc")
+	defer os.RemoveAll(dir)
+
+	twoDocIndex := initTwoDocScorch(dir)
 	testRegexpSearch(t, twoDocIndex, internalIDMakerScorch, searcherMaker)
 	_ = twoDocIndex.Close()
 }
 
 func TestRegexpStringSearchScorch(t *testing.T) {
-	twoDocIndex := initTwoDocScorch()
+	dir, _ := ioutil.TempDir("", "scorchTwoDoc")
+	defer os.RemoveAll(dir)
+
+	twoDocIndex := initTwoDocScorch(dir)
 	testRegexpSearch(t, twoDocIndex, internalIDMakerScorch, searcherStringMaker)
 	_ = twoDocIndex.Close()
 }
@@ -144,7 +152,7 @@ func testRegexpSearch(t *testing.T, twoDocIndex index.Index,
 		for err == nil && next != nil {
 			if i < len(test.expecteds) {
 				if !next.IndexInternalID.Equals(test.expecteds[i].IndexInternalID) {
-					t.Errorf("test %d, expected result %d to have id %s got %s, next: %#v",
+					t.Errorf("test %d, expected result %d to have id %v got %v, next: %#v",
 						testIndex, i, test.expecteds[i].IndexInternalID, next.IndexInternalID, next)
 				}
 				if next.Score != test.expecteds[i].Score {

--- a/search/searcher/search_term_prefix.go
+++ b/search/searcher/search_term_prefix.go
@@ -38,7 +38,7 @@ func NewTermPrefixSearcher(indexReader index.IndexReader, prefix string,
 	for err == nil && tfd != nil {
 		terms = append(terms, tfd.Term)
 		if tooManyClauses(len(terms)) {
-			return nil, tooManyClausesErr()
+			return nil, tooManyClausesErr(len(terms))
 		}
 		tfd, err = fieldDict.Next()
 	}


### PR DESCRIPTION
`FAIL: TestRegexpSearchScorch (0.03s)	search_regexp_test.go:148: test 0, expected result 0 to have id  got , next: &search.DocumentMatch{Index:"", ID:"", IndexInternalID:index.IndexInternalID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2}, Score:1.916290731874155, Expl:(*search.Explanation)(0xc4235270e0), Locations:search.FieldTermLocationMap(nil), Fragments:search.FieldFragmentMap(nil), Sort:[]string{}, Fields:map[string]interface {}(nil), Document:<nil>, HitNumber:0x0, FieldTermLocations:[]search.FieldTermLocation(nil)}	search_regexp_test.go:148: test 1, expected result 0 to have id  got , next: &search.DocumentMatch{Index:"", ID:"", IndexInternalID:index.IndexInternalID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3}, Score:0.33875554280828685, Expl:(*search.Explanation)(0xc420c281e0), Locations:search.FieldTermLocationMap(nil), Fragments:search.FieldFragmentMap(nil), Sort:[]string{}, Fields:map[string]interface {}(nil), Document:<nil>, HitNumber:0x0, FieldTermLocations:[]search.FieldTermLocation(nil)}	search_regexp_test.go:148: test 1, expected result 1 to have id  got , next: &search.DocumentMatch{Index:"", ID:"", IndexInternalID:index.IndexInternalID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4}, Score:0.33875554280828685, Expl:(*search.Explanation)(0xc420c282a0), Locations:search.FieldTermLocationMap(nil), Fragments:search.FieldFragmentMap(nil), Sort:[]string{}, Fields:map[string]interface {}(nil), Document:<nil>, HitNumber:0x0, FieldTermLocations:[]search.FieldTermLocation(nil)} `

Fix: clean up index directory after the test - avoiding reusing old index.