### PR TITLE
Update .travis.yml to run for go versions 1.12.x and 1.13.x (latest)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 
 go:
- - "1.11.x"
  - "1.12.x"
  - "1.13.x"
 
@@ -16,11 +15,7 @@ script:
   - go test -race -v $(go list ./... | grep -v vendor/)
   - go vet $(go list ./... | grep -v vendor/)
   - go test ./test -v -indexType scorch
-  - if [[ ${TRAVIS_GO_VERSION} =~ ^1\.10 ]]; then
-        echo "errcheck skipped for go version" $TRAVIS_GO_VERSION;
-    else
-        errcheck -ignorepkg fmt $(go list ./... | grep -v vendor/);
-    fi
+  - errcheck -ignorepkg fmt $(go list ./... | grep -v vendor/);
   - docs/project-code-coverage.sh
   - docs/build_children.sh
 


### PR DESCRIPTION
>> etcd-io/bbolt complains with go version 1.11.x