### PR TITLE
MB-32855: Applying the disjunction 1-clause optimization

### DIFF
--- a/search/query/disjunction.go
+++ b/search/query/disjunction.go
@@ -80,12 +80,10 @@ func (q *DisjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
-	} else if len(ss) == 1 && q.Min <= 1 {
-		// update min setting of child searcher if supported; and return the
-		// single child searcher as is when min is not greater than 1.
-		if searcher, ok := ss[0].(minApplicableSearcher); ok {
-			searcher.SetMin(int(q.Min))
-		}
+	} else if len(ss) == 1 && int(q.Min) == ss[0].Min() {
+		// apply optimization only if both conditions below are satisfied:
+		// - disjunction searcher has only 1 child searcher
+		// - parent searcher's min setting is equal to child searcher's min
 
 		return ss[0], nil
 	}

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -63,13 +63,6 @@ type ValidatableQuery interface {
 	Validate() error
 }
 
-// A Searcher to which the "min" setting is applicable, and supports
-// updates to the setting.
-type minApplicableSearcher interface {
-	search.Searcher
-	SetMin(int)
-}
-
 // ParseQuery deserializes a JSON representation of
 // a Query object.
 func ParseQuery(input []byte) (Query, error) {

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -290,10 +290,6 @@ func (s *DisjunctionHeapSearcher) Min() int {
 	return s.min
 }
 
-func (s *DisjunctionHeapSearcher) SetMin(to int) {
-	s.min = to
-}
-
 func (s *DisjunctionHeapSearcher) DocumentMatchPoolSize() int {
 	rv := len(s.searchers)
 	for _, s := range s.searchers {

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -274,10 +274,6 @@ func (s *DisjunctionSliceSearcher) Min() int {
 	return s.min
 }
 
-func (s *DisjunctionSliceSearcher) SetMin(to int) {
-	s.min = to
-}
-
 func (s *DisjunctionSliceSearcher) DocumentMatchPoolSize() int {
 	rv := len(s.currs)
 	for _, s := range s.searchers {


### PR DESCRIPTION
+ This optimization can be applied only when ..
    - The parent disjunction searcher has only 1 child searcher.
    - The 1 child searcher's min is the same as the parent's min.
+ This means that the "min" setting doesn't need to be propagated.