### PR TITLE
scorch: fix crashes on ARM due to mis-aligned atomic access

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -41,12 +41,14 @@ const Version uint8 = 2
 var ErrClosed = fmt.Errorf("scorch closed")
 
 type Scorch struct {
+	nextSegmentID uint64
+	stats         Stats
+	iStats        internalStats
+
 	readOnly      bool
 	version       uint8
 	config        map[string]interface{}
 	analysisQueue *index.AnalysisQueue
-	stats         Stats
-	nextSegmentID uint64
 	path          string
 
 	unsafeBatch bool
@@ -72,8 +74,6 @@ type Scorch struct {
 
 	onEvent      func(event Event)
 	onAsyncError func(err error)
-
-	iStats internalStats
 
 	pauseLock sync.RWMutex
 

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -183,9 +183,9 @@ func (cfd *cachedFieldDocs) prepareField(field string, ss *SegmentSnapshot) {
 }
 
 type cachedDocs struct {
+	size  uint64
 	m     sync.Mutex                  // As the cache is asynchronously prepared, need a lock
 	cache map[string]*cachedFieldDocs // Keyed by field
-	size  uint64
 }
 
 func (c *cachedDocs) prepareFields(wantedFields []string, ss *SegmentSnapshot) error {


### PR DESCRIPTION
opening on behalf of @darren

makes Scorch and cachedDocs aligned so that scorch run properly on arm

see the bottom of page on https://golang.org/pkg/sync/atomic/#pkg-note-BUG

fixes #1231