### PR TITLE
scorch/zap: disable mmap on 32-bit systems

### DIFF
--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -128,6 +128,7 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkFactor uint32,
 	dictLocs []uint64) (*SegmentBase, error) {
 	sb := &SegmentBase{
 		mem:               mem,
+		memSize:           len(mem),
 		memCRC:            memCRC,
 		chunkFactor:       chunkFactor,
 		fieldsMap:         fieldsMap,

--- a/index/scorch/segment/zap/mem.go
+++ b/index/scorch/segment/zap/mem.go
@@ -1,0 +1,36 @@
+//  Copyright (c) 2017 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+func (s *SegmentBase) readMem(x, y uint64) []byte {
+	if s.mem == nil {
+		data, _ := ioutil.ReadAll(io.NewSectionReader(s.f, int64(x), int64(y-x)))
+		return data
+	}
+	return s.mem[x:y]
+}
+
+func (s *Segment) readMM(x, y int) []byte {
+	if s.mm == nil {
+		data, _ := ioutil.ReadAll(io.NewSectionReader(s.f, int64(x), int64(y-x)))
+		return data
+	}
+	return s.mm[x:y]
+}

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -797,7 +797,7 @@ func (s *SegmentBase) copyStoredDocs(newDocNum uint64, newDocNumOffsets []uint64
 
 	storedOffset0New := uint64(w.Count())
 
-	storedBytes := s.mem[storedOffset0 : storedOffsetN+readN+metaLenN+dataLenN]
+	storedBytes := s.readMem(storedOffset0, storedOffsetN+readN+metaLenN+dataLenN)
 	_, err := w.Write(storedBytes)
 	if err != nil {
 		return err
@@ -806,7 +806,7 @@ func (s *SegmentBase) copyStoredDocs(newDocNum uint64, newDocNumOffsets []uint64
 	// remap the storedOffset's for the docs into new offsets relative
 	// to storedOffset0New, filling the given docNumOffsetsOut array
 	for indexOffset := indexOffset0; indexOffset <= indexOffsetN; indexOffset += 8 {
-		storedOffset := binary.BigEndian.Uint64(s.mem[indexOffset : indexOffset+8])
+		storedOffset := binary.BigEndian.Uint64(s.readMem(indexOffset, indexOffset+8))
 		storedOffsetNew := storedOffset - storedOffset0 + storedOffset0New
 		newDocNumOffsets[newDocNum] = storedOffsetNew
 		newDocNum += 1

--- a/index/scorch/segment/zap/read.go
+++ b/index/scorch/segment/zap/read.go
@@ -19,8 +19,8 @@ import "encoding/binary"
 func (s *SegmentBase) getDocStoredMetaAndCompressed(docNum uint64) ([]byte, []byte) {
 	_, storedOffset, n, metaLen, dataLen := s.getDocStoredOffsets(docNum)
 
-	meta := s.mem[storedOffset+n : storedOffset+n+metaLen]
-	data := s.mem[storedOffset+n+metaLen : storedOffset+n+metaLen+dataLen]
+	meta := s.readMem(storedOffset+n, storedOffset+n+metaLen)
+	data := s.readMem(storedOffset+n+metaLen, storedOffset+n+metaLen+dataLen)
 
 	return meta, data
 }
@@ -29,14 +29,14 @@ func (s *SegmentBase) getDocStoredOffsets(docNum uint64) (
 	uint64, uint64, uint64, uint64, uint64) {
 	indexOffset := s.storedIndexOffset + (8 * docNum)
 
-	storedOffset := binary.BigEndian.Uint64(s.mem[indexOffset : indexOffset+8])
+	storedOffset := binary.BigEndian.Uint64(s.readMem(indexOffset, indexOffset+8))
 
 	var n uint64
 
-	metaLen, read := binary.Uvarint(s.mem[storedOffset : storedOffset+binary.MaxVarintLen64])
+	metaLen, read := binary.Uvarint(s.readMem(storedOffset, storedOffset+binary.MaxVarintLen64))
 	n += uint64(read)
 
-	dataLen, read := binary.Uvarint(s.mem[storedOffset+n : storedOffset+n+binary.MaxVarintLen64])
+	dataLen, read := binary.Uvarint(s.readMem(storedOffset+n, storedOffset+n+binary.MaxVarintLen64))
 	n += uint64(read)
 
 	return indexOffset, storedOffset, n, metaLen, dataLen

--- a/index/scorch/segment/zap/segment.go
+++ b/index/scorch/segment/zap/segment.go
@@ -31,11 +31,16 @@ import (
 	"github.com/golang/snappy"
 )
 
-var reflectStaticSizeSegmentBase int
+var (
+	reflectStaticSizeSegmentBase int
+	ptrSize                      int
+)
 
 func init() {
 	var sb SegmentBase
 	reflectStaticSizeSegmentBase = int(unsafe.Sizeof(sb))
+	var p *int
+	ptrSize = int(unsafe.Sizeof(p))
 }
 
 // Open returns a zap impl of a segment
@@ -44,24 +49,36 @@ func Open(path string) (segment.Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	mm, err := mmap.Map(f, mmap.RDONLY, 0)
+	stat, err := f.Stat()
 	if err != nil {
-		// mmap failed, try to close the file
-		_ = f.Close()
 		return nil, err
+	}
+	mmSize := int(stat.Size())
+
+	var mm mmap.MMap
+	var mem []byte
+	if ptrSize == 8 {
+		// Skip mmap on 32-bit systems due to limited virtual address space
+		mm, err = mmap.Map(f, mmap.RDONLY, 0)
+	}
+	if mm != nil {
+		mem = mm[0 : mmSize-FooterSize]
 	}
 
 	rv := &Segment{
 		SegmentBase: SegmentBase{
-			mem:            mm[0 : len(mm)-FooterSize],
+			f:              f,
+			mem:            mem,
+			memSize:        mmSize - FooterSize,
 			fieldsMap:      make(map[string]uint16),
 			fieldDvReaders: make(map[uint16]*docValueReader),
 			fieldFSTs:      make(map[uint16]*vellum.FST),
 		},
-		f:    f,
-		mm:   mm,
-		path: path,
-		refs: 1,
+		f:      f,
+		mm:     mm,
+		mmSize: mmSize,
+		path:   path,
+		refs:   1,
 	}
 	rv.SegmentBase.updateSize()
 
@@ -89,7 +106,9 @@ func Open(path string) (segment.Segment, error) {
 // SegmentBase is a memory only, read-only implementation of the
 // segment.Segment interface, using zap's data representation.
 type SegmentBase struct {
+	f                 *os.File
 	mem               []byte
+	memSize           int
 	memCRC            uint32
 	chunkFactor       uint32
 	fieldsMap         map[string]uint16 // fieldName -> fieldID+1
@@ -113,7 +132,7 @@ func (sb *SegmentBase) Size() int {
 
 func (sb *SegmentBase) updateSize() {
 	sizeInBytes := reflectStaticSizeSegmentBase +
-		cap(sb.mem)
+		sb.memSize
 
 	// fieldsMap
 	for k, _ := range sb.fieldsMap {
@@ -148,6 +167,7 @@ type Segment struct {
 
 	f       *os.File
 	mm      mmap.MMap
+	mmSize  int
 	path    string
 	version uint32
 	crc     uint32
@@ -168,7 +188,7 @@ func (s *Segment) Size() int {
 	sizeInBytes += 16
 
 	// do not include the mmap'ed part
-	return sizeInBytes + s.SegmentBase.Size() - cap(s.mem)
+	return sizeInBytes + s.SegmentBase.Size() - s.memSize
 }
 
 func (s *Segment) AddRef() {
@@ -188,52 +208,51 @@ func (s *Segment) DecRef() (err error) {
 }
 
 func (s *Segment) loadConfig() error {
-	crcOffset := len(s.mm) - 4
-	s.crc = binary.BigEndian.Uint32(s.mm[crcOffset : crcOffset+4])
+	crcOffset := s.mmSize - 4
+	s.crc = binary.BigEndian.Uint32(s.readMM(crcOffset, crcOffset+4))
 
 	verOffset := crcOffset - 4
-	s.version = binary.BigEndian.Uint32(s.mm[verOffset : verOffset+4])
+	s.version = binary.BigEndian.Uint32(s.readMM(verOffset, verOffset+4))
 	if s.version != Version {
 		return fmt.Errorf("unsupported version %d", s.version)
 	}
 
 	chunkOffset := verOffset - 4
-	s.chunkFactor = binary.BigEndian.Uint32(s.mm[chunkOffset : chunkOffset+4])
+	s.chunkFactor = binary.BigEndian.Uint32(s.readMM(chunkOffset, chunkOffset+4))
 
 	docValueOffset := chunkOffset - 8
-	s.docValueOffset = binary.BigEndian.Uint64(s.mm[docValueOffset : docValueOffset+8])
+	s.docValueOffset = binary.BigEndian.Uint64(s.readMM(docValueOffset, docValueOffset+8))
 
 	fieldsIndexOffset := docValueOffset - 8
-	s.fieldsIndexOffset = binary.BigEndian.Uint64(s.mm[fieldsIndexOffset : fieldsIndexOffset+8])
+	s.fieldsIndexOffset = binary.BigEndian.Uint64(s.readMM(fieldsIndexOffset, fieldsIndexOffset+8))
 
 	storedIndexOffset := fieldsIndexOffset - 8
-	s.storedIndexOffset = binary.BigEndian.Uint64(s.mm[storedIndexOffset : storedIndexOffset+8])
+	s.storedIndexOffset = binary.BigEndian.Uint64(s.readMM(storedIndexOffset, storedIndexOffset+8))
 
 	numDocsOffset := storedIndexOffset - 8
-	s.numDocs = binary.BigEndian.Uint64(s.mm[numDocsOffset : numDocsOffset+8])
+	s.numDocs = binary.BigEndian.Uint64(s.readMM(numDocsOffset, numDocsOffset+8))
 	return nil
 }
 
 func (s *SegmentBase) loadFields() error {
 	// NOTE for now we assume the fields index immediately precedes
-	// the footer, and if this changes, need to adjust accordingly (or
-	// store explicit length), where s.mem was sliced from s.mm in Open().
-	fieldsIndexEnd := uint64(len(s.mem))
+	// the footer.
+	fieldsIndexEnd := uint64(s.memSize)
 
 	// iterate through fields index
 	var fieldID uint64
 	for s.fieldsIndexOffset+(8*fieldID) < fieldsIndexEnd {
-		addr := binary.BigEndian.Uint64(s.mem[s.fieldsIndexOffset+(8*fieldID) : s.fieldsIndexOffset+(8*fieldID)+8])
+		addr := binary.BigEndian.Uint64(s.readMem(s.fieldsIndexOffset+(8*fieldID), s.fieldsIndexOffset+(8*fieldID)+8))
 
-		dictLoc, read := binary.Uvarint(s.mem[addr:fieldsIndexEnd])
+		dictLoc, read := binary.Uvarint(s.readMem(addr, fieldsIndexEnd))
 		n := uint64(read)
 		s.dictLocs = append(s.dictLocs, dictLoc)
 
 		var nameLen uint64
-		nameLen, read = binary.Uvarint(s.mem[addr+n : fieldsIndexEnd])
+		nameLen, read = binary.Uvarint(s.readMem(addr+n, fieldsIndexEnd))
 		n += uint64(read)
 
-		name := string(s.mem[addr+n : addr+n+nameLen])
+		name := string(s.readMem(addr+n, addr+n+nameLen))
 		s.fieldsInv = append(s.fieldsInv, name)
 		s.fieldsMap[name] = uint16(fieldID + 1)
 
@@ -266,8 +285,8 @@ func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 			sb.m.Lock()
 			if rv.fst, ok = sb.fieldFSTs[rv.fieldID]; !ok {
 				// read the length of the vellum data
-				vellumLen, read := binary.Uvarint(sb.mem[dictStart : dictStart+binary.MaxVarintLen64])
-				fstBytes := sb.mem[dictStart+uint64(read) : dictStart+uint64(read)+vellumLen]
+				vellumLen, read := binary.Uvarint(sb.readMem(dictStart, dictStart+binary.MaxVarintLen64))
+				fstBytes := sb.readMem(dictStart+uint64(read), dictStart+uint64(read)+vellumLen)
 				rv.fst, err = vellum.Load(fstBytes)
 				if err != nil {
 					sb.m.Unlock()
@@ -547,12 +566,12 @@ func (s *SegmentBase) loadDvReaders() error {
 	for fieldID, field := range s.fieldsInv {
 		var fieldLocStart, fieldLocEnd uint64
 		var n int
-		fieldLocStart, n = binary.Uvarint(s.mem[s.docValueOffset+read : s.docValueOffset+read+binary.MaxVarintLen64])
+		fieldLocStart, n = binary.Uvarint(s.readMem(s.docValueOffset+read, s.docValueOffset+read+binary.MaxVarintLen64))
 		if n <= 0 {
 			return fmt.Errorf("loadDvReaders: failed to read the docvalue offset start for field %d", fieldID)
 		}
 		read += uint64(n)
-		fieldLocEnd, n = binary.Uvarint(s.mem[s.docValueOffset+read : s.docValueOffset+read+binary.MaxVarintLen64])
+		fieldLocEnd, n = binary.Uvarint(s.readMem(s.docValueOffset+read, s.docValueOffset+read+binary.MaxVarintLen64))
 		if n <= 0 {
 			return fmt.Errorf("loadDvReaders: failed to read the docvalue offset end for field %d", fieldID)
 		}


### PR DESCRIPTION
skips the mmap() call on 32-bit systems, and falls back to direct file reads instead.

cc https://github.com/blevesearch/bleve/issues/1305#issuecomment-555282867 @mschoch @steveyen @sreekanth-cb 