### PR TITLE
Fix query string number in query string query

### DIFF
--- a/search/query/query_string_lex.go
+++ b/search/query/query_string_lex.go
@@ -273,6 +273,7 @@ func inNumOrStrState(l *queryStringLex, next rune, eof bool) (lexState, bool) {
 	// see where to go
 	if !l.seenDot && next == '.' {
 		// stay in this state
+		l.seenDot = true
 		l.buf += string(next)
 		return inNumOrStrState, true
 	} else if unicode.IsDigit(next) {

--- a/search/query/query_string_parser_test.go
+++ b/search/query/query_string_parser_test.go
@@ -50,6 +50,16 @@ func TestQuerySyntaxParserValid(t *testing.T) {
 				nil),
 		},
 		{
+			input:   "127.0.0.1",
+			mapping: mapping.NewIndexMapping(),
+			result: NewBooleanQueryForQueryString(
+				nil,
+				[]Query{
+					NewMatchQuery("127.0.0.1"),
+				},
+				nil),
+		},
+		{
 			input:   `"test phrase 1"`,
 			mapping: mapping.NewIndexMapping(),
 			result: NewBooleanQueryForQueryString(


### PR DESCRIPTION
Query string query lexer reads IP addresses as tNUMBER instead of tSTRING.

The error is in the **inNumOrStrState** (_search/query/query_string_lex.go_) function where the **seenDot** field of the lexer is never set to true:

```go
// see where to go
if !l.seenDot && next == '.' {
    // stay in this state
    l.buf += string(next)
    return inNumOrStrState, true
}
```

This PR fixes this issue.

