### PR TITLE
when index is already closed, close returns ErrorIndexClosed

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -755,6 +755,10 @@ func (i *indexImpl) Close() error {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
+	if !i.open {
+		return ErrorIndexClosed
+	}
+
 	indexStats.UnRegister(i)
 
 	i.open = false


### PR DESCRIPTION
this change make Close() consistent with the other bleve
methods.  if an index is closed, the method should do
nothing, and return ErrorIndexClosed.

previously, the underlying index implementation would
be closed again, and in the case of scorch this can
lead to panics:

```
ERRO[0004] runtime.plainError close of closed channel
/usr/local/go/src/runtime/panic.go:513 (0x42e079)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/go/src/runtime/chan.go:335 (0x4074fe)
	closechan: panic(plainError("close of closed channel"))
```