### PR TITLE
Fix for numSnapshotsToKeep dilution with merge ops

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -159,7 +159,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 	// process tasks in serial for now
 	var notifications []chan *IndexSnapshot
 	var filenames []string
-	for _, task := range resultMergePlan.Tasks {
+	for tnum, task := range resultMergePlan.Tasks {
 		if len(task.Segments) == 0 {
 			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)
 			continue
@@ -239,6 +239,11 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			}
 
 			atomic.AddUint64(&s.stats.TotFileMergeSegments, uint64(len(segmentsToMerge)))
+		}
+
+		// update stats before the first introduction from the merge
+		if tnum == 0 {
+			atomic.StoreUint64(&s.stats.RecentMergeInProgEpoch, ourSnapshot.epoch)
 		}
 
 		sm := &segmentMerge{

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -33,9 +33,10 @@ type Stats struct {
 	TotBatchIntroTime uint64
 	MaxBatchIntroTime uint64
 
-	CurRootEpoch       uint64
-	LastPersistedEpoch uint64
-	LastMergedEpoch    uint64
+	CurRootEpoch           uint64
+	LastPersistedEpoch     uint64
+	LastMergedEpoch        uint64
+	RecentMergeInProgEpoch uint64
 
 	TotOnErrors uint64
 


### PR DESCRIPTION
The numSnapshotsToKeep logic is perceived to have two
shortcomings wrt the disk based segment merging.
1- It can result in index size amplification due to the
   duplicated segment data across index snapshots
   (kept for respecting numSnapshotsToKeep ) before and after a 
   disk based merge operation.

2- While retaining the mandated number of older snapshots, scorch isn’t
   considering the above mentioned data duplication across index
   snapshots and thus compromises the effectiveness of numSnapshotsToKeep.
   Essentially scorch isn’t retaining enough snapshots with non-duplicated data.

This fix aims to address that by accounting the recent/ongoing merge
operations to prevent the redundant snapshots from getting sneaked
into the numSnapshotsToKeep reserve.