### PR TITLE
remove maxTerms optimization for ComputeGeoRange()

### DIFF
--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -40,7 +40,7 @@ func NewGeoBoundingBoxSearcher(indexReader index.IndexReader, minLon, minLat,
 
 	// do math to produce list of terms needed for this search
 	onBoundaryTerms, notOnBoundaryTerms, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
-		minLon, minLat, maxLon, maxLat, checkBoundaries, DisjunctionMaxClauseCount)
+		minLon, minLat, maxLon, maxLat, checkBoundaries)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ var geoMaxShift = document.GeoPrecisionStep * 4
 var geoDetailLevel = ((geo.GeoBits << 1) - geoMaxShift) / 2
 
 func ComputeGeoRange(term uint64, shift uint,
-	sminLon, sminLat, smaxLon, smaxLat float64, checkBoundaries bool, maxTerms int) (
+	sminLon, sminLat, smaxLon, smaxLat float64, checkBoundaries bool) (
 	onBoundary [][]byte, notOnBoundary [][]byte, err error) {
 	preallocBytesLen := 32
 	preallocBytes := make([]byte, preallocBytesLen)
@@ -144,13 +144,6 @@ func ComputeGeoRange(term uint64, shift uint,
 	}
 
 	computeGeoRange = func(term uint64, shift uint) {
-		if maxTerms > 0 {
-			if len(onBoundary) > maxTerms {
-				err = tooManyClausesErr(len(onBoundary))
-			} else if len(notOnBoundary) > maxTerms {
-				err = tooManyClausesErr(len(notOnBoundary))
-			}
-		}
 		if err != nil {
 			return
 		}

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -19,9 +19,11 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve/document"
+	"github.com/blevesearch/bleve/geo"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/index/store/gtreap"
 	"github.com/blevesearch/bleve/index/upsidedown"
+	"github.com/blevesearch/bleve/numeric"
 	"github.com/blevesearch/bleve/search"
 )
 
@@ -202,20 +204,18 @@ func setupGeo(t *testing.T) index.Index {
 func TestComputeGeoRange(t *testing.T) {
 	tests := []struct {
 		degs        float64
-		maxTerms    int
 		onBoundary  int
 		offBoundary int
 		err         string
 	}{
-		{0.01, 0, 4, 0, ""},
-		{0.1, 0, 56, 144, ""},
-		{100.0, 0, 32768, 258560, ""},
-		{100.0, 1024, 0, 0, "geo range produces too many terms, so should have error"},
+		{0.01, 4, 0, ""},
+		{0.1, 56, 144, ""},
+		{100.0, 32768, 258560, ""},
 	}
 
-	for _, test := range tests {
+	for testi, test := range tests {
 		onBoundaryRes, offBoundaryRes, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
-			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true, test.maxTerms)
+			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true)
 		if (err != nil) != (test.err != "") {
 			t.Errorf("test: %+v, err: %v", test, err)
 		}
@@ -224,6 +224,17 @@ func TestComputeGeoRange(t *testing.T) {
 		}
 		if len(offBoundaryRes) != test.offBoundary {
 			t.Errorf("test: %+v, offBoundaryRes: %v", test, len(offBoundaryRes))
+		}
+
+		onBROrig, offBROrig := origComputeGeoRange(0, GeoBitsShift1Minus1,
+			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true)
+		if !reflect.DeepEqual(onBoundaryRes, onBROrig) {
+			t.Errorf("testi: %d, test: %+v, onBoundaryRes != onBROrig,\n onBoundaryRes:%v,\n onBROrig: %v",
+				testi, test, onBoundaryRes, onBROrig)
+		}
+		if !reflect.DeepEqual(offBoundaryRes, offBROrig) {
+			t.Errorf("testi: %d, test: %+v, offBoundaryRes, offBROrig,\n offBoundaryRes: %v,\n offBROrig: %v",
+				testi, test, offBoundaryRes, offBROrig)
 		}
 	}
 }
@@ -264,7 +275,7 @@ func benchmarkComputeGeoRange(b *testing.B,
 
 	for i := 0; i < b.N; i++ {
 		onBoundaryRes, offBoundaryRes, err :=
-			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries, 0)
+			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries)
 		if err != nil {
 			b.Fatalf("expected no err")
 		}
@@ -272,4 +283,64 @@ func benchmarkComputeGeoRange(b *testing.B,
 			b.Fatalf("boundaries not matching")
 		}
 	}
