### PR TITLE
fix scorch regex literal prefix for case insensitive

### DIFF
--- a/index/scorch/segment/regexp.go
+++ b/index/scorch/segment/regexp.go
@@ -55,7 +55,7 @@ func LiteralPrefix(s *syntax.Regexp) string {
 		s = s.Sub[0]
 	}
 
-	if s.Op == syntax.OpLiteral {
+	if s.Op == syntax.OpLiteral && (s.Flags&syntax.FoldCase == 0) {
 		return string(s.Rune)
 	}
 

--- a/index/scorch/segment/regexp_test.go
+++ b/index/scorch/segment/regexp_test.go
@@ -40,6 +40,7 @@ func TestLiteralPrefix(t *testing.T) {
 		{`^hello`, ""},
 		{`^`, ""},
 		{`$`, ""},
+		{`(?i)mArTy`, ""},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
the previous version incorrectly returned a literal
prefix when case-insensitive matching was enabled