### PR TITLE
handle empty IntCoders

### DIFF
--- a/index/scorch/segment/zap/intcoder.go
+++ b/index/scorch/segment/zap/intcoder.go
@@ -18,7 +18,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"math"
 )
+
+const termNotEncoded = math.MaxUint64
 
 type chunkedIntCoder struct {
 	final     []byte
@@ -105,6 +108,10 @@ func (c *chunkedIntCoder) Close() {
 
 // Write commits all the encoded chunked integers to the provided writer.
 func (c *chunkedIntCoder) Write(w io.Writer) (int, error) {
+	if len(c.final) <= 0 {
+		return 0, nil
+	}
+
 	bufNeeded := binary.MaxVarintLen64 * (1 + len(c.chunkLens))
 	if len(c.buf) < bufNeeded {
 		c.buf = make([]byte, bufNeeded)

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -562,14 +562,19 @@ func writePostings(postings *roaring.Bitmap, tfEncoder, locEncoder *chunkedIntCo
 		}
 	}
 
+	var bw int
 	tfOffset := uint64(w.Count())
-	_, err = tfEncoder.Write(w)
+	if bw, err = tfEncoder.Write(w); bw == 0 {
+		tfOffset = termNotEncoded
+	}
 	if err != nil {
 		return 0, err
 	}
 
 	locOffset := uint64(w.Count())
-	_, err = locEncoder.Write(w)
+	if bw, err = locEncoder.Write(w); bw == 0 {
+		locOffset = termNotEncoded
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -218,7 +218,12 @@ func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 	// prepare the freq chunk details
 	if rv.includeFreqNorm {
 		var numFreqChunks uint64
-		numFreqChunks, read = binary.Uvarint(p.sb.mem[p.freqOffset+n : p.freqOffset+n+binary.MaxVarintLen64])
+		if p.freqOffset == termNotEncoded {
+			numFreqChunks = 0
+		} else {
+			numFreqChunks, read = binary.Uvarint(p.sb.mem[p.freqOffset+n : p.freqOffset+n+binary.MaxVarintLen64])
+		}
+
 		n += uint64(read)
 		if cap(rv.freqChunkOffsets) >= int(numFreqChunks) {
 			rv.freqChunkOffsets = rv.freqChunkOffsets[:int(numFreqChunks)]
@@ -236,7 +241,12 @@ func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
 	if rv.includeLocs {
 		n = 0
 		var numLocChunks uint64
-		numLocChunks, read = binary.Uvarint(p.sb.mem[p.locOffset+n : p.locOffset+n+binary.MaxVarintLen64])
+		if p.locOffset == termNotEncoded {
+			numLocChunks = 0
+		} else {
+			numLocChunks, read = binary.Uvarint(p.sb.mem[p.locOffset+n : p.locOffset+n+binary.MaxVarintLen64])
+		}
+
 		n += uint64(read)
 		if cap(rv.locChunkOffsets) >= int(numLocChunks) {
 			rv.locChunkOffsets = rv.locChunkOffsets[:int(numLocChunks)]
@@ -376,38 +386,46 @@ func (i *PostingsIterator) Size() int {
 
 func (i *PostingsIterator) loadChunk(chunk int) error {
 	if i.includeFreqNorm {
-		if chunk >= len(i.freqChunkOffsets) {
-			return fmt.Errorf("tried to load freq chunk that doesn't exist %d/(%d)",
-				chunk, len(i.freqChunkOffsets))
-		}
-
-		end, start := i.freqChunkStart, i.freqChunkStart
-		s, e := readChunkBoundary(chunk, i.freqChunkOffsets)
-		start += s
-		end += e
-		i.currChunkFreqNorm = i.postings.sb.mem[start:end]
-		if i.freqNormReader == nil {
-			i.freqNormReader = bytes.NewReader(i.currChunkFreqNorm)
+		if i.postings.freqOffset == termNotEncoded {
+			i.freqNormReader = bytes.NewReader([]byte(nil))
 		} else {
-			i.freqNormReader.Reset(i.currChunkFreqNorm)
+			if chunk >= len(i.freqChunkOffsets) {
+				return fmt.Errorf("tried to load freq chunk that doesn't exist %d/(%d)",
+					chunk, len(i.freqChunkOffsets))
+			}
+
+			end, start := i.freqChunkStart, i.freqChunkStart
+			s, e := readChunkBoundary(chunk, i.freqChunkOffsets)
+			start += s
+			end += e
+			i.currChunkFreqNorm = i.postings.sb.mem[start:end]
+			if i.freqNormReader == nil {
+				i.freqNormReader = bytes.NewReader(i.currChunkFreqNorm)
+			} else {
+				i.freqNormReader.Reset(i.currChunkFreqNorm)
+			}
 		}
 	}
 
 	if i.includeLocs {
-		if chunk >= len(i.locChunkOffsets) {
-			return fmt.Errorf("tried to load loc chunk that doesn't exist %d/(%d)",
-				chunk, len(i.locChunkOffsets))
-		}
-
-		end, start := i.locChunkStart, i.locChunkStart
-		s, e := readChunkBoundary(chunk, i.locChunkOffsets)
-		start += s
-		end += e
-		i.currChunkLoc = i.postings.sb.mem[start:end]
-		if i.locReader == nil {
-			i.locReader = bytes.NewReader(i.currChunkLoc)
+		if i.postings.locOffset == termNotEncoded {
+			i.locReader = bytes.NewReader([]byte(nil))
 		} else {
-			i.locReader.Reset(i.currChunkLoc)
+			if chunk >= len(i.locChunkOffsets) {
+				return fmt.Errorf("tried to load loc chunk that doesn't exist %d/(%d)",
+					chunk, len(i.locChunkOffsets))
+			}
+
+			end, start := i.locChunkStart, i.locChunkStart
+			s, e := readChunkBoundary(chunk, i.locChunkOffsets)
+			start += s
+			end += e
+			i.currChunkLoc = i.postings.sb.mem[start:end]
+			if i.locReader == nil {
+				i.locReader = bytes.NewReader(i.currChunkLoc)
+			} else {
+				i.locReader.Reset(i.currChunkLoc)
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, IntCoders continue to persist
un-necessary chunk metadata onto disk evenif
there is no actual chunkdata to persist to disk.
This results in huge index size bloating, esp
when the term vectors are disabled.

This change aims to identify the empty encodings
with a special `termNotEncoded` value on disk,
and avoids any zap format changes.