### PR TITLE
Support for bounded polygon query

### DIFF
--- a/search/query/geo_boundingpolygon.go
+++ b/search/query/geo_boundingpolygon.go
@@ -26,7 +26,7 @@ import (
 )
 
 type GeoBoundingPolygonQuery struct {
-	Points   []geo.Point `json:"points"`
+	Points   []geo.Point `json:"polygon_points"`
 	FieldVal string      `json:"field,omitempty"`
 	BoostVal *Boost      `json:"boost,omitempty"`
 }
@@ -69,7 +69,7 @@ func (q *GeoBoundingPolygonQuery) Validate() error {
 
 func (q *GeoBoundingPolygonQuery) UnmarshalJSON(data []byte) error {
 	tmp := struct {
-		Points   []interface{} `json:"points"`
+		Points   []interface{} `json:"polygon_points"`
 		FieldVal string        `json:"field,omitempty"`
 		BoostVal *Boost        `json:"boost,omitempty"`
 	}{}

--- a/search/query/geo_boundingpolygon.go
+++ b/search/query/geo_boundingpolygon.go
@@ -1,0 +1,94 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/blevesearch/bleve/geo"
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/mapping"
+	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/search/searcher"
+)
+
+type GeoBoundingPolygonQuery struct {
+	Points   []geo.Point `json:"points"`
+	FieldVal string      `json:"field,omitempty"`
+	BoostVal *Boost      `json:"boost,omitempty"`
+}
+
+func NewGeoBoundingPolygonQuery(points []geo.Point) *GeoBoundingPolygonQuery {
+	return &GeoBoundingPolygonQuery{
+		Points: points}
+}
+
+func (q *GeoBoundingPolygonQuery) SetBoost(b float64) {
+	boost := Boost(b)
+	q.BoostVal = &boost
+}
+
+func (q *GeoBoundingPolygonQuery) Boost() float64 {
+	return q.BoostVal.Value()
+}
+
+func (q *GeoBoundingPolygonQuery) SetField(f string) {
+	q.FieldVal = f
+}
+
+func (q *GeoBoundingPolygonQuery) Field() string {
+	return q.FieldVal
+}
+
+func (q *GeoBoundingPolygonQuery) Searcher(i index.IndexReader,
+	m mapping.IndexMapping, options search.SearcherOptions) (search.Searcher, error) {
+	field := q.FieldVal
+	if q.FieldVal == "" {
+		field = m.DefaultSearchField()
+	}
+
+	return searcher.NewGeoBoundedPolygonSearcher(i, q.Points, field, q.BoostVal.Value(), options)
+}
+
+func (q *GeoBoundingPolygonQuery) Validate() error {
+	return nil
+}
+
+func (q *GeoBoundingPolygonQuery) UnmarshalJSON(data []byte) error {
+	tmp := struct {
+		Points   []interface{} `json:"points"`
+		FieldVal string        `json:"field,omitempty"`
+		BoostVal *Boost        `json:"boost,omitempty"`
+	}{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	q.Points = make([]geo.Point, 0, len(tmp.Points))
+	for _, i := range tmp.Points {
+		// now use our generic point parsing code from the geo package
+		lon, lat, found := geo.ExtractGeoPoint(i)
+		if !found {
+			return fmt.Errorf("geo polygon point: %v is not in a valid format", i)
+		}
+		q.Points = append(q.Points, geo.Point{Lon: lon, Lat: lat})
+	}
+
+	q.FieldVal = tmp.FieldVal
+	q.BoostVal = tmp.BoostVal
+	return nil
+}

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -273,7 +273,7 @@ func ParseQuery(input []byte) (Query, error) {
 		}
 		return &rv, nil
 	}
-	_, hasPoints := tmp["points"]
+	_, hasPoints := tmp["polygon_points"]
 	if hasPoints {
 		var rv GeoBoundingPolygonQuery
 		err := json.Unmarshal(input, &rv)

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -273,6 +273,15 @@ func ParseQuery(input []byte) (Query, error) {
 		}
 		return &rv, nil
 	}
+	_, hasPoints := tmp["points"]
+	if hasPoints {
+		var rv GeoBoundingPolygonQuery
+		err := json.Unmarshal(input, &rv)
+		if err != nil {
+			return nil, err
+		}
+		return &rv, nil
+	}
 	return nil, fmt.Errorf("unknown query type")
 }
 

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -34,7 +34,7 @@ func NewGeoPointDistanceSearcher(indexReader index.IndexReader, centerLon,
 	// build a searcher for the box
 	boxSearcher, err := boxSearcher(indexReader,
 		topLeftLon, topLeftLat, bottomRightLon, bottomRightLat,
-		field, boost, options)
+		field, boost, options, false)
 	if err != nil {
 		return nil, err
 	}
