### PR TITLE
fix case when docInChunk = fieldChunkCount

### DIFF
--- a/cmd/bleve/cmd/zap/docvalue.go
+++ b/cmd/bleve/cmd/zap/docvalue.go
@@ -181,7 +181,7 @@ var docvalueCmd = &cobra.Command{
 		// find the chunkNumber where the docValues are stored
 		docInChunk := uint64(localDocNum) / uint64(segment.ChunkFactor())
 
-		if fieldChunkCount < docInChunk {
+		if fieldChunkCount <= docInChunk {
 			return fmt.Errorf("No chunk exists for chunk number: %d for "+
 				"localDocNum: %d", docInChunk, localDocNum)
 		}


### PR DESCRIPTION
specifically, if docInChunk 0,
but there are 0 chunks,
we cannot proceed