### PR TITLE
DocNumbers - skip segments, that don't include requested ids

### DIFF
--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -423,17 +423,21 @@ func (s *SegmentBase) DocNumbers(ids []string) (*roaring.Bitmap, error) {
 		sMax := ""
 		iMin := ""
 
-		sMaxB, err := idDict.fst.GetMaxKey()
-		if err != nil {
-			skipCheck = true
-		} else {
-			sMax = string(sMaxB)
-			iMin = ids[0]
-			for i := 1; i < len(ids); i++ {
-				if ids[i] < iMin {
-					iMin = ids[i]
+		if len(ids) > 0 {
+			sMaxB, err := idDict.fst.GetMaxKey()
+			if err != nil {
+				skipCheck = true
+			} else {
+				sMax = string(sMaxB)
+				iMin = ids[0]
+				for i := 1; i < len(ids); i++ {
+					if ids[i] < iMin {
+						iMin = ids[i]
+					}
 				}
 			}
+		} else {
+			skipCheck = true
 		}
 		if skipCheck || (iMin <= sMax) {
 			for _, id := range ids {

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -418,19 +418,18 @@ func (s *SegmentBase) DocNumbers(ids []string) (*roaring.Bitmap, error) {
 		}
 
 		postingsList := emptyPostingsList
-		filteredIds := ids[:0]
+		filteredIds := make([]string, 0, len(ids))
 		sMax := ""
 
 		sMaxB, err := idDict.fst.GetMaxKey()
-		if err == nil {
-			sMax = string(sMaxB)
-			for _, id := range ids {
-				if id <= sMax {
-					filteredIds = append(filteredIds, id)
-				}
+		if err != nil {
+			return nil, err
+		}
+		sMax = string(sMaxB)
+		for _, id := range ids {
+			if id <= sMax {
+				filteredIds = append(filteredIds, id)
 			}
-		} else {
-			filteredIds = ids
 		}
 
 		for _, id := range filteredIds {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -137,7 +137,7 @@
 			"importpath": "github.com/couchbase/vellum",
 			"repository": "https://github.com/couchbase/vellum",
 			"vcs": "git",
-			"revision": "01d5c56e609533acd717717c8acc0d2dea6bfb89",
+			"revision": "f377ee3282b954c46915d89482bf93288ee7dd12",
 			"branch": "master",
 			"notests": true
 		}


### PR DESCRIPTION
Small performance improvement in SegmentBase.DocNumbers function.

Check, if current segment maximum docId smaller then smallest requested id.
If so, just skip this segment. This code uses recent vellum update (`GetMaxKey()`).