### PR TITLE
Tightening the scorch stale file clean ups

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -764,12 +764,11 @@ func (s *Scorch) removeOldData() {
 	if err != nil {
 		s.fireAsyncError(fmt.Errorf("got err removing old bolt snapshots: %v", err))
 	}
+	atomic.AddUint64(&s.stats.TotSnapshotsRemovedFromMetaStore, uint64(removed))
 
-	if removed > 0 {
-		err = s.removeOldZapFiles()
-		if err != nil {
-			s.fireAsyncError(fmt.Errorf("got err removing old zap files: %v", err))
-		}
+	err = s.removeOldZapFiles()
+	if err != nil {
+		s.fireAsyncError(fmt.Errorf("got err removing old zap files: %v", err))
 	}
 }
 

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -490,6 +490,9 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["CurOnDiskBytes"] = numBytesUsedDisk
 	m["CurOnDiskFiles"] = numFilesOnDisk
 
+	s.rootLock.RLock()
+	m["CurFilesIneligibleForRemoval"] = uint64(len(s.ineligibleForRemoval))
+	s.rootLock.RUnlock()
 	// TODO: consider one day removing these backwards compatible
 	// names for apps using the old names
 	m["updates"] = m["TotUpdates"]

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -107,6 +107,9 @@ type Stats struct {
 	TotFileMergeIntroductionsDone    uint64
 	TotFileMergeIntroductionsSkipped uint64
 
+	CurFilesIneligibleForRemoval     uint64
+	TotSnapshotsRemovedFromMetaStore uint64
+
 	TotMemMergeBeg          uint64
 	TotMemMergeErr          uint64
 	TotMemMergeDone         uint64


### PR DESCRIPTION
Fix for #1269.
Its observed in an under resourced situation that
the merger was treading ahead of the persister and the
scorch files were piling up. It was reaching upto 70K
with an update heavy workload.

The intention of this fix is to unflip any
ineligible files which are genuinely eligible for
clean up.

Also, adding stats to track this for future.