### PR TITLE
MB-32855: Revert conjunction-single clause optimization

### DIFF
--- a/search/query/conjunction.go
+++ b/search/query/conjunction.go
@@ -73,9 +73,6 @@ func (q *ConjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
-	} else if len(ss) == 1 {
-		// return single nested searcher as is
-		return ss[0], nil
 	}
 
 	return searcher.NewConjunctionSearcher(i, ss, options)


### PR DESCRIPTION
Reverting the single-clause conjunction optimization for now,
as we're noticing unexpected results while executing a boolean
query in certain scenarios.