### PR TITLE
coord factor disabling

### DIFF
--- a/search/query/match.go
+++ b/search/query/match.go
@@ -24,13 +24,14 @@ import (
 )
 
 type MatchQuery struct {
-	Match     string             `json:"match"`
-	FieldVal  string             `json:"field,omitempty"`
-	Analyzer  string             `json:"analyzer,omitempty"`
-	BoostVal  *Boost             `json:"boost,omitempty"`
-	Prefix    int                `json:"prefix_length"`
-	Fuzziness int                `json:"fuzziness"`
-	Operator  MatchQueryOperator `json:"operator,omitempty"`
+	Match        string             `json:"match"`
+	FieldVal     string             `json:"field,omitempty"`
+	Analyzer     string             `json:"analyzer,omitempty"`
+	BoostVal     *Boost             `json:"boost,omitempty"`
+	Prefix       int                `json:"prefix_length"`
+	Fuzziness    int                `json:"fuzziness"`
+	Operator     MatchQueryOperator `json:"operator,omitempty"`
+	DisableCoord bool               `json:"disable_coord,omitempty"`
 }
 
 type MatchQueryOperator int
@@ -114,6 +115,10 @@ func (q *MatchQuery) SetOperator(operator MatchQueryOperator) {
 	q.Operator = operator
 }
 
+func (q *MatchQuery) SetDisableCoord(disable bool) {
+	q.DisableCoord = disable
+}
+
 func (q *MatchQuery) Searcher(i index.IndexReader, m mapping.IndexMapping, options search.SearcherOptions) (search.Searcher, error) {
 
 	field := q.FieldVal
@@ -160,6 +165,7 @@ func (q *MatchQuery) Searcher(i index.IndexReader, m mapping.IndexMapping, optio
 			shouldQuery := NewDisjunctionQuery(tqs)
 			shouldQuery.SetMin(1)
 			shouldQuery.SetBoost(q.BoostVal.Value())
+			shouldQuery.SetDisableCoord(q.DisableCoord)
 			return shouldQuery.Searcher(i, m, options)
 
 		case MatchQueryOperatorAnd:

--- a/search/query/query_test.go
+++ b/search/query/query_test.go
@@ -106,6 +106,22 @@ func TestParseQuery(t *testing.T) {
 			}(),
 		},
 		{
+			input: []byte(`{"disjuncts":[{"match":"beer","field":"desc","disable_coord":true}],"disable_coord":true}`),
+			output: func() Query {
+				q := NewDisjunctionQuery([]Query{
+					func() Query {
+						q := NewMatchQuery("beer")
+						q.SetField("desc")
+						q.SetDisableCoord(true)
+						return q
+					}(),
+				})
+				q.SetDisableCoord(true)
+
+				return q
+			}(),
+		},
+		{
 			input: []byte(`{"must":{"conjuncts": [{"match":"beer","field":"desc"}]},"should":{"disjuncts": [{"match":"water","field":"desc"}],"min":1.0},"must_not":{"disjuncts": [{"match":"devon","field":"desc"}]}}`),
 			output: func() Query {
 				q := NewBooleanQuery(

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -31,14 +31,26 @@ var DisjunctionMaxClauseCount = 0
 // slice implementation to a heap implementation.
 var DisjunctionHeapTakeover = 10
 
-func NewDisjunctionSearcher(indexReader index.IndexReader,
-	qsearchers []search.Searcher, min float64, options search.SearcherOptions) (
-	search.Searcher, error) {
-	return newDisjunctionSearcher(indexReader, qsearchers, min, options, true)
+func NewDisjunctionSearcher(
+	indexReader index.IndexReader,
+	qsearchers []search.Searcher,
+	min float64,
+	options search.SearcherOptions,
+) (search.Searcher, error) {
+	return newDisjunctionSearcher(indexReader, qsearchers, min, true, options, true)
+}
+
+func NewUncoordDisjunctionSearcher(
+	indexReader index.IndexReader,
+	qsearchers []search.Searcher,
+	min float64,
+	options search.SearcherOptions,
+) (search.Searcher, error) {
+	return newDisjunctionSearcher(indexReader, qsearchers, min, false, options, true)
 }
 
 func newDisjunctionSearcher(indexReader index.IndexReader,
-	qsearchers []search.Searcher, min float64, options search.SearcherOptions,
+	qsearchers []search.Searcher, min float64, enableCoord bool, options search.SearcherOptions,
 	limit bool) (search.Searcher, error) {
 	// attempt the "unadorned" disjunction optimization only when we
 	// do not need extra information like freq-norm's or term vectors
@@ -53,11 +65,10 @@ func newDisjunctionSearcher(indexReader index.IndexReader,
 	}
 
 	if len(qsearchers) > DisjunctionHeapTakeover {
-		return newDisjunctionHeapSearcher(indexReader, qsearchers, min, options,
-			limit)
+		return newDisjunctionHeapSearcher(indexReader, qsearchers, min, enableCoord, options, limit)
 	}
-	return newDisjunctionSliceSearcher(indexReader, qsearchers, min, options,
-		limit)
+
+	return newDisjunctionSliceSearcher(indexReader, qsearchers, min, enableCoord, options, limit)
 }
 
 func optimizeCompositeSearcher(optimizationKind string,

--- a/search/searcher/search_disjunction_test.go
+++ b/search/searcher/search_disjunction_test.go
@@ -49,6 +49,20 @@ func TestDisjunctionSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	steveTermSearcher, err := NewTermSearcher(twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bobertTermSearcher, err := NewTermSearcher(twoDocIndexReader, "bobert", "name", 1.0, explainTrue)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	steveOrBobertUncoordSearcher, err := NewUncoordDisjunctionSearcher(twoDocIndexReader, []search.Searcher{steveTermSearcher, bobertTermSearcher}, 0, explainTrue)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	martyTermSearcher2, err := NewTermSearcher(twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +99,19 @@ func TestDisjunctionSearch(t *testing.T) {
 				{
 					IndexInternalID: index.IndexInternalID("3"),
 					Score:           0.6775110856165737,
+				},
+			},
+		},
+		{
+			searcher: steveOrBobertUncoordSearcher,
+			results: []*search.DocumentMatch{
+				{
+					IndexInternalID: index.IndexInternalID("2"),
+					Score:           1.3550221712331474,
+				},
+				{
+					IndexInternalID: index.IndexInternalID("5"),
+					Score:           1.3550221712331474,
 				},
 			},
 		},

--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -80,8 +80,7 @@ func newMultiTermSearcherBytes(indexReader index.IndexReader,
 	search.Searcher, error) {
 
 	// build disjunction searcher of these ranges
-	searcher, err := newDisjunctionSearcher(indexReader, searchers, 0, options,
-		limit)
+	searcher, err := newDisjunctionSearcher(indexReader, searchers, 0, true, options, limit)
 	if err != nil {
 		for _, s := range searchers {
 			_ = s.Close()


### PR DESCRIPTION
In some cases, it can be useful to disable the coord factor in disjunctive queries. This PR adds that functionality to disjunctive and match queries. If you have any feedback or find any problems with the changes, let me know and I'll update the PR.

Some background: https://www.elastic.co/guide/en/elasticsearch/guide/current/practical-scoring-function.html#coord