### PR TITLE
Initialise the root snapshot's DecRef errs with Close()

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -263,7 +263,7 @@ func (s *Scorch) Close() (err error) {
 		err = s.rootBolt.Close()
 		s.rootLock.Lock()
 		if s.root != nil {
-			_ = s.root.DecRef()
+			err = s.root.DecRef()
 		}
 		s.root = nil
 		s.rootLock.Unlock()

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -263,7 +263,10 @@ func (s *Scorch) Close() (err error) {
 		err = s.rootBolt.Close()
 		s.rootLock.Lock()
 		if s.root != nil {
-			err = s.root.DecRef()
+			err2 := s.root.DecRef()
+			if err == nil {
+				err = err2
+			}
 		}
 		s.root = nil
 		s.rootLock.Unlock()


### PR DESCRIPTION
During the scorch's Close call, the root snapshot's
DecRef return errs are ignored. Fixing that to bubble up
the errors so that the higher levels may listen and
act on it.