### PR TITLE
Start analysis workers lazily

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,9 @@ type configuration struct {
 }
 
 func (c *configuration) SetAnalysisQueueSize(n int) {
+	if c.analysisQueue != nil {
+		c.analysisQueue.Close()
+	}
 	c.analysisQueue = index.NewAnalysisQueue(n)
 }
 

--- a/index/analysis.go
+++ b/index/analysis.go
@@ -16,6 +16,7 @@ package index
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/blevesearch/bleve/analysis"
 	"github.com/blevesearch/bleve/document"
@@ -75,23 +76,33 @@ func NewAnalysisWork(i Index, d *document.Document, rc chan *AnalysisResult) *An
 type AnalysisQueue struct {
 	queue chan *AnalysisWork
 	done  chan struct{}
+
+	startWorkersOnce sync.Once
+	numWorkers       int
+
+	closeOnce sync.Once
+}
+
+func (q *AnalysisQueue) startWorkers() {
+	for i := 0; i < q.numWorkers; i++ {
+		go AnalysisWorker(*q)
+	}
 }
 
 func (q *AnalysisQueue) Queue(work *AnalysisWork) {
+	q.startWorkersOnce.Do(q.startWorkers)
 	q.queue <- work
 }
 
 func (q *AnalysisQueue) Close() {
-	close(q.done)
+	q.closeOnce.Do(func() { close(q.done) })
 }
 
 func NewAnalysisQueue(numWorkers int) *AnalysisQueue {
 	rv := AnalysisQueue{
-		queue: make(chan *AnalysisWork),
-		done:  make(chan struct{}),
-	}
-	for i := 0; i < numWorkers; i++ {
-		go AnalysisWorker(rv)
+		queue:      make(chan *AnalysisWork),
+		done:       make(chan struct{}),
+		numWorkers: numWorkers,
 	}
 	return &rv
 }


### PR DESCRIPTION
Fixes two issues with potentially superfluous goroutines related to analysis workers:

1. When a `Config` is created, analysis workers are started immediately. As a consequence, every Go binary that transitively imports `github.com/blevesearch/bleve` has those goroutines running even if no analysis work is ever performed (the root `bleve` package also contains definitions of query and result types so there are legitimate reasons for importing it in library code).
2. When `SetAnalysisQueueSize` is called on a config object, the old analysis workers keep running in idle state forever, not receiving new work but not getting shut down.