### PR TITLE
[GEO] Search all numeric type terms to match geo points

### DIFF
--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -96,7 +96,7 @@ func boxSearcher(indexReader index.IndexReader,
 func buildDistFilter(dvReader index.DocValueReader, field string,
 	centerLon, centerLat, maxDist float64) FilterFunc {
 	return func(d *search.DocumentMatch) bool {
-		// check geo matches against all numeric tpe terms indexed
+		// check geo matches against all numeric type terms indexed
 		var lons, lats []float64
 		var found bool
 

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -96,7 +96,8 @@ func boxSearcher(indexReader index.IndexReader,
 func buildDistFilter(dvReader index.DocValueReader, field string,
 	centerLon, centerLat, maxDist float64) FilterFunc {
 	return func(d *search.DocumentMatch) bool {
-		var lon, lat float64
+		// check geo matches against all numeric tpe terms indexed
+		var lons, lats []float64
 		var found bool
 
 		err := dvReader.VisitDocValues(d.IndexInternalID, func(field string, term []byte) {
@@ -106,16 +107,18 @@ func buildDistFilter(dvReader index.DocValueReader, field string,
 			if err == nil && shift == 0 {
 				i64, err := prefixCoded.Int64()
 				if err == nil {
-					lon = geo.MortonUnhashLon(uint64(i64))
-					lat = geo.MortonUnhashLat(uint64(i64))
+					lons = append(lons, geo.MortonUnhashLon(uint64(i64)))
+					lats = append(lats, geo.MortonUnhashLat(uint64(i64)))
 					found = true
 				}
 			}
 		})
 		if err == nil && found {
-			dist := geo.Haversin(lon, lat, centerLon, centerLat)
-			if dist <= maxDist/1000 {
-				return true
+			for i := range lons {
+				dist := geo.Haversin(lons[i], lats[i], centerLon, centerLat)
+				if dist <= maxDist/1000 {
+					return true
+				}
 			}
 		}
 		return false

--- a/search_test.go
+++ b/search_test.go
@@ -1622,9 +1622,9 @@ func TestGeoDistanceIssue1301(t *testing.T) {
 		}
 	}
 
-	// Not setting "Field" for the following query is returning inconsistent
-	// results, when there's another field indexed which is numeric and both
-	// these fields are included within _all.
+	// Not setting "Field" for the following query, targets it against the _all
+	// field and this is returning inconsistent results, when there's another
+	// field indexed along with the geopoint which is numeric.
 	// As reported in: https://github.com/blevesearch/bleve/issues/1301
 	lat, lon := 22.371154, 114.112603
 	q := NewGeoDistanceQuery(lon, lat, "1km")


### PR DESCRIPTION
If a field (for example _all) were to index multiple numeric terms
(of type numeric and geopoint morton hash), verify all numeric
matches rather than just the last encountered entry to determine
if the entry morton unhashes into a geo point match.

Fixes: https://github.com/blevesearch/bleve/issues/1301