### PR TITLE
add support for configuring the boltdb initialMmapSize option

### DIFF
--- a/index/store/boltdb/store.go
+++ b/index/store/boltdb/store.go
@@ -74,6 +74,12 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 		bo.ReadOnly = ro
 	}
 
+	if initialMmapSize, ok := config["initialMmapSize"].(int); ok {
+		bo.InitialMmapSize = initialMmapSize
+	} else if initialMmapSize, ok := config["initialMmapSize"].(float64); ok {
+		bo.InitialMmapSize = int(initialMmapSize)
+	}
+
 	db, err := bolt.Open(path, 0600, bo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Without this option, sometimes committing a write Tx will block
until all ongoing read Txs finish.  If your application supports
running long searches, this may result in unacceptable delays
to indexing the data.

By setting this value to a very large value (say 1TB), you can
ensure that bolt will never need to remap to complete the
write Tx.  On 64-bit systems this may be an acceptable trade-off.

See also:
https://github.com/boltdb/bolt/issues/240
https://github.com/boltdb/bolt/issues/489