### PR TITLE
bugfix for issue 1173

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/size"
+	"strings"
 )
 
 var reflectStaticSizeDocumentMatch int
@@ -139,6 +140,40 @@ type FieldTermLocation struct {
 	Field    string
 	Term     string
 	Location Location
+}
+
+func FieldTermLocationCompare(x, y *FieldTermLocation) int {
+	cmp := strings.Compare(x.Field, y.Field)
+	if cmp != 0 {
+		return cmp
+	}
+	cmp = strings.Compare(x.Term, y.Term)
+	if cmp != 0 {
+		return cmp
+	}
+	cmp =  x.Location.ArrayPositions.Compare(y.Location.ArrayPositions)
+	if cmp != 0 {
+		return cmp
+	}
+	if x.Location.Pos < y.Location.Pos {
+		return -1
+	} else if x.Location.Pos > y.Location.Pos{
+		return 1
+	} else {
+		return 0
+	}
+}
+
+type FieldTermLocations []FieldTermLocation
+
+func (c FieldTermLocations) Len() int           { return len(c) }
+func (c FieldTermLocations) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c FieldTermLocations) Less(i, j int) bool {
+	cmp := FieldTermLocationCompare(&c[i], &c[j])
+	if cmp < 0 {
+		return true
+	}
+	return false
 }
 
 type FieldFragmentMap map[string][]string

--- a/search/util.go
+++ b/search/util.go
@@ -14,6 +14,8 @@
 
 package search
 
+import "sort"
+
 func MergeLocations(locations []FieldTermLocationMap) FieldTermLocationMap {
 	rv := locations[0]
 
@@ -65,5 +67,18 @@ func MergeFieldTermLocations(dest []FieldTermLocation, matches []*DocumentMatch)
 		}
 	}
 
-	return dest
+	if len(dest) < 2 {
+		return dest
+	}
+	sort.Sort(FieldTermLocations(dest))
+	var index int
+	index = 1
+	// remove duplicate location
+	for i :=0; i < (len(dest) - 1); i++ {
+		if FieldTermLocationCompare(&dest[i], &dest[i+1]) != 0 {
+			dest[index] = dest[i+1]
+			index++
+		}
+	}
+	return dest[:index]
 }

--- a/search/util_test.go
+++ b/search/util_test.go
@@ -89,3 +89,234 @@ func TestMergeLocations(t *testing.T) {
 		t.Errorf("expected %v, got %v", expectedMerge, mergedLocations)
 	}
 }
+
+func TestMergeFieldTermLocations(t *testing.T) {
+	ftls := []FieldTermLocation {
+		FieldTermLocation{
+			Field: "a",
+			Term:  "a",
+			Location: Location{
+				Pos: 10,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "b",
+			Location: Location{
+				Pos: 12,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "b",
+			Term:  "a",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "b",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "a",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "e",
+			Term:  "c",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+				ArrayPositions: []uint64{0,1},
+			},
+		},
+		FieldTermLocation{
+			Field: "e",
+			Term:  "c",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+				ArrayPositions: []uint64{1,0},
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "b",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+	}
+	dms := []*DocumentMatch {
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "a",
+					Term:  "a",
+					Location: Location{
+						Pos: 10,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "a",
+					Term:  "b",
+					Location: Location{
+						Pos: 12,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "b",
+					Term:  "a",
+					Location: Location{
+						Pos: 1,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "a",
+					Term:  "b",
+					Location: Location{
+						Pos: 1,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "a",
+					Term:  "b",
+					Location: Location{
+						Pos: 1,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+		&DocumentMatch{
+			FieldTermLocations: []FieldTermLocation {
+				FieldTermLocation{
+					Field: "a",
+					Term:  "a",
+					Location: Location{
+						Pos: 1,
+						Start: 1,
+						End: 2,
+					},
+				},
+			},
+		},
+	}
+	expectedFtls := []FieldTermLocation {
+		FieldTermLocation{
+			Field: "a",
+			Term:  "a",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "a",
+			Location: Location{
+				Pos: 10,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "b",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "a",
+			Term:  "b",
+			Location: Location{
+				Pos: 12,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "b",
+			Term:  "a",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+			},
+		},
+		FieldTermLocation{
+			Field: "e",
+			Term:  "c",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+				ArrayPositions: []uint64{0,1},
+			},
+		},
+		FieldTermLocation{
+			Field: "e",
+			Term:  "c",
+			Location: Location{
+				Pos: 1,
+				Start: 1,
+				End: 2,
+				ArrayPositions: []uint64{1,0},
+			},
+		},
+
+	}
+	ftls = MergeFieldTermLocations(ftls, dms)
+	if !reflect.DeepEqual(ftls, expectedFtls) {
+		t.Errorf("expected %v, got %v", expectedFtls, ftls)
+	}
+}


### PR DESCRIPTION
when multi terms searcher which has duplicate terms, the term location will be duplicated, for phrase query, will make array of locations enlarge, it is large array in some case, This may cause performance degradation and panic for no memory for array. 
this PR try to fix issue [1173](https://github.com/blevesearch/bleve/issues/1173)