### PR TITLE
Re-enabling conjunction single clause optimization conditionally

### DIFF
--- a/search/query/conjunction.go
+++ b/search/query/conjunction.go
@@ -73,6 +73,16 @@ func (q *ConjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
+	} else if len(ss) == 1 {
+		// If the single searcher within this conjunction query happens to
+		// be a match none, do not apply this optimization - as in the case
+		// where this conjunction query is a boolean query's must, when the
+		// boolean searcher is being initialized, it's must searcher would
+		// be reset to nil - there by dropping what could have played a
+		// relevant role.
+		if _, ok := ss[0].(*searcher.MatchNoneSearcher); !ok {
+			return ss[0], nil
+		}
 	}
 
 	return searcher.NewConjunctionSearcher(i, ss, options)

--- a/search_test.go
+++ b/search_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blevesearch/bleve/analysis/analyzer/custom"
 	"github.com/blevesearch/bleve/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/analysis/analyzer/standard"
+	"github.com/blevesearch/bleve/analysis/token/length"
 	"github.com/blevesearch/bleve/analysis/token/lowercase"
 	"github.com/blevesearch/bleve/analysis/tokenizer/single"
 	"github.com/blevesearch/bleve/analysis/tokenizer/whitespace"
@@ -1221,5 +1222,78 @@ func TestDisjunctionMinPropagation(t *testing.T) {
 
 	if res.Total != 0 {
 		t.Fatalf("Expect 0 results, but got: %v", res.Total)
+	}
+}
+
+func TestBooleanMustSingleMatchNone(t *testing.T) {
+	idxMapping := NewIndexMapping()
+	if err := idxMapping.AddCustomTokenFilter(length.Name, map[string]interface{}{
+		"min":  3.0,
+		"max":  5.0,
+		"type": length.Name,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idxMapping.AddCustomAnalyzer("custom1", map[string]interface{}{
+		"type":          "custom",
+		"tokenizer":     "single",
+		"token_filters": []interface{}{length.Name},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	idxMapping.DefaultAnalyzer = "custom1"
+	idx, err := New("testidx", idxMapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = os.RemoveAll("testidx")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	doc := map[string]interface{}{
+		"languages_known": "Dutch",
+		"dept":            "Sales",
+	}
+
+	batch := idx.NewBatch()
+	if err = batch.Index("doc", doc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = idx.Batch(batch); err != nil {
+		t.Fatal(err)
+	}
+
+	// this is a successful match
+	matchSales := NewMatchQuery("Sales")
+	matchSales.SetField("dept")
+
+	// this would spin off a MatchNoneSearcher as the
+	// token filter rules out the word "French"
+	matchFrench := NewMatchQuery("French")
+	matchFrench.SetField("languages_known")
+
+	bq := NewBooleanQuery()
+	bq.AddShould(matchSales)
+	bq.AddMust(matchFrench)
+
+	sr := NewSearchRequest(bq)
+	res, err := idx.Search(sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Total != 0 {
+		t.Fatalf("Expected 0 results but got: %v", res.Total)
 	}
 }


### PR DESCRIPTION
If the conjunction query had a single clause, and this single clause
were to be a match-none searcher, do not apply the optimization
of returning the single searcher itself. This is because if the
conjunction query were a boolean query's must, then when the boolean
searcher is being initialized, it's must searcher would be reset to
nil - there by dropping what could have played a relevant role.