### PR TITLE
Avoid unnecessary conversions

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -413,7 +413,7 @@ func (i *IndexSnapshot) segmentIndexAndLocalDocNumFromGlobal(docNum uint64) (int
 		}) - 1
 
 	localDocNum := docNum - i.offsets[segmentIndex]
-	return int(segmentIndex), localDocNum
+	return segmentIndex, localDocNum
 }
 
 func (i *IndexSnapshot) ExternalID(id index.IndexInternalID) (string, error) {

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -394,7 +394,7 @@ func (dm *DocumentMapping) walkDocument(data interface{}, path []string, indexes
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		dm.processProperty(float64(val.Uint()), path, indexes, context)
 	case reflect.Float32, reflect.Float64:
-		dm.processProperty(float64(val.Float()), path, indexes, context)
+		dm.processProperty(val.Float(), path, indexes, context)
 	case reflect.Bool:
 		dm.processProperty(val.Bool(), path, indexes, context)
 	}

--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -62,8 +62,7 @@ func queryTimeFromString(t string) (time.Time, error) {
 }
 
 func (t *BleveQueryTime) MarshalJSON() ([]byte, error) {
-	tt := time.Time(t.Time)
-	return []byte("\"" + tt.Format(QueryDateTimeFormat) + "\""), nil
+	return []byte("\"" + t.Time.Format(QueryDateTimeFormat) + "\""), nil
 }
 
 func (t *BleveQueryTime) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
No need to convert when it's already matching the right type.