### PR TITLE
Update RoaringBitmap/roaring package

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -78,7 +78,7 @@
 			"importpath": "github.com/RoaringBitmap/roaring",
 			"repository": "https://github.com/RoaringBitmap/roaring",
 			"vcs": "",
-			"revision": "d0ce1763c3526f65703c395da50da7a7fb2138d5",
+			"revision": "bbe4f2294041c4a33ed31f5bc61c19507acd9cb7",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This updates the version of `RoaringBitmap/roaring` package. Unfortunately, there was a really tricky [bug](https://github.com/RoaringBitmap/roaring/pull/229) with `Iterator.AdvanceIfNeeded`, so it is better to update the dependency.