### PR TITLE
add test cases for multi-sort with search before/after

### DIFF
--- a/test/tests/sort/data/g.json
+++ b/test/tests/sort/data/g.json
@@ -1,0 +1,8 @@
+{
+	"id": "g",
+	"name": "marty",
+	"age": 27,
+  "born": "2012-09-21",
+	"title": "mista",
+	"tags": ["foo", "bar"]
+}

--- a/test/tests/sort/searches.json
+++ b/test/tests/sort/searches.json
@@ -10,7 +10,7 @@
       "sort": ["name"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "c"
@@ -20,6 +20,9 @@
         },
         {
           "id": "a"
+        },
+        {
+          "id": "g"
         },
         {
           "id": "e"
@@ -44,7 +47,7 @@
       "sort": ["-name"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
         {
           "id": "b"
@@ -54,6 +57,9 @@
         },
         {
           "id": "a"
+        },
+        {
+          "id": "g"
         },
         {
           "id": "f"
@@ -78,7 +84,7 @@
       "sort": [{"by":"field","field":"name","missing":"first","desc":true}]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
         {
           "id": "d"
@@ -91,6 +97,9 @@
         },
         {
           "id": "a"
+        },
+        {
+          "id": "g"
         },
         {
           "id": "f"
@@ -112,7 +121,7 @@
       "sort": ["age"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "f"
@@ -125,6 +134,9 @@
         },
         {
           "id": "c"
+        },
+        {
+          "id": "g"
         },
         {
           "id": "d"
@@ -146,11 +158,14 @@
       "sort": ["-age"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "d"
 				},
+        {
+          "id": "g"
+        },
         {
           "id": "b"
         },
@@ -180,13 +195,16 @@
       "sort": [{"by":"field","field":"age","missing":"first","desc":true}]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
         {
           "id": "e"
         },
 				{
 					"id": "d"
+				},
+				{
+					"id": "g"
 				},
         {
           "id": "b"
@@ -214,7 +232,7 @@
       "sort": ["born"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "c"
@@ -227,6 +245,9 @@
         },
         {
           "id": "b"
+        },
+        {
+          "id": "g"
         },
         {
           "id": "a"
@@ -248,11 +269,14 @@
       "sort": ["-born"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "a"
 				},
+        {
+          "id": "g"
+        },
         {
           "id": "b"
         },
@@ -282,7 +306,7 @@
       "sort": [{"by":"field","field":"born","missing":"first","desc":true}]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
         {
           "id": "f"
@@ -290,6 +314,9 @@
 				{
 					"id": "a"
 				},
+        {
+          "id": "g"
+        },
         {
           "id": "b"
         },
@@ -316,8 +343,11 @@
       "sort": [{"by":"field","field":"tags","mode":"min"}]
     },
     "result": {
-      "total_hits": 6,
+      "total_hits": 7,
       "hits": [
+        {
+          "id": "g"
+        },
         {
           "id": "a"
         },
@@ -350,7 +380,7 @@
       "sort": ["age", "name"]
 		},
 		"result": {
-			"total_hits": 6,
+			"total_hits": 7,
 			"hits": [
 				{
 					"id": "f"
@@ -365,6 +395,9 @@
           "id": "b"
         },
         {
+          "id": "g"
+        },
+        {
           "id": "d"
         },
         {
@@ -374,39 +407,42 @@
 		}
 	},
   {
-      "comment": "sort by docid descending",
-  		"search": {
-  			"from": 0,
-  			"size": 10,
-  			"query": {
-  				"match_all":{}
-  			},
-        "sort": ["-_id"]
-  		},
-  		"result": {
-  			"total_hits": 6,
-  			"hits": [
-  				{
-  					"id": "f"
-  				},
-          {
-            "id": "e"
-          },
-          {
-            "id": "d"
-          },
-          {
-            "id": "c"
-          },
-          {
-            "id": "b"
-          },
-          {
-            "id": "a"
-          }
-  			]
-  		}
-  	},
+    "comment": "sort by docid descending",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "match_all":{}
+      },
+      "sort": ["-_id"]
+    },
+    "result": {
+      "total_hits": 7,
+      "hits": [
+        {
+          "id": "g"
+        },
+        {
+          "id": "f"
+        },
+        {
+          "id": "e"
+        },
+        {
+          "id": "d"
+        },
+        {
+          "id": "c"
+        },
+        {
+          "id": "b"
+        },
+        {
+          "id": "a"
+        }
+      ]
+    }
+  },
   {
     "comment": "sort by name, ascending, after marty",
     "search": {
@@ -419,8 +455,40 @@
       "search_after": ["marty"]
     },
     "result": {
-      "total_hits": 6,
+      "total_hits": 7,
       "hits": [
+        {
+          "id": "e"
+        },
+        {
+          "id": "b"
+        },
+        {
+          "id": "d"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "multi-valued sort by name, _id (both ascending), after frank",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "match_all":{}
+      },
+      "sort": ["name", "_id"],
+      "search_after": ["frank", "f"]
+    },
+    "result": {
+      "total_hits": 7,
+      "hits": [
+        {
+          "id": "a"
+        },
+        {
+          "id": "g"
+        },
         {
           "id": "e"
         },
@@ -445,7 +513,7 @@
       "search_before": ["nancy"]
     },
     "result": {
-      "total_hits": 6,
+      "total_hits": 7,
       "hits": [
         {
           "id": "c"
@@ -455,6 +523,38 @@
         },
         {
           "id": "a"
+        },
+        {
+          "id": "g"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "multi-valued sort by name, _id (both ascending), before nancy",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "match_all":{}
+      },
+      "sort": ["name", "_id"],
+      "search_before": ["nancy", "e"]
+    },
+    "result": {
+      "total_hits": 7,
+      "hits": [
+        {
+          "id": "c"
+        },
+        {
+          "id": "f"
+        },
+        {
+          "id": "a"
+        },
+        {
+          "id": "g"
         }
       ]
     }


### PR DESCRIPTION
This PR adds new test cases for sorts with tied (ie. identical) values.

The tests pass using the default index and keyvalue types:

```
$ go test ./test/... -count=1 -v -run TestIntegration
=== RUN   TestIntegration
--- PASS: TestIntegration (0.67s)
    integration_test.go:49: using index type upside_down and kv type boltdb
    integration_test.go:71: Running test: alias
    integration_test.go:71: Running test: basic
    integration_test.go:71: Running test: employee
    integration_test.go:71: Running test: facet
    integration_test.go:71: Running test: fosdem
    integration_test.go:71: Running test: geo
    integration_test.go:71: Running test: phrase
    integration_test.go:71: Running test: sort
PASS
ok  	_/home/tyler/src/bleve/test	0.685s
```

But the same tests fail when using `scorch`:

```
$ go test ./test/... -count=1 -v -run TestIntegration -indexType=scorch -kvType=scorch
=== RUN   TestIntegration
--- FAIL: TestIntegration (1.11s)
    integration_test.go:49: using index type scorch and kv type scorch
    integration_test.go:71: Running test: alias
    integration_test.go:71: Running test: basic
    integration_test.go:71: Running test: employee
    integration_test.go:71: Running test: facet
    integration_test.go:71: Running test: fosdem
    integration_test.go:71: Running test: geo
    integration_test.go:71: Running test: phrase
    integration_test.go:71: Running test: sort
    integration_test.go:150: test error - sort by name, ascending
    integration_test.go:151: test 0 - expected hit 2 to have ID a got g
    integration_test.go:150: test error - sort by name, ascending
    integration_test.go:151: test 0 - expected hit 3 to have ID g got a
    integration_test.go:150: test error - sort by name, descending
    integration_test.go:151: test 1 - expected hit 2 to have ID a got g
    integration_test.go:150: test error - sort by name, descending
    integration_test.go:151: test 1 - expected hit 3 to have ID g got a
    integration_test.go:150: test error - sort by name, descending, missing first
    integration_test.go:151: test 2 - expected hit 3 to have ID a got g
    integration_test.go:150: test error - sort by name, descending, missing first
    integration_test.go:151: test 2 - expected hit 4 to have ID g got a
    integration_test.go:150: test error - sort by name, ascending, before nancy
    integration_test.go:151: test 14 - expected hit 2 to have ID a got g
    integration_test.go:150: test error - sort by name, ascending, before nancy
    integration_test.go:151: test 14 - expected hit 3 to have ID g got a
FAIL
FAIL	_/home/tyler/src/bleve/test	1.130s
```

The failures occur on the "tied" values. Scorch appears to simply returned tied values in a different order than the default index/kv.

Results are returned in the expected order when using a multi-valued sort so that the results no longer tie.

This doesn't impact my usage of bleve (since I've always used scorch) but I'm opening this PR in case it is news/noteworthy for you. Feel free to simply close if the issue is known and/or not considered a problem.