@@ -54,19 +54,20 @@ func NewGeoPointDistanceSearcher(indexReader index.IndexReader, centerLon,
 // two boxes joined through a disjunction searcher
 func boxSearcher(indexReader index.IndexReader,
 	topLeftLon, topLeftLat, bottomRightLon, bottomRightLat float64,
-	field string, boost float64, options search.SearcherOptions) (
+	field string, boost float64, options search.SearcherOptions, checkBoundaries bool) (
 	search.Searcher, error) {
 	if bottomRightLon < topLeftLon {
 		// cross date line, rewrite as two parts
 
 		leftSearcher, err := NewGeoBoundingBoxSearcher(indexReader,
 			-180, bottomRightLat, bottomRightLon, topLeftLat,
-			field, boost, options, false)
+			field, boost, options, checkBoundaries)
 		if err != nil {
 			return nil, err
 		}
 		rightSearcher, err := NewGeoBoundingBoxSearcher(indexReader,
-			topLeftLon, bottomRightLat, 180, topLeftLat, field, boost, options, false)
+			topLeftLon, bottomRightLat, 180, topLeftLat, field, boost, options,
+			checkBoundaries)
 		if err != nil {
 			_ = leftSearcher.Close()
 			return nil, err
@@ -85,7 +86,7 @@ func boxSearcher(indexReader index.IndexReader,
 	// build geoboundinggox searcher for that bounding box
 	boxSearcher, err := NewGeoBoundingBoxSearcher(indexReader,
 		topLeftLon, bottomRightLat, bottomRightLon, topLeftLat, field, boost,
-		options, false)
+		options, checkBoundaries)
 	if err != nil {
 		return nil, err
 	}

--- a/search/searcher/search_geopolygon.go
+++ b/search/searcher/search_geopolygon.go
@@ -1,0 +1,110 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"github.com/blevesearch/bleve/geo"
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/numeric"
+	"github.com/blevesearch/bleve/search"
+	"math"
+)
+
+func NewGeoBoundedPolygonSearcher(indexReader index.IndexReader,
+	polygon []geo.Point, field string, boost float64,
+	options search.SearcherOptions) (search.Searcher, error) {
+
+	// compute the bounding box enclosing the polygon
+	topLeftLon, topLeftLat, bottomRightLon, bottomRightLat, err :=
+		geo.BoundingRectangleForPolygon(polygon)
+	if err != nil {
+		return nil, err
+	}
+
+	// build a searcher for the bounding box on the polygon
+	boxSearcher, err := boxSearcher(indexReader,
+		topLeftLon, topLeftLat, bottomRightLon, bottomRightLat,
+		field, boost, options, true)
+	if err != nil {
+		return nil, err
+	}
+
+	dvReader, err := indexReader.DocValueReader([]string{field})
+	if err != nil {
+		return nil, err
+	}
+
+	// wrap it in a filtering searcher that checks for the polygon inclusivity
+	return NewFilteringSearcher(boxSearcher,
+		buildPolygonFilter(dvReader, field, polygon)), nil
+}
+
+const float64EqualityThreshold = 1e-6
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) <= float64EqualityThreshold
+}
+
+// buildPolygonFilter returns true if the point lies inside the
+// polygon. It is based on the ray-casting technique as referred
+// here: https://wrf.ecse.rpi.edu/nikola/pubdetails/pnpoly.html
+func buildPolygonFilter(dvReader index.DocValueReader, field string,
+	polygon []geo.Point) FilterFunc {
+	return func(d *search.DocumentMatch) bool {
+		var lon, lat float64
+		var found bool
+
+		err := dvReader.VisitDocValues(d.IndexInternalID, func(field string, term []byte) {
+			// only consider the values which are shifted 0
+			prefixCoded := numeric.PrefixCoded(term)
+			shift, err := prefixCoded.Shift()
+			if err == nil && shift == 0 {
+				i64, err := prefixCoded.Int64()
+				if err == nil {
+					lon = geo.MortonUnhashLon(uint64(i64))
+					lat = geo.MortonUnhashLat(uint64(i64))
+					found = true
+				}
+			}
+		})
+
+		// Note: this approach works for points which are strictly inside
+		// the polygon. ie it might fail for certain points on the polygon boundaries.
+		if err == nil && found {
+			nVertices := len(polygon)
+			var inside bool
+			// check for a direct vertex match
+			if almostEqual(polygon[0].Lat, lat) &&
+				almostEqual(polygon[0].Lon, lon) {
+				return true
+			}
+
+			for i := 1; i < nVertices; i++ {
+				if almostEqual(polygon[i].Lat, lat) &&
+					almostEqual(polygon[i].Lon, lon) {
+					return true
+				}
+				if (polygon[i].Lat > lat) != (polygon[i-1].Lat > lat) &&
+					lon < (polygon[i-1].Lon-polygon[i].Lon)*(lat-polygon[i].Lat)/
+						(polygon[i-1].Lat-polygon[i].Lat)+polygon[i].Lon {
+					inside = !inside
+				}
+			}
+			return inside
+
+		}
+		return false
+	}
+}

