### PR TITLE
MB-33364 - perf wrinkles with geo queries

### DIFF
--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -40,7 +40,7 @@ func NewGeoBoundingBoxSearcher(indexReader index.IndexReader, minLon, minLat,
 
 	// do math to produce list of terms needed for this search
 	onBoundaryTerms, notOnBoundaryTerms, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
-		minLon, minLat, maxLon, maxLat, checkBoundaries)
+		minLon, minLat, maxLon, maxLat, checkBoundaries, indexReader, field)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,8 @@ var geoMaxShift = document.GeoPrecisionStep * 4
 var geoDetailLevel = ((geo.GeoBits << 1) - geoMaxShift) / 2
 
 func ComputeGeoRange(term uint64, shift uint,
-	sminLon, sminLat, smaxLon, smaxLat float64, checkBoundaries bool) (
+	sminLon, sminLat, smaxLon, smaxLat float64, checkBoundaries bool,
+	indexReader index.IndexReader, field string) (
 	onBoundary [][]byte, notOnBoundary [][]byte, err error) {
 	preallocBytesLen := 32
 	preallocBytes := make([]byte, preallocBytesLen)
@@ -117,6 +118,21 @@ func ComputeGeoRange(term uint64, shift uint,
 		return rv
 	}
 
+	isIndexed := func(term []byte) bool {
+		if indexReader != nil {
+			reader, err := indexReader.TermFieldReader(term, field, false, false, false)
+			if err != nil || reader == nil {
+				return false
+			}
+			if reader.Count() == 0 {
+				_ = reader.Close()
+				return false
+			}
+			_ = reader.Close()
+		}
+		return true
+	}
+
 	var computeGeoRange func(term uint64, shift uint) // declare for recursion
 
 	relateAndRecurse := func(start, end uint64, res, level uint) {
@@ -131,10 +147,13 @@ func ComputeGeoRange(term uint64, shift uint,
 		if within || (level == geoDetailLevel &&
 			geo.RectIntersects(minLon, minLat, maxLon, maxLat,
 				sminLon, sminLat, smaxLon, smaxLat)) {
-			if !within && checkBoundaries {
-				onBoundary = append(onBoundary, makePrefixCoded(int64(start), res))
-			} else {
-				notOnBoundary = append(notOnBoundary, makePrefixCoded(int64(start), res))
+			codedTerm := makePrefixCoded(int64(start), res)
+			if isIndexed(codedTerm) {
+				if !within && checkBoundaries {
+					onBoundary = append(onBoundary, makePrefixCoded(int64(start), res))
+				} else {
+					notOnBoundary = append(notOnBoundary, makePrefixCoded(int64(start), res))
+				}
 			}
 		} else if level < geoDetailLevel &&
 			geo.RectIntersects(minLon, minLat, maxLon, maxLat,

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -215,7 +215,7 @@ func TestComputeGeoRange(t *testing.T) {
 
 	for testi, test := range tests {
 		onBoundaryRes, offBoundaryRes, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
-			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true)
+			-1.0*test.degs, -1.0*test.degs, test.degs, test.degs, true, nil, "")
 		if (err != nil) != (test.err != "") {
 			t.Errorf("test: %+v, err: %v", test, err)
 		}
@@ -275,7 +275,7 @@ func benchmarkComputeGeoRange(b *testing.B,
 
 	for i := 0; i < b.N; i++ {
 		onBoundaryRes, offBoundaryRes, err :=
-			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries)
+			ComputeGeoRange(0, GeoBitsShift1Minus1, minLon, minLat, maxLon, maxLat, checkBoundaries, nil, "")
 		if err != nil {
 			b.Fatalf("expected no err")
 		}

--- a/search/searcher/search_geopointdistance_test.go
+++ b/search/searcher/search_geopointdistance_test.go
@@ -113,7 +113,7 @@ func TestGeoPointDistanceCompare(t *testing.T) {
 			minLon, minLat, maxLon, maxLat float64, checkBoundaries bool) {
 			// do math to produce list of terms needed for this search
 			onBoundaryRes, offBoundaryRes, err := ComputeGeoRange(0, GeoBitsShift1Minus1,
-				minLon, minLat, maxLon, maxLat, checkBoundaries)
+				minLon, minLat, maxLon, maxLat, checkBoundaries, nil, "")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Geo queries are reported to have high memory consumption
and higher latencies.
One plausible root cause for this could be,
-Very high number of candidate terms computed during
 the bounded box ranges. (unlike other queries, looks like
 these terms are just mathematically created without actual
 existence in the bleve index)
-Too many candidate terms keeps more TermFieldReaders and
 term searcher objects live and manage over the disjunction heap.

This fix tries to filter out the onBoundary/notOnBoundary
terms early in the search path so that it creates
lesser garbage from TFRs, term byte searchers and lighter
disjunction heap management.

Fix have shown good improvement with numbers in local/mac
environment against the functional tests with
1000 documents and num_queries=100

Average FTS latency in ms for 100 queries
63.20892059(new) Vs 189.9222353(existing)

~3X improvement in average latency is observed with
latency reduction upto 6X for certain queries.

So the latency spikes got better normalised.
eg:
New ms             Vs          Old ms

80.392502	 Vs    427.297942
306.575176	 Vs    1555.539272
435.612816	 Vs    2431.383857
307.829132	 Vs    1402.138768
148.749478	 Vs     936.793944
293.825909	 Vs    944.349282
390.313823	 Vs    469.521313
620.221195	 Vs    2414.491882
455.174285      Vs   1655.026496
185.31835         Vs .  746.681948




