### PR TITLE
Fix Boolean Searcher's MustNotSearcher from advancing incorrectly

### DIFF
--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -356,10 +356,10 @@ func (s *BooleanSearcher) Advance(ctx *search.SearchContext, ID index.IndexInter
 		}
 
 		if s.mustNotSearcher != nil {
-			// Additional check for mustNotSearcher whose cursor isn't tracked by
-			// currentID to prevent it from moving when the searcher's already
-			// where it should be.
-			if s.currMustNot == nil || !s.currMustNot.IndexInternalID.Equals(ID) {
+			// Additional check for mustNotSearcher, whose cursor isn't tracked by
+			// currentID to prevent it from moving when the searcher's tracked
+			// position is already ahead of or at the requested ID.
+			if s.currMustNot == nil || s.currMustNot.IndexInternalID.Compare(ID) < 0 {
 				if s.currMustNot != nil {
 					ctx.DocumentMatchPool.Put(s.currMustNot)
 				}

--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -332,8 +332,14 @@ func (s *BooleanSearcher) Advance(ctx *search.SearchContext, ID index.IndexInter
 		}
 	}
 
-	// Advance the searcher only if the cursor is trailing the lookup ID
-	if s.currentID == nil || s.currentID.Compare(ID) < 0 {
+	// Advance the searchers only if the currentID cursor is trailing the lookup ID,
+	// additionally if the mustNotSearcher has been initialized, ensure that the
+	// cursor used to track the mustNotSearcher (currMustNot, which isn't tracked by
+	// currentID) is trailing the lookup ID as well - for in the case where currentID
+	// is nil and currMustNot is already at or ahead of the lookup ID, we MUST NOT
+	// advance the currentID or the currMustNot cursors.
+	if (s.currentID == nil || s.currentID.Compare(ID) < 0) &&
+		(s.currMustNot == nil || s.currMustNot.IndexInternalID.Compare(ID) < 0) {
 		var err error
 		if s.mustSearcher != nil {
 			if s.currMust != nil {
@@ -356,17 +362,12 @@ func (s *BooleanSearcher) Advance(ctx *search.SearchContext, ID index.IndexInter
 		}
 
 		if s.mustNotSearcher != nil {
-			// Additional check for mustNotSearcher, whose cursor isn't tracked by
-			// currentID to prevent it from moving when the searcher's tracked
-			// position is already ahead of or at the requested ID.
-			if s.currMustNot == nil || s.currMustNot.IndexInternalID.Compare(ID) < 0 {
-				if s.currMustNot != nil {
-					ctx.DocumentMatchPool.Put(s.currMustNot)
-				}
-				s.currMustNot, err = s.mustNotSearcher.Advance(ctx, ID)
-				if err != nil {
-					return nil, err
-				}
+			if s.currMustNot != nil {
+				ctx.DocumentMatchPool.Put(s.currMustNot)
+			}
+			s.currMustNot, err = s.mustNotSearcher.Advance(ctx, ID)
+			if err != nil {
+				return nil, err
 			}
 		}
 

--- a/search_test.go
+++ b/search_test.go
@@ -553,7 +553,7 @@ func TestNestedBooleanSearchers(t *testing.T) {
 	}
 }
 
-func TestNestedBooleanMustNotSearcher(t *testing.T) {
+func TestNestedBooleanMustNotSearcherUpsidedown(t *testing.T) {
 	// create an index with default settings
 	idxMapping := NewIndexMapping()
 	idx, err := New("testidx", idxMapping)
@@ -891,18 +891,23 @@ func TestMultipleNestedBooleanMustNotSearchersOnScorch(t *testing.T) {
 }
 
 func testBooleanMustNotSearcher(t *testing.T, indexName string) {
-	defer func() {
-		err := os.RemoveAll("testidx")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
 	im := NewIndexMapping()
 	idx, err := NewUsing("testidx", im, indexName, Config.DefaultKVStore, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	defer func() {
+		err = idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err := os.RemoveAll("testidx")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	docs := []struct {
 		Name    string


### PR DESCRIPTION
+ Noted incorrect advancing of the boolean's currMustNot position:
    [0xc4200b82c0] BOOL Advance to ID: 13965, currID: 13943, currMust: 13943, currMustNot: 13966
    [0xc4200b82c0] BOOL Advanced, now currID: 13965, currMust: 13965, currMustNot: 13967
+ Fix the incorrect comparison for Boolean searcher's MustNot cached entry
    - If the current position is already where it should be do not advance
    - If the position is only less than (and not just inequal) to the requested ID, advance
+ Unit tests (thanks @mschoch)
+ Addresses https://github.com/blevesearch/bleve/issues/1059