### PR TITLE
MB-33600: Allow date ranges before epoch time

### DIFF
--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -41,12 +41,12 @@ type BleveQueryTime struct {
 	time.Time
 }
 
-var minValidTime time.Time
-var maxValidTime time.Time
+var MinRFC3339CompatibleTime time.Time
+var MaxRFC3339CompatibleTime time.Time
 
 func init() {
-	minValidTime, _ = time.Parse(time.RFC3339, "1677-12-01T00:00:00Z")
-	maxValidTime, _ = time.Parse(time.RFC3339, "2262-04-11T11:59:59Z")
+	MinRFC3339CompatibleTime, _ = time.Parse(time.RFC3339, "1677-12-01T00:00:00Z")
+	MaxRFC3339CompatibleTime, _ = time.Parse(time.RFC3339, "2262-04-11T11:59:59Z")
 }
 
 func queryTimeFromString(t string) (time.Time, error) {
@@ -151,7 +151,7 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 	min := math.Inf(-1)
 	max := math.Inf(1)
 	if !q.Start.IsZero() {
-		if q.Start.Before(minValidTime) || q.Start.After(maxValidTime) {
+		if !isDatetimeCompatible(q.Start) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, start: %v", q.Start)
 		}
@@ -159,7 +159,7 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 		min = numeric.Int64ToFloat64(startInt64)
 	}
 	if !q.End.IsZero() {
-		if q.End.Before(minValidTime) || q.End.After(maxValidTime) {
+		if !isDatetimeCompatible(q.End) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, end: %v", q.End)
 		}
@@ -179,4 +179,13 @@ func (q *DateRangeQuery) Validate() error {
 		return err
 	}
 	return nil
+}
+
+func isDatetimeCompatible(t BleveQueryTime) bool {
+	if QueryDateTimeFormat == time.RFC3339 &&
+		(t.Before(MinRFC3339CompatibleTime) || t.After(MaxRFC3339CompatibleTime)) {
+		return false
+	}
+
+	return true
 }

--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -41,6 +41,13 @@ type BleveQueryTime struct {
 	time.Time
 }
 
+var epochTime time.Time
+
+func init() {
+	unixEpochTime := "1970-01-01T00:00:00Z"
+	epochTime, _ = time.Parse(time.RFC3339, unixEpochTime)
+}
+
 func queryTimeFromString(t string) (time.Time, error) {
 	dateTimeParser, err := cache.DateTimeParserNamed(QueryDateTimeParser)
 	if err != nil {
@@ -144,7 +151,7 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 	max := math.Inf(1)
 	if !q.Start.IsZero() {
 		startInt64 := q.Start.UnixNano()
-		if startInt64 < 0 {
+		if startInt64 < 0 && q.Start.After(epochTime) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, start: %v", q.Start)
 		}
@@ -152,7 +159,7 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 	}
 	if !q.End.IsZero() {
 		endInt64 := q.End.UnixNano()
-		if endInt64 < 0 {
+		if endInt64 < 0 && q.End.After(epochTime) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, end: %v", q.End)
 		}

--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -41,11 +41,12 @@ type BleveQueryTime struct {
 	time.Time
 }
 
-var epochTime time.Time
+var minValidTime time.Time
+var maxValidTime time.Time
 
 func init() {
-	unixEpochTime := "1970-01-01T00:00:00Z"
-	epochTime, _ = time.Parse(time.RFC3339, unixEpochTime)
+	minValidTime, _ = time.Parse(time.RFC3339, "1677-12-01T00:00:00Z")
+	maxValidTime, _ = time.Parse(time.RFC3339, "2262-04-11T11:59:59Z")
 }
 
 func queryTimeFromString(t string) (time.Time, error) {
@@ -150,19 +151,19 @@ func (q *DateRangeQuery) parseEndpoints() (*float64, *float64, error) {
 	min := math.Inf(-1)
 	max := math.Inf(1)
 	if !q.Start.IsZero() {
-		startInt64 := q.Start.UnixNano()
-		if startInt64 < 0 && q.Start.After(epochTime) {
+		if q.Start.Before(minValidTime) || q.Start.After(maxValidTime) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, start: %v", q.Start)
 		}
+		startInt64 := q.Start.UnixNano()
 		min = numeric.Int64ToFloat64(startInt64)
 	}
 	if !q.End.IsZero() {
-		endInt64 := q.End.UnixNano()
-		if endInt64 < 0 && q.End.After(epochTime) {
+		if q.End.Before(minValidTime) || q.End.After(maxValidTime) {
 			// overflow
 			return nil, nil, fmt.Errorf("invalid/unsupported date range, end: %v", q.End)
 		}
+		endInt64 := q.End.UnixNano()
 		max = numeric.Int64ToFloat64(endInt64)
 	}
 

--- a/search/query/date_range_test.go
+++ b/search/query/date_range_test.go
@@ -81,6 +81,41 @@ func TestValidateDatetimeRanges(t *testing.T) {
 			end:    "1960-02-21T15:23:34Z",
 			expect: true,
 		},
+		{
+			start:  "0001-01-01T00:00:00Z",
+			end:    "0001-01-01T00:00:00Z",
+			expect: false,
+		},
+		{
+			start:  "0001-01-01T00:00:00Z",
+			end:    "2000-01-01T00:00:00Z",
+			expect: true,
+		},
+		{
+			start:  "1677-11-30T11:59:59Z",
+			end:    "2262-04-11T11:59:59Z",
+			expect: false,
+		},
+		{
+			start:  "2262-04-12T00:00:00Z",
+			end:    "2262-04-11T11:59:59Z",
+			expect: false,
+		},
+		{
+			start:  "1677-12-01T00:00:00Z",
+			end:    "2262-04-12T00:00:00Z",
+			expect: false,
+		},
+		{
+			start:  "1677-12-01T00:00:00Z",
+			end:    "1677-11-30T11:59:59Z",
+			expect: false,
+		},
+		{
+			start:  "1677-12-01T00:00:00Z",
+			end:    "2262-04-11T11:59:59Z",
+			expect: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/search/query/date_range_test.go
+++ b/search/query/date_range_test.go
@@ -76,6 +76,11 @@ func TestValidateDatetimeRanges(t *testing.T) {
 			end:    "2262-04-12T00:00:00Z",
 			expect: false,
 		},
+		{
+			start:  "1950-03-22T12:23:23Z",
+			end:    "1960-02-21T15:23:34Z",
+			expect: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
    + MinAllowedTime: 1677-12-01T00:00:00Z
    + MaxAllowedTime: 2262-04-11T11:59:59Z

    Any NonZero time.Time values that fall outside this range
    will cause UnixNano() to overflow (int64 cannot accommodate).