### PR TITLE
add missing setter method for SetSearchBefore

### DIFF
--- a/search.go
+++ b/search.go
@@ -342,6 +342,12 @@ func (r *SearchRequest) SetSearchAfter(after []string) {
 	r.SearchAfter = after
 }
 
+// SetSearchBefore sets the request to skip over hits with a sort
+// value greater than the provided sort before key
+func (r *SearchRequest) SetSearchBefore(before []string) {
+	r.SearchBefore = before
+}
+
 // UnmarshalJSON deserializes a JSON representation of
 // a SearchRequest
 func (r *SearchRequest) UnmarshalJSON(input []byte) error {


### PR DESCRIPTION
There's a setter method for `SearchAfter` (called `SetSearchAfter`) but no method to do the same for `SearchBefore`.