### PR TITLE
add optional validation hooks to scorch/zap

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -223,7 +223,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			}
 			err = zap.ValidateMerge(segmentsToMerge, docsToDrop, seg.(*zap.Segment))
 			if err != nil {
-				return fmt.Errorf("merge validation failed: %v")
+				return fmt.Errorf("merge validation failed: %v", err)
 			}
 			oldNewDocNums = make(map[uint64][]uint64)
 			for i, segNewDocNums := range newDocNums {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -316,7 +316,7 @@ func (s *Scorch) mergeSegmentBases(snapshot *IndexSnapshot,
 	}
 	err = zap.ValidateMerge(nil, sbs, sbsDrops, seg.(*zap.Segment))
 	if err != nil {
-		return nil, 0, fmt.Errorf("merge validation failed: %v", err)
+		return nil, 0, fmt.Errorf("in-memory merge validation failed: %v", err)
 	}
 
 	// update persisted stats

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -221,6 +221,10 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 				return err
 			}
+			err = zap.ValidateMerge(segmentsToMerge, docsToDrop, seg.(*zap.Segment))
+			if err != nil {
+				return fmt.Errorf("merge validation failed: %v")
+			}
 			oldNewDocNums = make(map[uint64][]uint64)
 			for i, segNewDocNums := range newDocNums {
 				oldNewDocNums[task.Segments[i].Id()] = segNewDocNums

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -151,7 +151,6 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 		atomic.AddUint64(&s.stats.TotFileMergePlanNone, 1)
 		return nil
 	}
-
 	atomic.AddUint64(&s.stats.TotFileMergePlanOk, 1)
 
 	atomic.AddUint64(&s.stats.TotFileMergePlanTasks, uint64(len(resultMergePlan.Tasks)))
@@ -221,7 +220,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 				return err
 			}
-			err = zap.ValidateMerge(segmentsToMerge, docsToDrop, seg.(*zap.Segment))
+			err = zap.ValidateMerge(segmentsToMerge, nil, docsToDrop, seg.(*zap.Segment))
 			if err != nil {
 				return fmt.Errorf("merge validation failed: %v", err)
 			}
@@ -314,6 +313,10 @@ func (s *Scorch) mergeSegmentBases(snapshot *IndexSnapshot,
 	if err != nil {
 		atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 		return nil, 0, err
+	}
+	err = zap.ValidateMerge(nil, sbs, sbsDrops, seg.(*zap.Segment))
+	if err != nil {
+		return nil, 0, fmt.Errorf("merge validation failed: %v", err)
 	}
 
 	// update persisted stats

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -33,8 +33,9 @@ var DefaultFileMergerBufferSize = 1024 * 1024
 
 // ValidateMerge can be set by applications to perform additional checks
 // on a new segment produced by a merge, by default this does nothing.
+// Caller should provide EITHER segments or memSegments, but not both.
 // This API is experimental and may be removed at any time.
-var ValidateMerge = func(segments []*Segment, drops []*roaring.Bitmap, newSegment *Segment) error {
+var ValidateMerge = func(segments []*Segment, memSegments []*SegmentBase, drops []*roaring.Bitmap, newSegment *Segment) error {
 	return nil
 }
 

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -31,6 +31,13 @@ import (
 
 var DefaultFileMergerBufferSize = 1024 * 1024
 
+// ValidateMerge can be set by applications to perform additional checks
+// on a new segment produced by a merge, by default this does nothing.
+// This API is experimental and may be removed at any time.
+var ValidateMerge = func(segments []*Segment, drops []*roaring.Bitmap, newSegment *Segment) error {
+	return nil
+}
+
 const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
 
 // Merge takes a slice of zap segments and bit masks describing which

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -33,6 +33,14 @@ var NewSegmentBufferNumResultsBump int = 100
 var NewSegmentBufferNumResultsFactor float64 = 1.0
 var NewSegmentBufferAvgBytesPerDocFactor float64 = 1.0
 
+// ValidateDocFields can be set by applications to perform additional checks
+// on fields in a document being added to a new segment, by default it does
+// nothing.
+// This API is experimental and may be removed at any time.
+var ValidateDocFields = func(field document.Field) error {
+	return nil
+}
+
 // AnalysisResultsToSegmentBase produces an in-memory zap-encoded
 // SegmentBase from analysis results
 func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
@@ -520,6 +528,11 @@ func (s *interim) writeStoredFields() (
 
 			if opts.IncludeDocValues() {
 				s.IncludeDocValues[fieldID] = true
+			}
+
+			err := ValidateDocFields(field)
+			if err != nil {
+				return 0, err
 			}
 		}
 


### PR DESCRIPTION
ValidateDocFields can be used to check each field
seen by zap

ValidateMerge can be used to check the results of
a merge operation

These hooks are intended to allow for application specific
checks inside the main bleve branch, so as to allow maximum
flexibility with minimal disruption.  These hooks are not
intended to be permanent, but that decision can be made
at a later time.