--- a/search/searcher/search_geopolygon_test.go
+++ b/search/searcher/search_geopolygon_test.go
@@ -83,6 +83,10 @@ func TestRealGeoPolygons(t *testing.T) {
 		{[]geo.Point{{Lon: -80.304, Lat: 40.740}, {Lon: -80.038, Lat: 40.239}, {Lon: -79.562, Lat: 40.786}, {Lon: -80.018, Lat: 40.328}}, "loc", []string{"p"}},
 		{[]geo.Point{{Lon: -111.918, Lat: 33.515}, {Lon: -111.938, Lat: 33.494}, {Lon: -111.944, Lat: 33.481}, {Lon: -111.886, Lat: 33.517},
 			{Lon: -111.919, Lat: 33.468}, {Lon: -111.929, Lat: 33.508}}, "loc", []string{"q"}},
+		// real points near cb bangalore
+		{[]geo.Point{{Lat: 12.974872, Lon: 77.607749}, {Lat: 12.971725, Lon: 77.610110},
+			{Lat: 12.972530, Lon: 77.606912}, {Lat: 12.975112, Lon: 77.603780},
+		}, "loc", []string{"amoeba", "communiti"}},
 	}
 
 	i := setupGeoPolygonPoints(t)
@@ -287,5 +291,26 @@ func setupGeoPolygonPoints(t *testing.T) index.Index {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	err = i.Update(&document.Document{
+		ID: "amoeba",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 77.60490, 12.97467),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "communiti",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 77.608237, 12.97237),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return i
 }

