### PR TITLE
asciifolding test apples from MB-33486

### DIFF
--- a/analysis/char/asciifolding/asciifolding_test.go
+++ b/analysis/char/asciifolding/asciifolding_test.go
@@ -43,6 +43,10 @@ func TestAsciiFoldingFilter(t *testing.T) {
 			// composite unicode runes are folded to more than one ASCII rune
 			input:  []byte(`ÆꜴ`),
 			output: []byte(`AEAO`),
+		}, {
+			// apples from https://issues.couchbase.com/browse/MB-33486
+			input:  []byte(`Ápple Àpple Äpple Âpple Ãpple Åpple`),
+			output: []byte(`Apple Apple Apple Apple Apple Apple`),
 		},
 	}
 


### PR DESCRIPTION
@mihirkamdarcouchbase provided some asciifolding strings in https://issues.couchbase.com/browse/MB-33486, so I figured I'd bring them over into a unit test case as a sanity check