### PR TITLE
Fix import ordering with goimports

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -16,9 +16,10 @@ package zap
 
 import (
 	"bufio"
-	"github.com/couchbase/vellum"
 	"math"
 	"os"
+
+	"github.com/couchbase/vellum"
 )
 
 const Version uint32 = 11


### PR DESCRIPTION
Keeps the list sorted and prevents future merge conflicts.