### PR TITLE
Adding validation checks for geopoint field types

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -75,6 +75,10 @@ func (dm *DocumentMapping) Validate(cache *registry.Cache) error {
 				return err
 			}
 		}
+		if field.Type == "geopoint" && !field.DocValues {
+			return fmt.Errorf("DocValues option should be enabled "+
+				"for field type: '%s'", field.Type)
+		}
 		switch field.Type {
 		case "text", "datetime", "number", "boolean", "geopoint":
 		default:


### PR DESCRIPTION
As the DocValues indexing option is mandatory for geo queries to
work, adding new validation checks to ensure that DocValues are
enabled for geopoint field types.
