### PR TITLE
add method to access analyzer of a text field

### DIFF
--- a/document/field_text.go
+++ b/document/field_text.go
@@ -86,6 +86,10 @@ func (t *TextField) Analyze() (int, analysis.TokenFrequencies) {
 	return fieldLength, tokenFreqs
 }
 
+func (t *TextField) Analyzer() *analysis.Analyzer {
+	return t.analyzer
+}
+
 func (t *TextField) Value() []byte {
 	return t.value
 }


### PR DESCRIPTION
this change allows applications to see the analyzer set for
a text field, useful if applications want to modify the document
after mapping, but prior to indexing.