+}
+
+// --------------------------------------------------------------------
+
+// original, non-optimized implementation of ComputeGeoRange
+func origComputeGeoRange(term uint64, shift uint,
+	sminLon, sminLat, smaxLon, smaxLat float64,
+	checkBoundaries bool) (
+	onBoundary [][]byte, notOnBoundary [][]byte) {
+	split := term | uint64(0x1)<<shift
+	var upperMax uint64
+	if shift < 63 {
+		upperMax = term | ((uint64(1) << (shift + 1)) - 1)
+	} else {
+		upperMax = 0xffffffffffffffff
+	}
+	lowerMax := split - 1
+	onBoundary, notOnBoundary = origRelateAndRecurse(term, lowerMax, shift,
+		sminLon, sminLat, smaxLon, smaxLat, checkBoundaries)
+	plusOnBoundary, plusNotOnBoundary := origRelateAndRecurse(split, upperMax, shift,
+		sminLon, sminLat, smaxLon, smaxLat, checkBoundaries)
+	onBoundary = append(onBoundary, plusOnBoundary...)
+	notOnBoundary = append(notOnBoundary, plusNotOnBoundary...)
+	return
+}
+
+// original, non-optimized implementation of relateAndRecurse
+func origRelateAndRecurse(start, end uint64, res uint,
+	sminLon, sminLat, smaxLon, smaxLat float64,
+	checkBoundaries bool) (
+	onBoundary [][]byte, notOnBoundary [][]byte) {
+	minLon := geo.MortonUnhashLon(start)
+	minLat := geo.MortonUnhashLat(start)
+	maxLon := geo.MortonUnhashLon(end)
+	maxLat := geo.MortonUnhashLat(end)
+
+	level := ((geo.GeoBits << 1) - res) >> 1
+
+	within := res%document.GeoPrecisionStep == 0 &&
+		geo.RectWithin(minLon, minLat, maxLon, maxLat,
+			sminLon, sminLat, smaxLon, smaxLat)
+	if within || (level == geoDetailLevel &&
+		geo.RectIntersects(minLon, minLat, maxLon, maxLat,
+			sminLon, sminLat, smaxLon, smaxLat)) {
+		if !within && checkBoundaries {
+			return [][]byte{
+				numeric.MustNewPrefixCodedInt64(int64(start), res),
+			}, nil
+		}
+		return nil,
+			[][]byte{
+				numeric.MustNewPrefixCodedInt64(int64(start), res),
+			}
+	} else if level < geoDetailLevel &&
+		geo.RectIntersects(minLon, minLat, maxLon, maxLat,
+			sminLon, sminLat, smaxLon, smaxLat) {
+		return origComputeGeoRange(start, res-1, sminLon, sminLat, smaxLon, smaxLat,
+			checkBoundaries)
+	}
+	return nil, nil
 }

--- a/search/searcher/search_geopointdistance_test.go
+++ b/search/searcher/search_geopointdistance_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/blevesearch/bleve/geo"
 	"github.com/blevesearch/bleve/index"
 	"github.com/blevesearch/bleve/search"
 )
@@ -81,4 +82,76 @@ func testGeoPointDistanceSearch(i index.IndexReader, centerLon, centerLat, dist 
 		return nil, err
 	}
 	return rv, nil
+}
+
+func TestGeoPointDistanceCompare(t *testing.T) {
+	tests := []struct {
+		docLat, docLon       float64
+		centerLat, centerLon float64
+		distance             string
+	}{
+		// Data points originally from MB-33454.
+		{
+			docLat:    33.718,
+			docLon:    -116.8293,
+			centerLat: 39.59000587,
+			centerLon: -119.22998428,
+			distance:  "10000mi",
+		},
+		{
+			docLat:    41.1305,
+			docLon:    -121.6587,
+			centerLat: 61.28,
+			centerLon: -149.34,
+			distance:  "10000mi",
+		},
+	}
+
+	for testi, test := range tests {
+		// compares the results from ComputeGeoRange with original, non-optimized version
+		compare := func(desc string,
+			minLon, minLat, maxLon, maxLat float64, checkBoundaries bool) {
+			// do math to produce list of terms needed for this search
+			onBoundaryRes, offBoundaryRes, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
+				minLon, minLat, maxLon, maxLat, checkBoundaries)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			onBROrig, offBROrig := origComputeGeoRange(0, GeoBitsShift1Minus1,
+				minLon, minLat, maxLon, maxLat, checkBoundaries)
+			if !reflect.DeepEqual(onBoundaryRes, onBROrig) {
+				t.Fatalf("testi: %d, test: %+v, desc: %s, onBoundaryRes != onBROrig,\n onBoundaryRes:%v,\n onBROrig: %v",
+					testi, test, desc, onBoundaryRes, onBROrig)
+			}
+			if !reflect.DeepEqual(offBoundaryRes, offBROrig) {
+				t.Fatalf("testi: %d, test: %+v, desc: %s, offBoundaryRes, offBROrig,\n offBoundaryRes: %v,\n offBROrig: %v",
+					testi, test, desc, offBoundaryRes, offBROrig)
+			}
+		}
+
+		// follow the general approach of the GeoPointDistanceSearcher...
+		dist, err := geo.ParseDistance(test.distance)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		topLeftLon, topLeftLat, bottomRightLon, bottomRightLat, err :=
+			geo.RectFromPointDistance(test.centerLon, test.centerLat, dist)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if bottomRightLon < topLeftLon {
+			// crosses date line, rewrite as two parts
+			compare("-180/f", -180, bottomRightLat, bottomRightLon, topLeftLat, false)
+			compare("-180/t", -180, bottomRightLat, bottomRightLon, topLeftLat, true)
+
+			compare("180/f", topLeftLon, bottomRightLat, 180, topLeftLat, false)
+			compare("180/t", topLeftLon, bottomRightLat, 180, topLeftLat, true)
+		} else {
+			compare("reg/f", topLeftLon, bottomRightLat, bottomRightLon, topLeftLat, false)
+			compare("reg/t", topLeftLon, bottomRightLat, bottomRightLon, topLeftLat, true)
+		}
+	}
 }


### PR DESCRIPTION
Unlike normal disjunctions, a geoboundingbox searcher does not limit
its multi-term-searcher against the DisjunctionMaxClauseCount, so my
recent maxTerms optimization for ComputeGeoRange() in commit 3d774b9
was just wrong.

This commit is a manual revert instead of an automated "git revert",
in that the previous commit 3d774b9 also changed a few things that
we'd still like to keep (e.g., error return value instead of
panic'ing) and there are now more unit tests in this commit from
diagnosing this issue, which compare the outputs of the optimized
ComputeGeoRange() with the previous, non-optimized version.

See also: https://issues.couchbase.com/browse/MB-33614