### PR TITLE
MB-33462: Validating the range for a date range query

### DIFF
--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -143,10 +143,20 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 	min := math.Inf(-1)
 	max := math.Inf(1)
 	if !q.Start.IsZero() {
-		min = numeric.Int64ToFloat64(q.Start.UnixNano())
+		startInt64 := q.Start.UnixNano()
+		if startInt64 < 0 {
+			// overflow
+			return nil, nil, fmt.Errorf("invalid/unsupported date range, start: %v", q.Start)
+		}
+		min = numeric.Int64ToFloat64(startInt64)
 	}
 	if !q.End.IsZero() {
-		max = numeric.Int64ToFloat64(q.End.UnixNano())
+		endInt64 := q.End.UnixNano()
+		if endInt64 < 0 {
+			// overflow
+			return nil, nil, fmt.Errorf("invalid/unsupported date range, end: %v", q.End)
+		}
+		max = numeric.Int64ToFloat64(endInt64)
 	}
 
 	return &min, &max, nil

--- a/search/query/date_range_test.go
+++ b/search/query/date_range_test.go
@@ -49,3 +49,44 @@ func TestBleveQueryTime(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDatetimeRanges(t *testing.T) {
+	tests := []struct {
+		start  string
+		end    string
+		expect bool
+	}{
+		{
+			start:  "2019-03-22T13:25:00Z",
+			end:    "2019-03-22T18:25:00Z",
+			expect: true,
+		},
+		{
+			start:  "2019-03-22T13:25:00Z",
+			end:    "9999-03-22T13:25:00Z",
+			expect: false,
+		},
+		{
+			start:  "2019-03-22T13:25:00Z",
+			end:    "2262-04-11T11:59:59Z",
+			expect: true,
+		},
+		{
+			start:  "2019-03-22T13:25:00Z",
+			end:    "2262-04-12T00:00:00Z",
+			expect: false,
+		},
+	}
+
+	for _, test := range tests {
+		startTime, _ := time.Parse(time.RFC3339, test.start)
+		endTime, _ := time.Parse(time.RFC3339, test.end)
+
+		dateRangeQuery := NewDateRangeQuery(startTime, endTime)
+		if (dateRangeQuery.Validate() == nil) != test.expect {
+			t.Errorf("unexpected results while validating date range query with"+
+				" {start: %v, end: %v}, expected: %v",
+				test.start, test.end, test.expect)
+		}
+	}
+}


### PR DESCRIPTION
+ All datetimes after 2262-04-11T11:59:59Z will cause UnixNano()
  which generates an Int64 to overflow.
+ Error out early for these values rather than the query to fail
  quietly.