### PR TITLE
API change - optimize scorch non-scoring, no-term-vector disjunctions & conjunctions

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -341,11 +341,19 @@ type Optimizable interface {
 	Optimize(kind string, octx OptimizableContext) (OptimizableContext, error)
 }
 
+// Represents a result of optimization -- see the Finish() method.
+type Optimized interface{}
+
 type OptimizableContext interface {
 	// Once all the optimzable resources have been provided the same
 	// OptimizableContext instance, the optimization preparations are
 	// finished or completed via the Finish() method.
-	Finish() error
+	//
+	// Depending on the optimization being performed, the Finish()
+	// method might return a non-nil Optimized instance.  For example,
+	// the Optimized instance might represent an optimized
+	// TermFieldReader instance.
+	Finish() (Optimized, error)
 }
 
 type DocValueReader interface {

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -53,9 +53,9 @@ type OptimizeTFRConjunction struct {
 	tfrs []*IndexSnapshotTermFieldReader
 }
 
-func (o *OptimizeTFRConjunction) Finish() error {
+func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 	if len(o.tfrs) <= 1 {
-		return nil
+		return nil, nil
 	}
 
 	for i := range o.snapshot.segment {
@@ -89,5 +89,5 @@ func (o *OptimizeTFRConjunction) Finish() error {
 		}
 	}
 
-	return nil
+	return nil, nil
 }

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -20,15 +20,27 @@ import (
 	"github.com/RoaringBitmap/roaring"
 
 	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/scorch/segment"
 	"github.com/blevesearch/bleve/index/scorch/segment/zap"
 )
 
-func (s *IndexSnapshotTermFieldReader) Optimize(kind string, octx index.OptimizableContext) (
-	index.OptimizableContext, error) {
-	if kind != "conjunction" {
-		return octx, nil
+func (s *IndexSnapshotTermFieldReader) Optimize(kind string,
+	octx index.OptimizableContext) (index.OptimizableContext, error) {
+	if kind == "conjunction" {
+		return s.optimizeConjunction(octx)
 	}
 
+	if kind == "disjunction:unadorned" {
+		return s.optimizeDisjunctionUnadorned(octx)
+	}
+
+	return octx, nil
+}
+
+// ----------------------------------------------------------------
+
+func (s *IndexSnapshotTermFieldReader) optimizeConjunction(
+	octx index.OptimizableContext) (index.OptimizableContext, error) {
 	if octx == nil {
 		octx = &OptimizeTFRConjunction{snapshot: s.snapshot}
 	}
@@ -39,7 +51,7 @@ func (s *IndexSnapshotTermFieldReader) Optimize(kind string, octx index.Optimiza
 	}
 
 	if o.snapshot != s.snapshot {
-		return nil, fmt.Errorf("tried to optimize across different snapshots")
+		return nil, fmt.Errorf("tried to optimize conjunction across different snapshots")
 	}
 
 	o.tfrs = append(o.tfrs, s)
@@ -80,6 +92,8 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 			bm.And(itr.ActualBM)
 		}
 
+		// in this conjunction optimization, the postings iterators
+		// will all share the same AND'ed together actual bitmap
 		for _, tfr := range o.tfrs {
 			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
 			if ok && itr.ActualBM != nil {
@@ -90,4 +104,109 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 	}
 
 	return nil, nil
+}
+
+// ----------------------------------------------------------------
+
+// An "unadorned" disjunction optimization is appropriate when
+// additional or subsidiary information like freq-norm's and
+// term-vectors are not required, and instead only the internal-id's
+// are needed.
+func (s *IndexSnapshotTermFieldReader) optimizeDisjunctionUnadorned(
+	octx index.OptimizableContext) (index.OptimizableContext, error) {
+	if octx == nil {
+		octx = &OptimizeTFRDisjunctionUnadorned{snapshot: s.snapshot}
+	}
+
+	o, ok := octx.(*OptimizeTFRDisjunctionUnadorned)
+	if !ok {
+		return nil, nil
+	}
+
+	if o.snapshot != s.snapshot {
+		return nil, fmt.Errorf("tried to optimize unadorned disjunction across different snapshots")
+	}
+
+	o.tfrs = append(o.tfrs, s)
+
+	return o, nil
+}
+
+type OptimizeTFRDisjunctionUnadorned struct {
+	snapshot *IndexSnapshot
+
+	tfrs []*IndexSnapshotTermFieldReader
+}
+
+var OptimizeTFRDisjunctionUnadornedTerm = []byte("<disjunction:unadorned>")
+var OptimizeTFRDisjunctionUnadornedField = "*"
+
+// Finish of an unadorned disjunction optimization will compute a
+// termFieldReader with an "actual" bitmap that represents the
+// constituent bitmaps OR'ed together.  This termFieldReader cannot
+// provide any freq-norm or termVector associated information.
+func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err error) {
+	if len(o.tfrs) <= 1 {
+		return nil, nil
+	}
+
+	// We use an artificial term and field because the optimized
+	// termFieldReader can represent multiple terms and fields.
+	oTFR := &IndexSnapshotTermFieldReader{
+		term:               OptimizeTFRDisjunctionUnadornedTerm,
+		field:              OptimizeTFRDisjunctionUnadornedField,
+		snapshot:           o.snapshot,
+		iterators:          make([]segment.PostingsIterator, len(o.snapshot.segment)),
+		segmentOffset:      0,
+		includeFreq:        false,
+		includeNorm:        false,
+		includeTermVectors: false,
+	}
+
+	var docNums []uint32            // Collected docNum's from 1-hit posting lists.
+	var actualBMs []*roaring.Bitmap // Collected from regular posting lists.
+
+	for i := range o.snapshot.segment {
+		docNums = docNums[:0]
+		actualBMs = actualBMs[:0]
+
+		for _, tfr := range o.tfrs {
+			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			if !ok {
+				return nil, nil
+			}
+
+			docNum, ok := itr.DocNum1Hit()
+			if ok {
+				docNums = append(docNums, uint32(docNum))
+				continue
+			}
+
+			if itr.ActualBM != nil {
+				actualBMs = append(actualBMs, itr.ActualBM)
+			}
+		}
+
+		var bm *roaring.Bitmap
+		if len(actualBMs) > 2 {
+			bm = roaring.HeapOr(actualBMs...)
+		} else if len(actualBMs) == 2 {
+			bm = roaring.Or(actualBMs[0], actualBMs[1])
+		} else if len(actualBMs) == 1 {
+			bm = actualBMs[0].Clone()
+		}
+
+		if bm == nil {
+			bm = roaring.New()
+		}
+
+		bm.AddMany(docNums)
+
+		oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(bm, false, false)
+		if err != nil {
+			return nil, nil
+		}
+	}
+
+	return oTFR, nil
 }

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -24,17 +24,21 @@ import (
 	"github.com/blevesearch/bleve/index/scorch/segment/zap"
 )
 
+var OptimizeConjunction = true
+var OptimizeConjunctionUnadorned = true
+var OptimizeDisjunctionUnadorned = true
+
 func (s *IndexSnapshotTermFieldReader) Optimize(kind string,
 	octx index.OptimizableContext) (index.OptimizableContext, error) {
-	if kind == "conjunction" {
+	if OptimizeConjunction && kind == "conjunction" {
 		return s.optimizeConjunction(octx)
 	}
 
-	if kind == "conjunction:unadorned" {
+	if OptimizeConjunctionUnadorned && kind == "conjunction:unadorned" {
 		return s.optimizeConjunctionUnadorned(octx)
 	}
 
-	if kind == "disjunction:unadorned" {
+	if OptimizeDisjunctionUnadorned && kind == "disjunction:unadorned" {
 		return s.optimizeDisjunctionUnadorned(octx)
 	}
 

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -30,6 +30,10 @@ func (s *IndexSnapshotTermFieldReader) Optimize(kind string,
 		return s.optimizeConjunction(octx)
 	}
 
+	if kind == "conjunction:unadorned" {
+		return s.optimizeConjunctionUnadorned(octx)
+	}
+
 	if kind == "disjunction:unadorned" {
 		return s.optimizeDisjunctionUnadorned(octx)
 	}
@@ -95,7 +99,9 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 		}
 
 		// in this conjunction optimization, the postings iterators
-		// will all share the same AND'ed together actual bitmap
+		// will all share the same AND'ed together actual bitmap.  The
+		// regular conjunction searcher machinery will still be used,
+		// but the underlying bitmap will be smaller.
 		for _, tfr := range o.tfrs {
 			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
 			if ok && itr.ActualBM != nil {
@@ -106,6 +112,177 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 	}
 
 	return nil, nil
+}
+
+// ----------------------------------------------------------------
+
+// An "unadorned" conjunction optimization is appropriate when
+// additional or subsidiary information like freq-norm's and
+// term-vectors are not required, and instead only the internal-id's
+// are needed.
+func (s *IndexSnapshotTermFieldReader) optimizeConjunctionUnadorned(
+	octx index.OptimizableContext) (index.OptimizableContext, error) {
+	if octx == nil {
+		octx = &OptimizeTFRConjunctionUnadorned{snapshot: s.snapshot}
+	}
+
+	o, ok := octx.(*OptimizeTFRConjunctionUnadorned)
+	if !ok {
+		return nil, nil
+	}
+
+	if o.snapshot != s.snapshot {
+		return nil, fmt.Errorf("tried to optimize unadorned conjunction across different snapshots")
+	}
+
+	o.tfrs = append(o.tfrs, s)
+
+	return o, nil
+}
+
+type OptimizeTFRConjunctionUnadorned struct {
+	snapshot *IndexSnapshot
+
+	tfrs []*IndexSnapshotTermFieldReader
+}
+
+var OptimizeTFRConjunctionUnadornedTerm = []byte("<conjunction:unadorned>")
+var OptimizeTFRConjunctionUnadornedField = "*"
+
+// Finish of an unadorned conjunction optimization will compute a
+// termFieldReader with an "actual" bitmap that represents the
+// constituent bitmaps AND'ed together.  This termFieldReader cannot
+// provide any freq-norm or termVector associated information.
+func (o *OptimizeTFRConjunctionUnadorned) Finish() (rv index.Optimized, err error) {
+	if len(o.tfrs) <= 1 {
+		return nil, nil
+	}
+
+	// We use an artificial term and field because the optimized
+	// termFieldReader can represent multiple terms and fields.
+	oTFR := &IndexSnapshotTermFieldReader{
+		term:               OptimizeTFRConjunctionUnadornedTerm,
+		field:              OptimizeTFRConjunctionUnadornedField,
+		snapshot:           o.snapshot,
+		iterators:          make([]segment.PostingsIterator, len(o.snapshot.segment)),
+		segmentOffset:      0,
+		includeFreq:        false,
+		includeNorm:        false,
+		includeTermVectors: false,
+	}
+
+	var actualBMs []*roaring.Bitmap // Collected from regular posting lists.
+
+OUTER:
+	for i := range o.snapshot.segment {
+		actualBMs = actualBMs[:0]
+
+		var docNum1HitLast uint64
+		var docNum1HitLastOk bool
+
+		for _, tfr := range o.tfrs {
+			if _, ok := tfr.iterators[i].(*segment.EmptyPostingsIterator); ok {
+				// An empty postings iterator means the entire AND is empty.
+				oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+				continue OUTER
+			}
+
+			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			if !ok {
+				// We optimize zap postings iterators only.
+				return nil, nil
+			}
+
+			// If the postings iterator is "1-hit" optimized, then we
+			// can perform several optimizations up-front here.
+			docNum1Hit, ok := itr.DocNum1Hit()
+			if ok {
+				if docNum1Hit == zap.DocNum1HitFinished {
+					// An empty docNum here means the entire AND is empty.
+					oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+					continue OUTER
+				}
+
+				if docNum1HitLastOk && docNum1HitLast != docNum1Hit {
+					// The docNum1Hit doesn't match the previous
+					// docNum1HitLast, so the entire AND is empty.
+					oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+					continue OUTER
+				}
+
+				docNum1HitLast = docNum1Hit
+				docNum1HitLastOk = true
+
+				continue
+			}
+
+			if itr.ActualBM == nil {
+				// An empty actual bitmap means the entire AND is empty.
+				oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+				continue OUTER
+			}
+
+			// Collect the actual bitmap for more processing later.
+			actualBMs = append(actualBMs, itr.ActualBM)
+		}
+
+		if docNum1HitLastOk {
+			// We reach here if all the 1-hit optimized posting
+			// iterators had the same 1-hit docNum, so we can check if
+			// our collected actual bitmaps also have that docNum.
+			for _, bm := range actualBMs {
+				if !bm.Contains(uint32(docNum1HitLast)) {
+					// The docNum1Hit isn't in one of our actual
+					// bitmaps, so the entire AND is empty.
+					oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+					continue OUTER
+				}
+			}
+
+			// The actual bitmaps and docNum1Hits all contain or have
+			// the same 1-hit docNum, so that's our AND'ed result.
+			oTFR.iterators[i], err = zap.PostingsIteratorFrom1Hit(
+				docNum1HitLast, zap.NormBits1Hit, false, false)
+			if err != nil {
+				return nil, nil
+			}
+
+			continue OUTER
+		}
+
+		if len(actualBMs) == 0 {
+			// If we've collected no actual bitmaps at this point,
+			// then the entire AND is empty.
+			oTFR.iterators[i] = segment.AnEmptyPostingsIterator
+			continue OUTER
+		}
+
+		if len(actualBMs) == 1 {
+			// If we've only 1 actual bitmap, then that's our result.
+			oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(
+				actualBMs[0], false, false)
+			if err != nil {
+				return nil, nil
+			}
+
+			continue OUTER
+		}
+
+		// Else, AND together our collected bitmaps as our result.
+		bm := roaring.And(actualBMs[0], actualBMs[1])
+
+		for _, actualBM := range actualBMs[2:] {
+			bm.And(actualBM)
+		}
+
+		oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(
+			bm, false, false)
+		if err != nil {
+			return nil, nil
+		}
+	}
+
+	return oTFR, nil
 }
 
 // ----------------------------------------------------------------

--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -125,3 +125,5 @@ func (e *EmptyPostingsIterator) Next() (Posting, error) {
 func (e *EmptyPostingsIterator) Size() int {
 	return 0
 }
+
+var AnEmptyPostingsIterator = &EmptyPostingsIterator{}

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -435,7 +435,7 @@ func (i *IndexSnapshot) InternalID(id string) (rv index.IndexInternalID, err err
 }
 
 func (i *IndexSnapshot) TermFieldReader(term []byte, field string, includeFreq,
-	includeNorm, includeTermVectors bool) (tfr index.TermFieldReader, err error) {
+	includeNorm, includeTermVectors bool) (index.TermFieldReader, error) {
 	rv := i.allocTermFieldReaderDicts(field)
 
 	rv.term = term

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -74,7 +74,7 @@ func (i *IndexSnapshotTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*in
 		rv = &index.TermFieldDoc{}
 	}
 	// find the next hit
-	for i.segmentOffset < len(i.postings) {
+	for i.segmentOffset < len(i.iterators) {
 		next, err := i.iterators[i.segmentOffset].Next()
 		if err != nil {
 			return nil, err

--- a/index_impl.go
+++ b/index_impl.go
@@ -458,6 +458,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	searcher, err := req.Query.Searcher(indexReader, i.m, search.SearcherOptions{
 		Explain:            req.Explain,
 		IncludeTermVectors: req.IncludeLocations || req.Highlight != nil,
+		NoScore:            req.NoScore,
 	})
 	if err != nil {
 		return nil, err

--- a/index_impl.go
+++ b/index_impl.go
@@ -458,7 +458,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	searcher, err := req.Query.Searcher(indexReader, i.m, search.SearcherOptions{
 		Explain:            req.Explain,
 		IncludeTermVectors: req.IncludeLocations || req.Highlight != nil,
-		NoScore:            req.NoScore,
+		Score:              req.Score,
 	})
 	if err != nil {
 		return nil, err

--- a/search.go
+++ b/search.go
@@ -261,6 +261,7 @@ func (h *HighlightRequest) AddField(field string) {
 // Explain triggers inclusion of additional search
 // result score explanations.
 // Sort describes the desired order for the results to be returned.
+// Score controls the kind of scoring performed
 //
 // A special field named "*" can be used to return all fields.
 type SearchRequest struct {
@@ -273,7 +274,7 @@ type SearchRequest struct {
 	Explain          bool              `json:"explain"`
 	Sort             search.SortOrder  `json:"sort"`
 	IncludeLocations bool              `json:"includeLocations"`
-	NoScore          bool              `json:"noScore"`
+	Score            string            `json:"score,omitempty"`
 }
 
 func (r *SearchRequest) Validate() error {
@@ -323,6 +324,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		Explain          bool              `json:"explain"`
 		Sort             []json.RawMessage `json:"sort"`
 		IncludeLocations bool              `json:"includeLocations"`
+		Score            string            `json:"score"`
 	}
 
 	err := json.Unmarshal(input, &temp)
@@ -349,6 +351,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	r.Fields = temp.Fields
 	r.Facets = temp.Facets
 	r.IncludeLocations = temp.IncludeLocations
+	r.Score = temp.Score
 	r.Query, err = query.ParseQuery(temp.Q)
 	if err != nil {
 		return err

--- a/search.go
+++ b/search.go
@@ -273,6 +273,7 @@ type SearchRequest struct {
 	Explain          bool              `json:"explain"`
 	Sort             search.SortOrder  `json:"sort"`
 	IncludeLocations bool              `json:"includeLocations"`
+	NoScore          bool              `json:"noScore"`
 }
 
 func (r *SearchRequest) Validate() error {

--- a/search/search.go
+++ b/search/search.go
@@ -280,7 +280,7 @@ type Searcher interface {
 type SearcherOptions struct {
 	Explain            bool
 	IncludeTermVectors bool
-	NoScore            bool
+	Score              string
 }
 
 // SearchContext represents the context around a single search

--- a/search/search.go
+++ b/search/search.go
@@ -280,6 +280,7 @@ type Searcher interface {
 type SearcherOptions struct {
 	Explain            bool
 	IncludeTermVectors bool
+	NoScore            bool
 }
 
 // SearchContext represents the context around a single search

--- a/search/searcher/base_test.go
+++ b/search/searcher/base_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/blevesearch/bleve/index/upsidedown"
 )
 
-var twoDocIndex index.Index //= upside_down.NewUpsideDownCouch(inmem.MustOpen())
+var twoDocIndex index.Index
 
 func init() {
 	twoDocIndex = initTwoDocUpsideDown()

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -55,7 +55,8 @@ func NewConjunctionSearcher(indexReader index.IndexReader,
 
 	// attempt the "unadorned" conjunction optimization only when we
 	// do not need extra information like freq-norm's or term vectors
-	if len(searchers) > 1 && options.NoScore && !options.IncludeTermVectors {
+	if len(searchers) > 1 &&
+		options.Score == "none" && !options.IncludeTermVectors {
 		rv, err := optimizeCompositeSearcher("conjunction:unadorned",
 			indexReader, searchers, options)
 		if err != nil || rv != nil {

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -77,7 +77,7 @@ func NewConjunctionSearcher(indexReader index.IndexReader, qsearchers []search.S
 		}
 
 		if octx != nil {
-			err := octx.Finish()
+			_, err := octx.Finish()
 			if err != nil {
 				return nil, err
 			}

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -15,14 +15,17 @@
 package searcher
 
 import (
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/scorch"
 	"github.com/blevesearch/bleve/search"
 )
 
 func TestConjunctionSearch(t *testing.T) {
-
 	twoDocIndexReader, err := twoDocIndex.Reader()
 	if err != nil {
 		t.Error(err)
@@ -218,6 +221,192 @@ func TestConjunctionSearch(t *testing.T) {
 		}
 		if len(test.results) != i {
 			t.Errorf("expected %d results got %d for test %d", len(test.results), i, testIndex)
+		}
+	}
+}
+
+type compositeSearchOptimizationTest struct {
+	fieldTerms  []string
+	expectEmpty string
+}
+
+func TestScorchCompositeSearchOptimizations(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "scorchTwoDoc")
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	twoDocIndex := initTwoDocScorch(dir)
+
+	twoDocIndexReader, err := twoDocIndex.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := twoDocIndexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	tests := []compositeSearchOptimizationTest{
+		{fieldTerms: []string{},
+			expectEmpty: "conjunction,disjunction"},
+		{fieldTerms: []string{"name:marty"},
+			expectEmpty: ""},
+		{fieldTerms: []string{"name:marty", "desc:beer"},
+			expectEmpty: ""},
+		{fieldTerms: []string{"name:marty", "name:marty"},
+			expectEmpty: ""},
+		{fieldTerms: []string{"name:marty", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: "conjunction"},
+		{fieldTerms: []string{"name:steve", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: ""},
+
+		{fieldTerms: []string{"name:NotARealName"},
+			expectEmpty: "conjunction,disjunction"},
+		{fieldTerms: []string{"name:NotARealName", "name:marty"},
+			expectEmpty: "conjunction"},
+		{fieldTerms: []string{"name:NotARealName", "name:marty", "desc:beer"},
+			expectEmpty: "conjunction"},
+		{fieldTerms: []string{"name:NotARealName", "name:marty", "name:marty"},
+			expectEmpty: "conjunction"},
+		{fieldTerms: []string{"name:NotARealName", "name:marty", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: "conjunction"},
+	}
+
+	// The theme of this unit test is that given one of the above
+	// search test cases -- no matter what searcher options we
+	// provide, across either conjunctions or disjunctions, whether we
+	// have optimizations that are enabled or disabled, the set of doc
+	// ID's from the search results from any of those combinations
+	// should be the same.
+	searcherOptionsToCompare := []search.SearcherOptions{
+		search.SearcherOptions{},
+		search.SearcherOptions{Explain: true},
+		search.SearcherOptions{IncludeTermVectors: true},
+		search.SearcherOptions{IncludeTermVectors: true, Explain: true},
+		search.SearcherOptions{Score: "none"},
+		search.SearcherOptions{Score: "none", IncludeTermVectors: true},
+		search.SearcherOptions{Score: "none", IncludeTermVectors: true, Explain: true},
+		search.SearcherOptions{Score: "none", Explain: true},
+	}
+
+	testScorchCompositeSearchOptimizations(t, twoDocIndexReader, tests,
+		searcherOptionsToCompare, "conjunction")
+
+	testScorchCompositeSearchOptimizations(t, twoDocIndexReader, tests,
+		searcherOptionsToCompare, "disjunction")
+}
+
+func testScorchCompositeSearchOptimizations(t *testing.T, indexReader index.IndexReader,
+	tests []compositeSearchOptimizationTest,
+	searcherOptionsToCompare []search.SearcherOptions,
+	compositeKind string) {
+	for testi := range tests {
+		resultsToCompare := map[string]bool{}
+
+		testScorchCompositeSearchOptimizationsHelper(t, indexReader, tests, testi,
+			searcherOptionsToCompare, compositeKind, false, resultsToCompare)
+
+		testScorchCompositeSearchOptimizationsHelper(t, indexReader, tests, testi,
+			searcherOptionsToCompare, compositeKind, true, resultsToCompare)
+	}
+}
+
+func testScorchCompositeSearchOptimizationsHelper(
+	t *testing.T, indexReader index.IndexReader,
+	tests []compositeSearchOptimizationTest, testi int,
+	searcherOptionsToCompare []search.SearcherOptions,
+	compositeKind string, allowOptimizations bool, resultsToCompare map[string]bool) {
+	// Save the global allowed optimization settings to restore later.
+	optimizeConjunction := scorch.OptimizeConjunction
+	optimizeConjunctionUnadorned := scorch.OptimizeConjunctionUnadorned
+	optimizeDisjunctionUnadorned := scorch.OptimizeDisjunctionUnadorned
+	optimizeDisjunctionUnadornedMinChildCardinality :=
+		scorch.OptimizeDisjunctionUnadornedMinChildCardinality
+
+	scorch.OptimizeConjunction = allowOptimizations
+	scorch.OptimizeConjunctionUnadorned = allowOptimizations
+	scorch.OptimizeDisjunctionUnadorned = allowOptimizations
+
+	if allowOptimizations {
+		scorch.OptimizeDisjunctionUnadornedMinChildCardinality = uint64(0)
+	}
+
+	defer func() {
+		scorch.OptimizeConjunction = optimizeConjunction
+		scorch.OptimizeConjunctionUnadorned = optimizeConjunctionUnadorned
+		scorch.OptimizeDisjunctionUnadorned = optimizeDisjunctionUnadorned
+		scorch.OptimizeDisjunctionUnadornedMinChildCardinality =
+			optimizeDisjunctionUnadornedMinChildCardinality
+	}()
+
+	test := tests[testi]
+
+	for searcherOptionsI, searcherOptions := range searcherOptionsToCompare {
+		// Construct the leaf term searchers.
+		var searchers []search.Searcher
+
+		for _, fieldTerm := range test.fieldTerms {
+			ft := strings.Split(fieldTerm, ":")
+			field := ft[0]
+			term := ft[1]
+
+			searcher, err := NewTermSearcher(indexReader, term, field, 1.0, searcherOptions)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			searchers = append(searchers, searcher)
+		}
+
+		// Construct the composite searcher.
+		var cs search.Searcher
+		var err error
+		if compositeKind == "conjunction" {
+			cs, err = NewConjunctionSearcher(indexReader, searchers, searcherOptions)
+		} else {
+			cs, err = NewDisjunctionSearcher(indexReader, searchers, 0, searcherOptions)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &search.SearchContext{
+			DocumentMatchPool: search.NewDocumentMatchPool(10, 0),
+		}
+
+		next, err := cs.Next(ctx)
+		i := 0
+		for err == nil && next != nil {
+			docID, err := indexReader.ExternalID(next.IndexInternalID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if searcherOptionsI == 0 && allowOptimizations == false {
+				resultsToCompare[string(docID)] = true
+			} else {
+				if !resultsToCompare[string(docID)] {
+					t.Errorf("missing %s", string(docID))
+				}
+			}
+
+			next, err = cs.Next(ctx)
+			i++
+		}
+
+		if i != len(resultsToCompare) {
+			t.Errorf("mismatched count, %d vs %d", i, len(resultsToCompare))
+		}
+
+		if i == 0 && !strings.Contains(test.expectEmpty, compositeKind) {
+			t.Errorf("testi: %d, compositeKind: %s, allowOptimizations: %t,"+
+				" searcherOptionsI: %d, searcherOptions: %#v,"+
+				" expected some results but got no results on test: %#v",
+				testi, compositeKind, allowOptimizations,
+				searcherOptionsI, searcherOptions, test)
 		}
 	}
 }

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -44,7 +44,7 @@ func newDisjunctionSearcher(indexReader index.IndexReader,
 	// do not need extra information like freq-norm's or term vectors
 	// and the requested min is simple
 	if len(qsearchers) > 1 && min <= 1 &&
-		options.NoScore && !options.IncludeTermVectors {
+		options.Score == "none" && !options.IncludeTermVectors {
 		rv, err := optimizeCompositeSearcher("disjunction:unadorned",
 			indexReader, qsearchers, options)
 		if err != nil || rv != nil {

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -61,8 +61,8 @@ func optimizeDisjunctionSearcher(indexReader index.IndexReader,
 	search.Searcher, error) {
 	// we cannot use the "unadorned" disjunction optimization if the
 	// caller wants extra information like freq-norm's for scoring or
-	// term vectors
-	if len(qsearchers) <= 1 || !options.NoScore || options.IncludeTermVectors {
+	// term vectors, or leverages the min feature
+	if len(qsearchers) <= 1 || min > 1 || !options.NoScore || options.IncludeTermVectors {
 		return nil, nil
 	}
 

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 type PhraseSearcher struct {
-	mustSearcher *ConjunctionSearcher
+	mustSearcher search.Searcher
 	queryNorm    float64
 	currMust     *search.DocumentMatch
 	terms        [][]string

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -39,7 +39,8 @@ type TermSearcher struct {
 
 func NewTermSearcher(indexReader index.IndexReader, term string, field string, boost float64, options search.SearcherOptions) (*TermSearcher, error) {
 	termBytes := []byte(term)
-	reader, err := indexReader.TermFieldReader(termBytes, field, true, true, options.IncludeTermVectors)
+	needFreqNorm := !options.NoScore
+	reader, err := indexReader.TermFieldReader(termBytes, field, needFreqNorm, needFreqNorm, options.IncludeTermVectors)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,8 @@ func NewTermSearcher(indexReader index.IndexReader, term string, field string, b
 }
 
 func NewTermSearcherBytes(indexReader index.IndexReader, term []byte, field string, boost float64, options search.SearcherOptions) (*TermSearcher, error) {
-	reader, err := indexReader.TermFieldReader(term, field, true, true, options.IncludeTermVectors)
+	needFreqNorm := !options.NoScore
+	reader, err := indexReader.TermFieldReader(term, field, needFreqNorm, needFreqNorm, options.IncludeTermVectors)
 	if err != nil {
 		return nil, err
 	}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -42,7 +42,7 @@ func NewTermSearcher(indexReader index.IndexReader, term string, field string, b
 }
 
 func NewTermSearcherBytes(indexReader index.IndexReader, term []byte, field string, boost float64, options search.SearcherOptions) (*TermSearcher, error) {
-	needFreqNorm := !options.NoScore
+	needFreqNorm := options.Score != "none"
 	reader, err := indexReader.TermFieldReader(term, field, needFreqNorm, needFreqNorm, options.IncludeTermVectors)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds...

1) an API to allow applications to optionally specify in a search request that the additional information of scoring and locations are not needed.  

2) these so-called "unadorned" search requests might also be comprised of disjunctions of term searches -- where these disjunctions might be optimized by the scorch indexing layer by OR()'ing the constituent bitmaps.

Regarding perf microbenchmarks (bleve-query) on a 200K en-wiki docs scorch index...
```
  for a high number of high-frequency terms...
    
    - wildcard search on "th*" (~31K hits)...
        before the change, with normal scoring         -  ~4.7 q/sec
        w/ NoScore:true                                -  ~5.1 q/sec
        w/ NoScore:true & unadorned disj. optimization - ~11.6 q/sec
    
  for a low number of high-frequency terms...
    
    - query-string search on "http www com" (~25K hits)...
        before the change, with normal scoring         - ~190 q/sec
        w/ NoScore:true                                - ~260 q/sec
        w/ NoScore:true & unadorned disj. optimization - ~415 q/sec
```