### PR TITLE
IndexReader initialisation in SearchContext

### DIFF
--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -141,6 +141,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 	searchContext := &search.SearchContext{
 		DocumentMatchPool: search.NewDocumentMatchPool(backingSize+searcher.DocumentMatchPoolSize(), len(hc.sort)),
 		Collector:         hc,
+		IndexReader:	   reader,
 	}
 
 	hc.dvReader, err = reader.DocValueReader(hc.neededFields)


### PR DESCRIPTION
Initialising the IndexReader field of the
SearchContext so that the DocumentMatchHandler
implementation will have enough details for
invoking the LoadAndHighlightFields API.