### PR TITLE
run integration tests with scorch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - gvt restore
   - go test -race -v $(go list ./... | grep -v vendor/)
   - go vet $(go list ./... | grep -v vendor/)
+  - go test ./test -v -indexType scorch
   - errcheck -ignorepkg fmt $(go list ./... | grep -v vendor/)
   - docs/project-code-coverage.sh
   - docs/build_children.sh

--- a/test/tests/basic/searches.json
+++ b/test/tests/basic/searches.json
@@ -189,6 +189,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"field": "birthday",
 				"start": "2010-01-01"
@@ -408,6 +409,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"query": "-title:mista"
 			}
@@ -516,6 +518,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"match_all": {}
 			}
@@ -543,6 +546,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"ids": ["b", "c"]
 			}
@@ -564,6 +568,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"query": "+age:>20 missess"
 			}

--- a/test/tests/fosdem/searches.json
+++ b/test/tests/fosdem/searches.json
@@ -3,6 +3,7 @@
 		"search": {
 			"from": 0,
 			"size": 10,
+			"sort": ["_id"],
 			"query": {
 				"field": "category",
 				"match_phrase": "Perl"

--- a/test/tests/sort/searches.json
+++ b/test/tests/sort/searches.json
@@ -1,37 +1,4 @@
 [
-	{
-    "comment": "default order, all have same score, then by natural index order",
-		"search": {
-			"from": 0,
-			"size": 10,
-			"query": {
-				"match_all":{}
-			}
-		},
-		"result": {
-			"total_hits": 6,
-			"hits": [
-				{
-					"id": "a"
-				},
-        {
-          "id": "b"
-        },
-        {
-          "id": "c"
-        },
-        {
-          "id": "d"
-        },
-        {
-          "id": "e"
-        },
-        {
-          "id": "f"
-        }
-			]
-		}
-	},
   {
     "comment": "sort by name, ascending",
 		"search": {


### PR DESCRIPTION
some minor changes have been made to a few of the queries to
ensure that the search results have a deterministic order

one test was removed as it was specifically checking the order
when no sort was specified, which is defined in a way that
does not lend itself to easy testing

we did not change all tests without sort order, as many of them
are correctly ordered by score already