--- a/search/searcher/search_geopolygon_test.go
+++ b/search/searcher/search_geopolygon_test.go
@@ -1,0 +1,291 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blevesearch/bleve/document"
+	"github.com/blevesearch/bleve/geo"
+	"github.com/blevesearch/bleve/index"
+	"github.com/blevesearch/bleve/index/store/gtreap"
+	"github.com/blevesearch/bleve/index/upsidedown"
+	"github.com/blevesearch/bleve/search"
+)
+
+func TestSimpleGeoPolygons(t *testing.T) {
+
+	tests := []struct {
+		polygon []geo.Point
+		field   string
+		want    []string
+	}{
+		// test points inside a triangle & on vertices
+		// r, s - inside and t,u - on vertices.
+		{[]geo.Point{{Lon: 1.0, Lat: 1.0}, {Lon: 2.0, Lat: 1.9}, {Lon: 2.0, Lat: 1.0}}, "loc", []string{"r", "s", "t", "u"}},
+		// non overlapping polygon for the indexed documents
+		{[]geo.Point{{Lon: 3.0, Lat: 1.0}, {Lon: 4.0, Lat: 2.5}, {Lon: 3.0, Lat: 2}}, "loc", nil},
+	}
+	i := setupGeoPolygonPoints(t)
+	indexReader, err := i.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	for _, test := range tests {
+		got, err := testGeoPolygonSearch(indexReader, test.polygon, test.field)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("expected %v, got %v for polygon: %+v", test.want, got, test.polygon)
+		}
+	}
+}
+
+func TestRealGeoPolygons(t *testing.T) {
+
+	tests := []struct {
+		polygon []geo.Point
+		field   string
+		want    []string
+	}{
+		{[]geo.Point{{Lon: -80.881, Lat: 35.282}, {Lon: -80.858, Lat: 35.281},
+			{Lon: -80.864, Lat: 35.270}}, "loc", []string{"k", "l"}},
+		{[]geo.Point{{Lon: -82.467, Lat: 36.356}, {Lon: -78.127, Lat: 36.321}, {Lon: -80.555, Lat: 32.932},
+			{Lon: -84.807, Lat: 33.111}}, "loc", []string{"k", "l", "m"}},
+		// same polygon vertices
+		{[]geo.Point{{Lon: -82.467, Lat: 36.356}, {Lon: -82.467, Lat: 36.356}, {Lon: -82.467, Lat: 36.356}, {Lon: -82.467, Lat: 36.356}}, "loc", nil},
+		// non-overlaping polygon
+		{[]geo.Point{{Lon: -89.113, Lat: 36.400}, {Lon: -93.947, Lat: 36.471}, {Lon: -93.947, Lat: 34.031}}, "loc", nil},
+		// concave polygon with a document `n` residing inside the hands, but outside the polygon
+		{[]geo.Point{{Lon: -71.65, Lat: 42.446}, {Lon: -71.649, Lat: 42.428}, {Lon: -71.640, Lat: 42.445}, {Lon: -71.649, Lat: 42.435}}, "loc", nil},
+		// V like concave polygon with a document 'p' residing inside the bottom corner
+		{[]geo.Point{{Lon: -80.304, Lat: 40.740}, {Lon: -80.038, Lat: 40.239}, {Lon: -79.562, Lat: 40.786}, {Lon: -80.018, Lat: 40.328}}, "loc", []string{"p"}},
+		{[]geo.Point{{Lon: -111.918, Lat: 33.515}, {Lon: -111.938, Lat: 33.494}, {Lon: -111.944, Lat: 33.481}, {Lon: -111.886, Lat: 33.517},
+			{Lon: -111.919, Lat: 33.468}, {Lon: -111.929, Lat: 33.508}}, "loc", []string{"q"}},
+	}
+
+	i := setupGeoPolygonPoints(t)
+	indexReader, err := i.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	for _, test := range tests {
+		got, err := testGeoPolygonSearch(indexReader, test.polygon, test.field)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("expected %v, got %v for polygon: %+v", test.want, got, test.polygon)
+		}
+	}
+}
+
+func TestGeoRectanglePolygon(t *testing.T) {
+
+	tests := []struct {
+		polygon []geo.Point
+		field   string
+		want    []string
+	}{
+		{[]geo.Point{{Lon: 0.001, Lat: 0.001}, {Lon: 85.002, Lat: 38.002}}, "loc",
+			[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}},
+	}
+
+	i := setupGeo(t)
+	indexReader, err := i.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	for _, test := range tests {
+		got, err := testGeoPolygonSearch(indexReader, test.polygon, test.field)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("expected %v, got %v for polygon: %+v", test.want, got, test.polygon)
+		}
+	}
+}
+
+func testGeoPolygonSearch(i index.IndexReader, polygon []geo.Point, field string) ([]string, error) {
+	var rv []string
+	gbs, err := NewGeoBoundedPolygonSearcher(i, polygon, field, 1.0, search.SearcherOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ctx := &search.SearchContext{
+		DocumentMatchPool: search.NewDocumentMatchPool(gbs.DocumentMatchPoolSize(), 0),
+	}
+	docMatch, err := gbs.Next(ctx)
+	for docMatch != nil && err == nil {
+		rv = append(rv, string(docMatch.IndexInternalID))
+		docMatch, err = gbs.Next(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rv, nil
+}
+
+func setupGeoPolygonPoints(t *testing.T) index.Index {
+	analysisQueue := index.NewAnalysisQueue(1)
+	i, err := upsidedown.NewUpsideDownCouch(
+		gtreap.Name,
+		map[string]interface{}{
+			"path": "",
+		},
+		analysisQueue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = i.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "k",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -80.86469327, 35.2782),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "l",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -80.8713, 35.28138),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "m",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -84.25, 33.153),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "n",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -89.992, 35.063),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "o",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -71.648, 42.437),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "p",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -80.016, 40.314),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "q",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, -111.919, 33.494),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "r",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 1.5, 1.1),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "s",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 2, 1.5),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "t",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 2.0, 1.9),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = i.Update(&document.Document{
+		ID: "u",
+		Fields: []document.Field{
+			document.NewGeoPointField("loc", []uint64{}, 2.0, 1.0),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return i
+}

--- a/test/tests/geo/data/amoeba_brewery.json
+++ b/test/tests/geo/data/amoeba_brewery.json
@@ -1,0 +1,1 @@
+{"name":"amoeba brewery","city":"bangalore","state":"KAR","code":"","country":"India","phone":"","website":"","type":"brewery","updated":"2019-09-17 20:00:20","description":"brewery near cb office","address":[],"geo":{"accuracy":"APPROXIMATE","lat":12.97467,"lon":77.60490}}

--- a/test/tests/geo/data/communiti_brewery.json
+++ b/test/tests/geo/data/communiti_brewery.json
@@ -1,0 +1,1 @@
+{"name":"communiti brewery","city":"bangalore","state":"KAR","code":"","country":"India","phone":"","website":"","type":"brewery","updated":"2019-09-17 20:00:20","description":"brewery near cb office","address":[],"geo":{"accuracy":"APPROXIMATE","lat":12.97237,"lon":77.608237}}

--- a/test/tests/geo/data/social_brewery.json
+++ b/test/tests/geo/data/social_brewery.json
@@ -1,0 +1,1 @@
+{"name":"social brewery","city":"bangalore","state":"KAR","code":"","country":"India","phone":"","website":"","type":"brewery","updated":"2019-09-17 20:00:20","description":"brewery near cb office, but outside the polygon","address":[],"geo":{"accuracy":"APPROXIMATE","lat":12.9736946,"lon":77.6042133}}

--- a/test/tests/geo/searches.json
+++ b/test/tests/geo/searches.json
@@ -220,5 +220,107 @@
         }
       ]
     }
