### PR TITLE
MB-32295: Optimization for conjunction/disjunction searchers

### DIFF
--- a/search/query/conjunction.go
+++ b/search/query/conjunction.go
@@ -74,7 +74,7 @@ func (q *ConjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
 	} else if len(ss) == 1 {
-        // return single nested searcher as is
+		// return single nested searcher as is
 		return ss[0], nil
 	}
 

--- a/search/query/disjunction.go
+++ b/search/query/disjunction.go
@@ -79,8 +79,8 @@ func (q *DisjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
-	} else if len(ss) == 1 {
-		// return the single nested searcher as is
+	} else if len(ss) == 1 && q.Min <= 1 {
+		// return the single nested searcher as is; only if min clauses is not greater than 1;
 		return ss[0], nil
 	}
 


### PR DESCRIPTION
If the number of nested searchers within a conjunction/disjunction
searcher is one, just return the nested searcher unwrapped as is, to
avoid an unnecessary level of indirection.