### PR TITLE
MB-31974 - Streaming search results

### DIFF
--- a/search/collector.go
+++ b/search/collector.go
@@ -30,3 +30,23 @@ type Collector interface {
 	SetFacetsBuilder(facetsBuilder *FacetsBuilder)
 	FacetResults() FacetResults
 }
+
+// DocumentMatchHandler is the type of document match callback
+// bleve will invoke during the search.
+// Eventually, bleve will indicate the completion of an ongoing search,
+// by passing a nil value for the document match callback.
+// The application should take a copy of the hit/documentMatch
+// if it wish to own it or need prolonged access to it.
+type DocumentMatchHandler func(hit *DocumentMatch) error
+
+type MakeDocumentMatchHandlerKeyType string
+
+var MakeDocumentMatchHandlerKey = MakeDocumentMatchHandlerKeyType(
+	"MakeDocumentMatchHandlerKey")
+
+// MakeDocumentMatchHandler is an optional DocumentMatchHandler
+// builder function which the applications can pass to bleve.
+// These builder methods gives a DocumentMatchHandler function
+// to bleve, which it will invoke on every document matches.
+type MakeDocumentMatchHandler  func(ctx *SearchContext) (
+	callback DocumentMatchHandler, loadID bool, err error)

--- a/search/search.go
+++ b/search/search.go
@@ -285,6 +285,7 @@ type SearcherOptions struct {
 // SearchContext represents the context around a single search
 type SearchContext struct {
 	DocumentMatchPool *DocumentMatchPool
+	Collector Collector
 }
 
 func (sc *SearchContext) Size() int {


### PR DESCRIPTION
Adding optional builder/maker callbacks for the
document match handlers from applications.
These builder method gives back a threadsafe
document match handler callback for bleve which
it will invoke for every document hit during
a search.
The application should make its own copy of
the hit/documentMatch in the callback if it
wish to hold on to data.
