### PR TITLE
Adding Contains method to segment TermDictionary

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -121,8 +121,8 @@ type IndexReaderOnly interface {
 	FieldDictOnly(field string, onlyTerms [][]byte, includeCount bool) (FieldDict, error)
 }
 
-type IndexReaderExists interface {
-	FieldDictExists(field string) (FieldDictExists, error)
+type IndexReaderContains interface {
+	FieldDictContains(field string) (FieldDictContains, error)
 }
 
 // FieldTerms contains the terms used by a document, keyed by field
@@ -234,8 +234,8 @@ type FieldDict interface {
 	Close() error
 }
 
-type FieldDictExists interface {
-	Exists(key []byte) (bool, error)
+type FieldDictContains interface {
+	Contains(key []byte) (bool, error)
 }
 
 // DocIDReader is the interface exposing enumeration of documents identifiers.

--- a/index/scorch/segment/empty.go
+++ b/index/scorch/segment/empty.go
@@ -91,8 +91,8 @@ func (e *EmptyDictionary) OnlyIterator(onlyTerms [][]byte,
 	return &EmptyDictionaryIterator{}
 }
 
-func (e *EmptyDictionary) ExistsIterator() DictionaryIterator {
-	return &EmptyDictionaryIterator{}
+func (e *EmptyDictionary) Contains(key []byte) (bool, error) {
+	return false, nil
 }
 
 type EmptyDictionaryIterator struct{}
@@ -101,7 +101,7 @@ func (e *EmptyDictionaryIterator) Next() (*index.DictEntry, error) {
 	return nil, nil
 }
 
-func (e *EmptyDictionaryIterator) Exists(key []byte) (bool, error) {
+func (e *EmptyDictionaryIterator) Contains(key []byte) (bool, error) {
 	return false, nil
 }
 

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -59,12 +59,12 @@ type TermDictionary interface {
 	AutomatonIterator(a vellum.Automaton,
 		startKeyInclusive, endKeyExclusive []byte) DictionaryIterator
 	OnlyIterator(onlyTerms [][]byte, includeCount bool) DictionaryIterator
-	ExistsIterator() DictionaryIterator
+
+	Contains(key []byte) (bool, error)
 }
 
 type DictionaryIterator interface {
 	Next() (*index.DictEntry, error)
-	Exists(key []byte) (bool, error)
 }
 
 type PostingsList interface {

--- a/index/scorch/snapshot_index_dict.go
+++ b/index/scorch/snapshot_index_dict.go
@@ -22,6 +22,7 @@ import (
 )
 
 type segmentDictCursor struct {
+	dict segment.TermDictionary
 	itr  segment.DictionaryIterator
 	curr index.DictEntry
 }
@@ -92,13 +93,13 @@ func (i *IndexSnapshotFieldDict) Close() error {
 	return nil
 }
 
-func (i *IndexSnapshotFieldDict) Exists(key []byte) (bool, error) {
+func (i *IndexSnapshotFieldDict) Contains(key []byte) (bool, error) {
 	if len(i.cursors) == 0 {
 		return false, nil
 	}
 
 	for _, cursor := range i.cursors {
-		if found, _ := cursor.itr.Exists(key); found {
+		if found, _ := cursor.dict.Contains(key); found {
 			return true, nil
 		}
 	}

--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -120,16 +120,16 @@ func ComputeGeoRange(term uint64, shift uint,
 		return rv
 	}
 
-	var fieldDict index.FieldDictExists
+	var fieldDict index.FieldDictContains
 	var isIndexed filterFunc
-	if irr, ok := indexReader.(index.IndexReaderExists); ok {
-		fieldDict, err = irr.FieldDictExists(field)
+	if irr, ok := indexReader.(index.IndexReaderContains); ok {
+		fieldDict, err = irr.FieldDictContains(field)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		isIndexed = func(term []byte) bool {
-			found, err := fieldDict.Exists(term)
+			found, err := fieldDict.Contains(term)
 			return err == nil && found
 		}
 	}

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -54,17 +54,17 @@ func NewNumericRangeSearcher(indexReader index.IndexReader,
 		maxInt64--
 	}
 
-	var fieldDict index.FieldDictExists
+	var fieldDict index.FieldDictContains
 	var isIndexed filterFunc
 	var err error
-	if irr, ok := indexReader.(index.IndexReaderExists); ok {
-		fieldDict, err = irr.FieldDictExists(field)
+	if irr, ok := indexReader.(index.IndexReaderContains); ok {
+		fieldDict, err = irr.FieldDictContains(field)
 		if err != nil {
 			return nil, err
 		}
 
 		isIndexed = func(term []byte) bool {
-			found, err := fieldDict.Exists(term)
+			found, err := fieldDict.Contains(term)
 			return err == nil && found
 		}
 	}


### PR DESCRIPTION
TermDictionary's Contains api implementation to use the
FST's Contains method directly, and there is
no need for a ContainsIterator for TD now.