### PR TITLE
fix issue mapping documents containing *time.Time

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -533,12 +533,14 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 					for _, fieldMapping := range subDocMapping.Fields {
 						if fieldMapping.Type != "text" {
 							allFieldsText = false
+							break
 						}
 					}
 					txt, err := property.MarshalText()
 					if err == nil && allFieldsText {
+						txtStr := string(txt)
 						for _, fieldMapping := range subDocMapping.Fields {
-							fieldMapping.processString(string(txt), pathString, path, indexes, context)
+							fieldMapping.processString(txtStr, pathString, path, indexes, context)
 						}
 						return
 					}

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -525,19 +525,25 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		if !propertyValue.IsNil() {
 			switch property := property.(type) {
 			case encoding.TextMarshaler:
-
-				txt, err := property.MarshalText()
-				if err == nil && subDocMapping != nil {
-					// index by explicit mapping
+				// ONLY process TextMarshaler if there is an explicit mapping
+				// AND all of the fiels are of type text
+				// OTHERWISE process field without TextMarshaler
+				if subDocMapping != nil {
+					allFieldsText := true
 					for _, fieldMapping := range subDocMapping.Fields {
-						if fieldMapping.Type == "text" {
-							fieldMapping.processString(string(txt), pathString, path, indexes, context)
+						if fieldMapping.Type != "text" {
+							allFieldsText = false
 						}
 					}
-				} else {
-					dm.walkDocument(property, path, indexes, context)
+					txt, err := property.MarshalText()
+					if err == nil && allFieldsText {
+						for _, fieldMapping := range subDocMapping.Fields {
+							fieldMapping.processString(string(txt), pathString, path, indexes, context)
+						}
+						return
+					}
 				}
-
+				dm.walkDocument(property, path, indexes, context)
 			default:
 				dm.walkDocument(property, path, indexes, context)
 			}


### PR DESCRIPTION
If documents contained a field of type *time.Time AND they also
had an explicit mapping for the field of a type OTHER THAN text,
the field would not be mapped.

The issue was introduced when we added special support for
handling encoding.TextMarshaler because *time.Time satisfies
this interface.

This change fixes this issue, but there are some more complicated
cases exposed by this, specifically related to mapping the same
field multiple times, and handling cases where you try to mix
multiple types.

Instead, our solution is to further limit the way we support
using ecoding.TextMarshaler.  The new limitation is that we ONLY
use the output of MarshalText() if you have an explicit mapping
AND ALL the index fields are of type text.  All other cases
will ignore TextMarshaler and follow regular indexing rules.