### PR TITLE
MB-32855: Revert disjunction-single clause optimization

### DIFF
--- a/index/store/moss/lower_test.go
+++ b/index/store/moss/lower_test.go
@@ -27,7 +27,7 @@ func openWithLower(t *testing.T, mo store.MergeOperator) (string, store.KVStore)
 	tmpDir, _ := ioutil.TempDir("", "mossStore")
 
 	config := map[string]interface{}{
-		"path": tmpDir,
+		"path":                    tmpDir,
 		"mossLowerLevelStoreName": "mossStore",
 	}
 

--- a/search/query/disjunction.go
+++ b/search/query/disjunction.go
@@ -80,12 +80,6 @@ func (q *DisjunctionQuery) Searcher(i index.IndexReader, m mapping.IndexMapping,
 
 	if len(ss) < 1 {
 		return searcher.NewMatchNoneSearcher(i)
-	} else if len(ss) == 1 && int(q.Min) == ss[0].Min() {
-		// apply optimization only if both conditions below are satisfied:
-		// - disjunction searcher has only 1 child searcher
-		// - parent searcher's min setting is equal to child searcher's min
-
-		return ss[0], nil
 	}
 
 	return searcher.NewDisjunctionSearcher(i, ss, q.Min, options)


### PR DESCRIPTION
+ Reverting the single-clause disjunction optimization as well,
  as we're noticing unexpected results while executing a boolean
  query in certain scenarios.
+ Note that I've already reverted the single-clause conjunction
  optimization with: https://github.com/blevesearch/bleve/pull/1133
+ Included unit tests that capture failing test cases with the
  above mentioned optimizations.

+ With this change, I've completely reverted:
   - https://github.com/blevesearch/bleve/pull/1073
   - https://github.com/blevesearch/bleve/pull/1116
   - https://github.com/blevesearch/bleve/pull/1128
+ Apologies for the grand mess :)

Also, some related discussion on why these optimizations don't
work: https://github.com/blevesearch/bleve/pull/1136