### PR TITLE
MB-33455: improve ComputeGeoRange() performance

### DIFF
--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -22,6 +22,9 @@ import (
 	"github.com/blevesearch/bleve/search"
 )
 
+var GeoBitsShift1 = (geo.GeoBits << 1)
+var GeoBitsShift1Minus1 = GeoBitsShift1 - 1
+
 func NewGeoBoundingBoxSearcher(indexReader index.IndexReader, minLon, minLat,
 	maxLon, maxLat float64, field string, boost float64,
 	options search.SearcherOptions, checkBoundaries bool) (
@@ -36,7 +39,7 @@ func NewGeoBoundingBoxSearcher(indexReader index.IndexReader, minLon, minLat,
 	}
 
 	// do math to produce list of terms needed for this search
-	onBoundaryTerms, notOnBoundaryTerms := ComputeGeoRange(0, (geo.GeoBits<<1)-1,
+	onBoundaryTerms, notOnBoundaryTerms := ComputeGeoRange(0, GeoBitsShift1Minus1,
 		minLon, minLat, maxLon, maxLat, checkBoundaries)
 
 	var onBoundarySearcher search.Searcher
@@ -94,59 +97,72 @@ var geoMaxShift = document.GeoPrecisionStep * 4
 var geoDetailLevel = ((geo.GeoBits << 1) - geoMaxShift) / 2
 
 func ComputeGeoRange(term uint64, shift uint,
-	sminLon, sminLat, smaxLon, smaxLat float64,
-	checkBoundaries bool) (
+	sminLon, sminLat, smaxLon, smaxLat float64, checkBoundaries bool) (
 	onBoundary [][]byte, notOnBoundary [][]byte) {
-	split := term | uint64(0x1)<<shift
-	var upperMax uint64
-	if shift < 63 {
-		upperMax = term | ((uint64(1) << (shift + 1)) - 1)
-	} else {
-		upperMax = 0xffffffffffffffff
-	}
-	lowerMax := split - 1
-	onBoundary, notOnBoundary = relateAndRecurse(term, lowerMax, shift,
-		sminLon, sminLat, smaxLon, smaxLat, checkBoundaries)
-	plusOnBoundary, plusNotOnBoundary := relateAndRecurse(split, upperMax, shift,
-		sminLon, sminLat, smaxLon, smaxLat, checkBoundaries)
-	onBoundary = append(onBoundary, plusOnBoundary...)
-	notOnBoundary = append(notOnBoundary, plusNotOnBoundary...)
-	return
-}
+	preallocBytesLen := 32
+	preallocBytes := make([]byte, preallocBytesLen)
 
-func relateAndRecurse(start, end uint64, res uint,
-	sminLon, sminLat, smaxLon, smaxLat float64,
-	checkBoundaries bool) (
-	onBoundary [][]byte, notOnBoundary [][]byte) {
-	minLon := geo.MortonUnhashLon(start)
-	minLat := geo.MortonUnhashLat(start)
-	maxLon := geo.MortonUnhashLon(end)
-	maxLat := geo.MortonUnhashLat(end)
-
-	level := ((geo.GeoBits << 1) - res) >> 1
-
-	within := res%document.GeoPrecisionStep == 0 &&
-		geo.RectWithin(minLon, minLat, maxLon, maxLat,
-			sminLon, sminLat, smaxLon, smaxLat)
-	if within || (level == geoDetailLevel &&
-		geo.RectIntersects(minLon, minLat, maxLon, maxLat,
-			sminLon, sminLat, smaxLon, smaxLat)) {
-		if !within && checkBoundaries {
-			return [][]byte{
-				numeric.MustNewPrefixCodedInt64(int64(start), res),
-			}, nil
+	makePrefixCoded := func(in int64, shift uint) (rv numeric.PrefixCoded) {
+		if len(preallocBytes) <= 0 {
+			preallocBytesLen = preallocBytesLen * 2
+			preallocBytes = make([]byte, preallocBytesLen)
 		}
-		return nil,
-			[][]byte{
-				numeric.MustNewPrefixCodedInt64(int64(start), res),
-			}
-	} else if level < geoDetailLevel &&
-		geo.RectIntersects(minLon, minLat, maxLon, maxLat,
-			sminLon, sminLat, smaxLon, smaxLat) {
-		return ComputeGeoRange(start, res-1, sminLon, sminLat, smaxLon, smaxLat,
-			checkBoundaries)
+
+		var err error
+		rv, preallocBytes, err =
+			numeric.NewPrefixCodedInt64Prealloc(in, shift, preallocBytes)
+		if err != nil {
+			panic(err)
+		}
+		return rv
 	}
-	return nil, nil
+
+	var computeGeoRange func(term uint64, shift uint) // declare for recursion
+
+	relateAndRecurse := func(start, end uint64, res, level uint) {
+		minLon := geo.MortonUnhashLon(start)
+		minLat := geo.MortonUnhashLat(start)
+		maxLon := geo.MortonUnhashLon(end)
+		maxLat := geo.MortonUnhashLat(end)
+
+		within := res%document.GeoPrecisionStep == 0 &&
+			geo.RectWithin(minLon, minLat, maxLon, maxLat,
+				sminLon, sminLat, smaxLon, smaxLat)
+		if within || (level == geoDetailLevel &&
+			geo.RectIntersects(minLon, minLat, maxLon, maxLat,
+				sminLon, sminLat, smaxLon, smaxLat)) {
+			if !within && checkBoundaries {
+				onBoundary = append(onBoundary, makePrefixCoded(int64(start), res))
+			} else {
+				notOnBoundary = append(notOnBoundary, makePrefixCoded(int64(start), res))
+			}
+		} else if level < geoDetailLevel &&
+			geo.RectIntersects(minLon, minLat, maxLon, maxLat,
+				sminLon, sminLat, smaxLon, smaxLat) {
+			computeGeoRange(start, res-1)
+		}
+	}
+
+	computeGeoRange = func(term uint64, shift uint) {
+		split := term | uint64(0x1)<<shift
+		var upperMax uint64
+		if shift < 63 {
+			upperMax = term | ((uint64(1) << (shift + 1)) - 1)
+		} else {
+			upperMax = 0xffffffffffffffff
+		}
+
+		lowerMax := split - 1
+
+		level := (GeoBitsShift1 - shift) >> 1
+
+		relateAndRecurse(term, lowerMax, shift, level)
+		relateAndRecurse(split, upperMax, shift, level)
+	}
+
+	computeGeoRange(term, shift)
+
+	return onBoundary, notOnBoundary
 }
 
 func buildRectFilter(dvReader index.DocValueReader, field string,

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -198,3 +198,46 @@ func setupGeo(t *testing.T) index.Index {
 
 	return i
 }
+
+// --------------------------------------------------------------------
+
+func BenchmarkComputeGeoRangePt01(b *testing.B) {
+	onBoundary := 4
+	offBoundary := 0
+	benchmarkComputeGeoRange(b, -0.01, -0.01, 0.01, 0.01, onBoundary, offBoundary)
+}
+
+func BenchmarkComputeGeoRangePt1(b *testing.B) {
+	onBoundary := 56
+	offBoundary := 144
+	benchmarkComputeGeoRange(b, -0.1, -0.1, 0.1, 0.1, onBoundary, offBoundary)
+}
+
+func BenchmarkComputeGeoRange10(b *testing.B) {
+	onBoundary := 5464
+	offBoundary := 53704
+	benchmarkComputeGeoRange(b, -10.0, -10.0, 10.0, 10.0, onBoundary, offBoundary)
+}
+
+func BenchmarkComputeGeoRange100(b *testing.B) {
+	onBoundary := 32768
+	offBoundary := 258560
+	benchmarkComputeGeoRange(b, -100.0, -100.0, 100.0, 100.0, onBoundary, offBoundary)
+}
+
+// --------------------------------------------------------------------
+
+func benchmarkComputeGeoRange(b *testing.B,
+	minLon, minLat, maxLon, maxLat float64, onBoundary, offBoundary int) {
+	checkBoundaries := true
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		onBoundaryRes, offBoundaryRes :=
+			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries)
+		if len(onBoundaryRes) != onBoundary || len(offBoundaryRes) != offBoundary {
+			b.Fatalf("boundaries not matching")
+		}
+	}
+}

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -199,6 +199,35 @@ func setupGeo(t *testing.T) index.Index {
 	return i
 }
 
+func TestComputeGeoRange(t *testing.T) {
+	tests := []struct {
+		degs        float64
+		maxTerms    int
+		onBoundary  int
+		offBoundary int
+		err         string
+	}{
+		{0.01, 0, 4, 0, ""},
+		{0.1, 0, 56, 144, ""},
+		{100.0, 0, 32768, 258560, ""},
+		{100.0, 1024, 0, 0, "geo range produces too many terms, so should have error"},
+	}
+
+	for _, test := range tests {
+		onBoundaryRes, offBoundaryRes, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
+			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true, test.maxTerms)
+		if (err != nil) != (test.err != "") {
+			t.Errorf("test: %+v, err: %v", test, err)
+		}
+		if len(onBoundaryRes) != test.onBoundary {
+			t.Errorf("test: %+v, onBoundaryRes: %v", test, len(onBoundaryRes))
+		}
+		if len(offBoundaryRes) != test.offBoundary {
+			t.Errorf("test: %+v, offBoundaryRes: %v", test, len(offBoundaryRes))
+		}
+	}
+}
+
 // --------------------------------------------------------------------
 
 func BenchmarkComputeGeoRangePt01(b *testing.B) {
@@ -234,8 +263,11 @@ func benchmarkComputeGeoRange(b *testing.B,
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		onBoundaryRes, offBoundaryRes :=
-			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries)
+		onBoundaryRes, offBoundaryRes, err :=
+			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries, 0)
+		if err != nil {
+			b.Fatalf("expected no err")
+		}
 		if len(onBoundaryRes) != onBoundary || len(offBoundaryRes) != offBoundary {
 			b.Fatalf("boundaries not matching")
 		}


### PR DESCRIPTION
This change improves ComputeGeoRange() performance by avoiding trips
to the allocator by using pre-allocated []byte slices and by avoiding
creation of interim [][]byte slices by append()'ing directly to
returned output slices.

Before the change...
```
  BenchmarkComputeGeoRangePt01-8 100000     18516 ns/op      2005 B/op     63 allocs/op
  BenchmarkComputeGeoRangePt1-8   10000    108882 ns/op     96267 B/op    736 allocs/op
  BenchmarkComputeGeoRange10-8       50  35883331 ns/op  35812513 B/op 184543 allocs/op
  BenchmarkComputeGeoRange100-8      10 192568538 ns/op 187524856 B/op 926510 allocs/op
```

After the change...
```
  BenchmarkComputeGeoRangePt01-8 100000     12447 ns/op       280 B/op      7 allocs/op
  BenchmarkComputeGeoRangePt1-8   30000     47053 ns/op     16416 B/op     28 allocs/op
  BenchmarkComputeGeoRange10-8      100  11836988 ns/op   8503406 B/op     76 allocs/op
  BenchmarkComputeGeoRange100-8      20  72555603 ns/op  42778777 B/op     89 allocs/op
```

In some (perhaps unnatural) cases where the bounding boxes are very
large... performance improves by ~2x, memory utilization improves by
~4x and trips to the allocator improves by ~10000x.

See also: https://issues.couchbase.com/browse/MB-33455