### PR TITLE
Api to trigger a force merge operation on an index

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -323,11 +323,14 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 
 	defer func() { _ = root.DecRef() }()
 
+	if nextMerge.creator == "" {
+		nextMerge.creator = "introduceMerge"
+	}
 	newSnapshot := &IndexSnapshot{
 		parent:   s,
 		internal: root.internal,
 		refs:     1,
-		creator:  "introduceMerge",
+		creator:  nextMerge.creator,
 	}
 
 	// iterate through current segments

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -247,7 +247,7 @@ func notifyMergeWatchers(lastPersistedEpoch uint64,
 
 func (s *Scorch) getNumSnapshotsToKeep(ourSnapshot *IndexSnapshot) int {
 	if ourSnapshot != nil &&
-		ourSnapshot.creator != forceMergeCreator {
+		ourSnapshot.creator != numSnapShotsToKeepOverRuler {
 		return s.numSnapshotsToKeep
 	}
 	return 1

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -78,6 +78,8 @@ type Scorch struct {
 	pauseLock sync.RWMutex
 
 	pauseCount uint64
+
+	mergerKickCh chan *mergerKick
 }
 
 type internalStats struct {
@@ -101,6 +103,7 @@ func NewScorch(storeName string,
 		nextSnapshotEpoch:    1,
 		closeCh:              make(chan struct{}),
 		ineligibleForRemoval: map[string]bool{},
+		mergerKickCh:         make(chan *mergerKick, 1),
 	}
 	rv.root = &IndexSnapshot{parent: rv, refs: 1, creator: "NewScorch"}
 	ro, ok := config["read_only"].(bool)

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -79,7 +79,7 @@ type Scorch struct {
 
 	pauseCount uint64
 
-	mergerKickCh chan *mergerKick
+	mergerKickCh chan *mergerCtrl
 }
 
 type internalStats struct {
@@ -103,7 +103,7 @@ func NewScorch(storeName string,
 		nextSnapshotEpoch:    1,
 		closeCh:              make(chan struct{}),
 		ineligibleForRemoval: map[string]bool{},
-		mergerKickCh:         make(chan *mergerKick, 1),
+		mergerKickCh:         make(chan *mergerCtrl, 1),
 	}
 	rv.root = &IndexSnapshot{parent: rv, refs: 1, creator: "NewScorch"}
 	ro, ok := config["read_only"].(bool)

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -2095,12 +2095,13 @@ func TestIndexForceMerge(t *testing.T) {
 
 	doneCh := make(chan struct{})
 	if si, ok := idx.(*Scorch); ok {
-		err := si.RequestMerge(&mergeplan.MergePlanOptions{
-			MaxSegmentsPerTier:   1,
-			MaxSegmentSize:       10000,
-			SegmentsPerMergeTask: 100,
-			FloorSegmentSize:     10000,
-		}, doneCh)
+		err := si.RequestMerge(&MergeRequest{
+			MergeOptions: &mergeplan.MergePlanOptions{
+				MaxSegmentsPerTier:   1,
+				MaxSegmentSize:       10000,
+				SegmentsPerMergeTask: 100,
+				FloorSegmentSize:     10000},
+			DoneCh: doneCh, OverrideNumSnapshotsToKeep: true})
 		if err != nil {
 			t.Errorf("RequestMerge failed, err: %v", err)
 		}

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -82,6 +82,10 @@ type Stats struct {
 	TotFileMergeLoopErr uint64
 	TotFileMergeLoopEnd uint64
 
+	TotFileMergeForceOpsStarted   uint64
+	TotFileMergeForceOpsCompleted uint64
+	TotFileMergeForceOpsSkipped   uint64
+
 	TotFileMergePlan     uint64
 	TotFileMergePlanErr  uint64
 	TotFileMergePlanNone uint64

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -44,6 +44,11 @@ func NewIndexAlias(indexes ...Index) *indexAliasImpl {
 	}
 }
 
+// Indexes just returns the indexes included in the
+// index alias at the moment in an unsafe way.
+// Caller must be aware that the results will be
+// inconsistent if there are concurrent Add/Remove
+// operations on the alias.
 func (i *indexAliasImpl) Indexes() []Index {
 	i.mutex.RLock()
 	rv := i.indexes

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -44,6 +44,13 @@ func NewIndexAlias(indexes ...Index) *indexAliasImpl {
 	}
 }
 
+func (i *indexAliasImpl) Indexes() []Index {
+	i.mutex.RLock()
+	rv := i.indexes
+	i.mutex.RUnlock()
+	return rv
+}
+
 func (i *indexAliasImpl) isAliasToSingleIndex() error {
 	if len(i.indexes) < 1 {
 		return ErrorAliasEmpty


### PR DESCRIPTION
Introducing a new merge request api to enable customers
conveniently invoke a custom compaction/merge operation
on an existing scorch index. This api would let advanced
bleve users to compact their index all the way down to a
single file segment based index.
The api takes an optional mergePlanOptions argument which
would be applied for the forceful merge operations, while
the original mergePlanOptions property of the index remains
intact after the forceful merge cycle exits.
In the absense of a mergePlanOptions argument, default policy
would be an aggressive one to target a single file segment index
with a maximum segment size of 1B.
In the event of incoming mutations, the forceful merge
operations bail out early than strictly applying the
mergePlanOptions to the index.
Its the caller's responsibility to ensure that there is
enough disk space before invoking this compaction/merge
operation as it needs at least double the disk space
since its a full compaction.

During/right after a force merge, this also cleans up older snapshots(for faster rollbacks) kept to reduce the disk usage.