+  },
+  {
+    "comment": "polygon around cb office area, using GeoJSON lat/lon as array",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "polygon_points": [[77.607749,12.974872],[77.6101101,12.971725],[77.606912,12.972530],[77.603780,12.975112]],
+        "field": "geo"
+      },
+      "sort": [
+        "name"
+      ]
+    },
+    "result": {
+      "total_hits": 2,
+      "hits": [
+        {
+          "id": "amoeba_brewery"
+        },
+        {
+          "id": "communiti_brewery"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "polygon around cb office area, using GeoJSON lat/lon as string",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "polygon_points": ["12.974872, 77.607749","12.971725, 77.6101101","12.972530, 77.606912","12.975112, 77.603780"],
+        "field": "geo"
+      },
+      "sort": [
+        "name"
+      ]
+    },
+    "result": {
+      "total_hits": 2,
+      "hits": [
+        {
+          "id": "amoeba_brewery"
+        },
+        {
+          "id": "communiti_brewery"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "polygon around cb office area",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "polygon_points": [{"lat":12.974872, "lon":77.607749}, {"lat":12.971725, "lon":77.6101101},
+          {"lat":12.972530, "lon":77.606912}, {"lat":12.975112, "lon":77.603780}],
+        "field": "geo"
+      },
+      "sort": [
+        "name"
+      ]
+    },
+    "result": {
+      "total_hits": 2,
+      "hits": [
+        {
+          "id": "amoeba_brewery"
+        },
+        {
+          "id": "communiti_brewery"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "polygon around cb office area as geohash",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "polygon_points": ["tdr1y40", "tdr1y13", "tdr1vcx", "tdr1vfj"],
+        "field": "geo"
+      },
+      "sort": [
+        "name"
+      ]
+    },
+    "result": {
+      "total_hits": 2,
+      "hits": [
+        {
+          "id": "amoeba_brewery"
+        },
+        {
+          "id": "communiti_brewery"
+        }
+      ]
+    }
   }
 ]
+


### PR DESCRIPTION
Attempt to introduce GeoBoundingPolygonQuery
to enable the bounded polygon queries.
Polygon searcher internally finds the bounded
rectangle for the given polygon points and
apply the filter which performs the point-in-polygon
checks.
In this iteration, as simplicity is preferred over
precision(on boundary points), the point-in-polygon check
is based on ray-casting algorithm.

geo points can be in any of the following forms as with other geo queries
{"query": {"field": "geo", "polygon_points":[[-80.881,35.282],[-80.858,35.281],[-80.864,35.270]]}}
"query": {"field": "geo", "polygon_points":[{"lon" :-80.881,"lat":35.282},{"lon":-80.858,"lat":35.281},{"lon":-80.864,"lat":35.270}]}}
{"query": {"field": "geo", "polygon_points":["35.282,-80.881","35.281, -80.858","35.270,-80.864"]}}
{"query": {"field": "geo", "polygon_points":["dnq2xwbk8","dnq88n9n8","dnq2xusws"]}}