### PR TITLE
Remove dictionary rows when no document is referring to it

### DIFF
--- a/index/store/merge.go
+++ b/index/store/merge.go
@@ -29,6 +29,9 @@ type MergeOperator interface {
 	// all processing until the FullMerge is done.
 	PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool)
 
+	// DecodeMergeVal decodes a merged value.
+	DecodeMergedVal(val []byte) (uint64, error)
+
 	// Name returns an identifier for the operator
 	Name() string
 }

--- a/index/store/merge.go
+++ b/index/store/merge.go
@@ -32,7 +32,7 @@ type MergeOperator interface {
 	// DecodeMergeVal decodes a merged value.
 	DecodeMergedVal(val []byte) (uint64, error)
 
-	// Name returns an identifier for the operator
+	// Name returns an identifier for the operator. Try.
 	Name() string
 }
 

--- a/index/upsidedown/row_merge.go
+++ b/index/upsidedown/row_merge.go
@@ -71,6 +71,10 @@ func (m *upsideDownMerge) PartialMerge(key, leftOperand, rightOperand []byte) ([
 	return rv, true
 }
 
+func (m *upsideDownMerge) DecodeMergedVal(val []byte) (uint64, error) {
+	return dictionaryRowParseV(val)
+}
+
 func (m *upsideDownMerge) Name() string {
 	return "upsideDownMerge"
 }


### PR DESCRIPTION
Hi - we have a project that uses bleve in-memory index based on gtreap implementation. We noticed a similar behavior that dictionary rows keep grow even after all the documents referring to them are deleted. I found https://github.com/blevesearch/bleve/issues/374, and seems that someone made a temporary only to leveldb, which does not apply to bleve in-memory index use-case.

So I've made this PR to systematically fix #374 for all different index store implementations. Looking forward to your feedback!