### PR TITLE
Index store writer

### DIFF
--- a/index/store/boltdb/reader.go
+++ b/index/store/boltdb/reader.go
@@ -15,6 +15,8 @@
 package boltdb
 
 import (
+	"io"
+
 	"github.com/blevesearch/bleve/index/store"
 	"github.com/boltdb/bolt"
 )
@@ -66,6 +68,11 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 
 	rv.Seek(start)
 	return rv
+}
+
+func (r *Reader) WriteTo(w io.Writer) error {
+	_, err := r.tx.WriteTo(w)
+	return err
 }
 
 func (r *Reader) Close() error {

--- a/index/store/boltdb/reader.go
+++ b/index/store/boltdb/reader.go
@@ -70,6 +70,12 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 	return rv
 }
 
+// As said in the BoltDB documentation:
+// You can use the Tx.WriteTo() function to write
+// a consistent view of the database to a writer.
+// If you call this from a read-only transaction,
+// it will perform a hot backup and not block
+// your other database reads and writes.
 func (r *Reader) WriteTo(w io.Writer) error {
 	_, err := r.tx.WriteTo(w)
 	return err

--- a/index/store/goleveldb/reader.go
+++ b/index/store/goleveldb/reader.go
@@ -15,6 +15,9 @@
 package goleveldb
 
 import (
+	"errors"
+	"io"
+
 	"github.com/blevesearch/bleve/index/store"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -60,6 +63,10 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 		iterator: iter,
 	}
 	return &rv
+}
+
+func (r *Reader) WriteTo(w io.Writer) error {
+	return errors.New("WriteTo ot implemented for goleveldb")
 }
 
 func (r *Reader) Close() error {

--- a/index/store/goleveldb/reader.go
+++ b/index/store/goleveldb/reader.go
@@ -66,7 +66,7 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 }
 
 func (r *Reader) WriteTo(w io.Writer) error {
-	return errors.New("WriteTo ot implemented for goleveldb")
+	return errors.New("WriteTo not implemented for goleveldb")
 }
 
 func (r *Reader) Close() error {

--- a/index/store/gtreap/reader.go
+++ b/index/store/gtreap/reader.go
@@ -18,8 +18,11 @@
 package gtreap
 
 import (
+	"io"
+
 	"github.com/blevesearch/bleve/index/store"
 
+	"errors"
 	"github.com/steveyen/gtreap"
 )
 
@@ -59,6 +62,10 @@ func (w *Reader) RangeIterator(start, end []byte) store.KVIterator {
 	}
 	rv.restart(&Item{k: start})
 	return &rv
+}
+
+func (r *Reader) WriteTo(w io.Writer) error {
+	return errors.New("WriteTo not implemented for gtreap")
 }
 
 func (w *Reader) Close() error {

--- a/index/store/kvstore.go
+++ b/index/store/kvstore.go
@@ -14,7 +14,10 @@
 
 package store
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"io"
+)
 
 // KVStore is an abstraction for working with KV stores.  Note that
 // in order to be used with the bleve.registry, it must also implement
@@ -59,6 +62,8 @@ type KVReader interface {
 	// RangeIterator returns a KVIterator that will
 	// visit all K/V pairs >= start AND < end
 	RangeIterator(start, end []byte) KVIterator
+
+	WriteTo(w io.Writer) error
 
 	// Close closes the iterator
 	Close() error

--- a/index/store/kvstore.go
+++ b/index/store/kvstore.go
@@ -63,6 +63,8 @@ type KVReader interface {
 	// visit all K/V pairs >= start AND < end
 	RangeIterator(start, end []byte) KVIterator
 
+	// WriteTo uses an io.Writer to write in the store.
+	// For now, it is only supported for boltdb store.
 	WriteTo(w io.Writer) error
 
 	// Close closes the iterator

--- a/index/store/metrics/reader.go
+++ b/index/store/metrics/reader.go
@@ -14,7 +14,12 @@
 
 package metrics
 
-import "github.com/blevesearch/bleve/index/store"
+import (
+	"errors"
+	"io"
+
+	"github.com/blevesearch/bleve/index/store"
+)
 
 type Reader struct {
 	s *Store
@@ -53,6 +58,10 @@ func (r *Reader) RangeIterator(start, end []byte) (i store.KVIterator) {
 		i = &Iterator{s: r.s, o: r.o.RangeIterator(start, end)}
 	})
 	return
+}
+
+func (r *Reader) WriteTo(w io.Writer) error {
+	return errors.New("WriteTo not implemented for metrics")
 }
 
 func (r *Reader) Close() error {

--- a/index/store/moss/reader.go
+++ b/index/store/moss/reader.go
@@ -15,6 +15,9 @@
 package moss
 
 import (
+	"errors"
+	"io"
+
 	"github.com/couchbase/moss"
 
 	"github.com/blevesearch/bleve/index/store"

--- a/index/store/moss/reader.go
+++ b/index/store/moss/reader.go
@@ -80,6 +80,10 @@ func (r *Reader) RangeIterator(start, end []byte) store.KVIterator {
 	return rv
 }
 
+func (r *Reader) WriteTo(w io.Writer) error {
+	return errors.New("WriteTo not implemented for moss")
+}
+
 func (r *Reader) Close() error {
 	return r.ss.Close()
 }

--- a/index/store/null/null.go
+++ b/index/store/null/null.go
@@ -15,6 +15,8 @@
 package null
 
 import (
+	"io"
+
 	"github.com/blevesearch/bleve/index/store"
 	"github.com/blevesearch/bleve/registry"
 )
@@ -55,6 +57,10 @@ func (r *reader) PrefixIterator(prefix []byte) store.KVIterator {
 
 func (r *reader) RangeIterator(start, end []byte) store.KVIterator {
 	return &iterator{}
+}
+
+func (r *reader) WriteTo(w io.Writer) error {
+	return nil
 }
 
 func (r *reader) Close() error {


### PR DESCRIPTION
In order to allow for replication, which is a common use case, I added the ()WriteTo function to the KVReader interface and implemented it for BoltDB.

Using the .Advanced() function, it is possible to access the Reader and use WriteTo(io.Writer) to replicate the store.

For example:
```golang
_, store, err := index.Advanced()
if err != nil {
   return err
}

r, err := store.Reader()
if err != nil {
   return err
}
defer r.Close()

tmpFile, err := ioutil.TempFile(path, "store.replicate.")
if err != nil {
   return err
}
defer tmpFile.Close()

err = r.WriteTo(tmpFile)
if err != nil {
   return err
}
```

I tested it locally and it works for my use case. Please let me know if there's anything I should add or change for this pull request to go through.

Thanks.