### PR TITLE
Adding error messages for negative fuzziness

### DIFF
--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -31,6 +31,10 @@ func NewFuzzySearcher(indexReader index.IndexReader, term string,
 		return nil, fmt.Errorf("fuzziness exceeds max (%d)", MaxFuzziness)
 	}
 
+	if fuzziness < 0 {
+		return nil, fmt.Errorf("invalid fuzziness, negative")
+	}
+
 	// Note: we don't byte slice the term for a prefix because of runes.
 	prefixTerm := ""
 	for i, r := range term {

--- a/search/searcher/search_fuzzy_test.go
+++ b/search/searcher/search_fuzzy_test.go
@@ -140,3 +140,16 @@ func TestFuzzySearch(t *testing.T) {
 		}
 	}
 }
+
+func TestFuzzySearchLimitErrors(t *testing.T) {
+	explainTrue := search.SearcherOptions{Explain: true}
+	_, err := NewFuzzySearcher(nil, "water", 3, 3, "desc", 1.0, explainTrue)
+	if err == nil {
+		t.Fatal("`fuzziness exceeds max (2)` error expected")
+	}
+
+	_, err = NewFuzzySearcher(nil, "water", 3, -1, "desc", 1.0, explainTrue)
+	if err == nil {
+		t.Fatal("`invalid fuzziness, negative` error expected")
+	}
+}


### PR DESCRIPTION
 Querying for negative fuzziness or edit distance is
 an invalid option and adding error messages for that.
 This would help further wrinkles down the line due to
 wrapping of -ve ED to a higher value during the uint
 typecasting.