### PR TITLE
fixes #1166 - perf optimizations for ReadUvarint()

### DIFF
--- a/index/scorch/segment/int.go
+++ b/index/scorch/segment/int.go
@@ -19,7 +19,10 @@
 
 package segment
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	MaxVarintSize = 9
@@ -91,4 +94,85 @@ func DecodeUvarintAscending(b []byte) ([]byte, uint64, error) {
 		v = (v << 8) | uint64(t)
 	}
 	return b[length:], v, nil
+}
+
+// ------------------------------------------------------------
+
+type MemUvarintReader struct {
+	C int64 // index of next byte to read from S
+	S []byte
+}
+
+func NewMemUvarintReader(s []byte) *MemUvarintReader {
+	return &MemUvarintReader{S: s}
+}
+
+// Len returns the number of unread bytes.
+func (r *MemUvarintReader) Len() int {
+	n := int(int64(len(r.S)) - r.C)
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+var ErrMemUvarintReaderOverflow = errors.New("MemUvarintReader overflow")
+
+// ReadUvarint reads an encoded uint64.  The original code this was
+// based on is at encoding/binary/ReadUvarint().
+func (r *MemUvarintReader) ReadUvarint() (uint64, error) {
+	var x uint64
+	var s uint
+	var C = r.C
+	var S = r.S
+
+	for true {
+		b := S[C]
+		C++
+
+		if b < 0x80 {
+			r.C = C
+
+			// why 63?  The original code had an 'i += 1' loop var and
+			// checked for i > 9 || i == 9 ...; but, we no longer
+			// check for the i var, but instead check here for s,
+			// which is incremented by 7.  So, 7*9 == 63.
+			//
+			// why the "extra" >= check?  The normal case is that s <
+			// 63, so we check this single >= guard first so that we
+			// hit the normal, nil-error return pathway sooner.
+			if s >= 63 && (s > 63 || s == 63 && b > 1) {
+				return 0, ErrMemUvarintReaderOverflow
+			}
+
+			return x | uint64(b)<<s, nil
+		}
+
+		x |= uint64(b&0x7f) << s
+		s += 7
+	}
+
+	return 0, nil // never reached, but compiler wants this
+}
+
+// SkipUvarint skips ahead one encoded uint64.
+func (r *MemUvarintReader) SkipUvarint() {
+	for true {
+		b := r.S[r.C]
+		r.C++
+
+		if b < 0x80 {
+			return
+		}
+	}
+}
+
+// SkipBytes skips a count number of bytes.
+func (r *MemUvarintReader) SkipBytes(count int64) {
+	r.C = r.C + count
+}
+
+func (r *MemUvarintReader) Reset(s []byte) {
+	r.C = 0
+	r.S = s
 }

--- a/index/scorch/segment/int.go
+++ b/index/scorch/segment/int.go
@@ -126,7 +126,7 @@ func (r *MemUvarintReader) ReadUvarint() (uint64, error) {
 	var C = r.C
 	var S = r.S
 
-	for true {
+	for {
 		b := S[C]
 		C++
 
@@ -151,13 +151,11 @@ func (r *MemUvarintReader) ReadUvarint() (uint64, error) {
 		x |= uint64(b&0x7f) << s
 		s += 7
 	}
-
-	return 0, nil // never reached, but compiler wants this
 }
 
 // SkipUvarint skips ahead one encoded uint64.
 func (r *MemUvarintReader) SkipUvarint() {
-	for true {
+	for {
 		b := r.S[r.C]
 		r.C++
 

--- a/index/scorch/segment/int.go
+++ b/index/scorch/segment/int.go
@@ -99,7 +99,7 @@ func DecodeUvarintAscending(b []byte) ([]byte, uint64, error) {
 // ------------------------------------------------------------
 
 type MemUvarintReader struct {
-	C int64 // index of next byte to read from S
+	C int // index of next byte to read from S
 	S []byte
 }
 
@@ -109,7 +109,7 @@ func NewMemUvarintReader(s []byte) *MemUvarintReader {
 
 // Len returns the number of unread bytes.
 func (r *MemUvarintReader) Len() int {
-	n := int(int64(len(r.S)) - r.C)
+	n := len(r.S) - r.C
 	if n < 0 {
 		return 0
 	}
@@ -168,7 +168,7 @@ func (r *MemUvarintReader) SkipUvarint() {
 }
 
 // SkipBytes skips a count number of bytes.
-func (r *MemUvarintReader) SkipBytes(count int64) {
+func (r *MemUvarintReader) SkipBytes(count int) {
 	r.C = r.C + count
 }
 

--- a/index/scorch/segment/zap/posting.go
+++ b/index/scorch/segment/zap/posting.go
@@ -628,7 +628,7 @@ func (i *PostingsIterator) nextBytes() (
 		}
 
 		// skip over all the location bytes
-		i.locReader.SkipBytes(int64(numLocsBytes))
+		i.locReader.SkipBytes(int(numLocsBytes))
 
 		endLoc := len(i.currChunkLoc) - i.locReader.Len()
 		bytesLoc = i.currChunkLoc[startLoc:endLoc]
@@ -781,7 +781,7 @@ func (i *PostingsIterator) currChunkNext(nChunk uint32) error {
 		}
 
 		// skip over all the location bytes
-		i.locReader.SkipBytes(int64(numLocsBytes))
+		i.locReader.SkipBytes(int(numLocsBytes))
 	}
 
 	return nil


### PR DESCRIPTION
This commit introduces a specialized MemUvarintReader which is focused
on the "hot inner loop" of scorch/zap's reading of uvarint's -- such
as the postingsList reading freqNormHasLocs and location information.

The various changes include...

- the separate bytes.Reader vs binary.ReadUvarint() codepaths are
  unified, and ReadByte() is now inlined.

- error return codes are removed, since the memory slices are
  "perfectly sized" in scorch/zap, which meant there's never an error.

- SkipUvarint() allows entries to be skipped more efficiently (by
  postingsList.currChunkNext()).

- prevRune maintenance is removed.

- postingsList.readLocation() is always provided a non-nil output
  location.

In microbenchmarks...
```
  $ go test -benchmem -bench=. ./index/scorch/segment/
  BenchmarkUvarint-8          100000000 16.4  ns/op 0 B/op 0 allocs/op
  BenchmarkMemUvarintReader-8 200000000  7.57 ns/op 0 B/op 0 allocs/op
```

In bleve-query microbenchmarks on a scorch index with 200K en-wiki
docs, high-frequency term ("http") searches that included locations
had throughput of ~21.5 q/sec before this change, and after this
change went to ~28.49 q/sec.