### PR TITLE
Fix concurrent read write on analysis

### DIFF
--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -820,7 +820,8 @@ func (udc *UpsideDownCouch) Batch(batch *index.Batch) (err error) {
 
 	if numUpdates > 0 {
 		go func() {
-			for _, doc := range batch.IndexOps {
+			for k := range batch.IndexOps {
+				doc := batch.IndexOps[k]
 				if doc != nil {
 					aw := index.NewAnalysisWork(udc, doc, resultChan)
 					// put the work on the queue


### PR DESCRIPTION
This is the stack trace we got in our tests
```
fatal error: concurrent map read and map write

goroutine 7 [running]:
runtime.throw(0x17b1b17, 0x21)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc00c97f8b8 sp=0xc00c97f888 pc=0x431422
runtime.mapaccess2_faststr(0x15f4040, 0xc011202f90, 0x257c531, 0x1, 0xc00c97fa70, 0xcb5919)
	/usr/local/go/src/runtime/map_faststr.go:116 +0x48f fp=0xc00c97f928 sp=0xc00c97f8b8 pc=0x4150ff
github.com/blevesearch/bleve/analysis.TokenFrequencies.MergeAll(0xc011202f90, 0x14488dd, 0x2, 0xc01121cc00)
	/home/circleci/.go_workspace/pkg/mod/github.com/blevesearch/bleve@v0.0.0-20190812174355-c997533a776f/    +0x100 fp=0xc00c97fa38 sp=0xc00c97f928 pc=0x9d6770
github.com/blevesearch/bleve/document.(*CompositeField).Compose(0xc00e499d80, 0x14488dd, 0x2, 0x1, 0xc01121cc00)
	/home/circleci/.go_workspace/pkg/mod/github.com/blevesearch/bleve@v0.0.0-20190812174355-c997533a776f/document/field_composite.go:122 +0xf2 fp=0xc00c97fa80 sp=0xc00c97fa38 pc=0x9dd902
github.com/blevesearch/bleve/index/upsidedown.(*UpsideDownCouch).Analyze(0xc001dbda80, 0xc00e499d00, 0x2)
	/home/circleci/.go_workspace/pkg/mod/github.com/blevesearch/bleve@v0.0.0-20190812174355-c997533a776f/index/upsidedown/analysis.go:77 +0xc10 fp=0xc00c97ff28 sp=0xc00c97fa80 pc=0xc9b630
github.com/blevesearch/bleve/index.AnalysisWorker(0xc0004f1e00, 0xc0004f1e60)
	/home/circleci/.go_workspace/pkg/mod/github.com/blevesearch/bleve@v0.0.0-20190812174355-c997533a776f/index/analysis.go:106 +0x55 fp=0xc00c97ffd0 sp=0xc00c97ff28 pc=0x9e12b5
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc00c97ffd8 sp=0xc00c97ffd0 pc=0x460741
created by github.com/blevesearch/bleve/index.NewAnalysisQueue
	/home/circleci/.go_workspace/pkg/mod/github.com/blevesearch/bleve@v0.0.0-20190812174355-c997533a776f/index/analysis.go:94 +0xc8
```

I think that the root cause is that iterating on the map, pointers change under the hood, which will lead to analysing the same document twice