### PR TITLE
avoid writing nil entry to newSegments on zap.Open failures

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -553,10 +553,11 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 			}
 		}()
 		for segmentID, path := range newSegmentPaths {
-			newSegments[segmentID], err = zap.Open(path)
+			seg, err := zap.Open(path)
 			if err != nil {
 				return fmt.Errorf("error opening new segment at %s, %v", path, err)
 			}
+			newSegments[segmentID] = seg
 		}
 
 		persist := &persistIntroduction{


### PR DESCRIPTION
i'm not certain what golang's behavior is with the previous syntax when an error occurs, but it seems safer to do it this way

/cc #1305