### PR TITLE
Extend Regexp support to accommodate expanding $ variables

### DIFF
--- a/analysis/char/regexp/regexp.go
+++ b/analysis/char/regexp/regexp.go
@@ -15,7 +15,6 @@
 package regexp
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 
@@ -38,7 +37,7 @@ func New(r *regexp.Regexp, replacement []byte) *CharFilter {
 }
 
 func (s *CharFilter) Filter(input []byte) []byte {
-	return s.r.ReplaceAllFunc(input, func(in []byte) []byte { return bytes.Repeat(s.replacement, len(in)) })
+	return s.r.ReplaceAll(input, s.replacement)
 }
 
 func CharFilterConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.CharFilter, error) {

--- a/analysis/char/regexp/regexp_test.go
+++ b/analysis/char/regexp/regexp_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestRegexpCharFilter(t *testing.T) {
-
 	htmlTagPattern := `</?[!\w]+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)/?>`
 	htmlRegex := regexp.MustCompile(htmlTagPattern)
 
@@ -31,7 +30,7 @@ func TestRegexpCharFilter(t *testing.T) {
 	}{
 		{
 			input:  []byte(`<html>test</html>`),
-			output: []byte(`      test       `),
+			output: []byte(` test `),
 		},
 	}
 
@@ -45,7 +44,6 @@ func TestRegexpCharFilter(t *testing.T) {
 }
 
 func TestZeroWidthNonJoinerCharFilter(t *testing.T) {
-
 	zeroWidthNonJoinerPattern := `\x{200C}`
 	zeroWidthNonJoinerRegex := regexp.MustCompile(zeroWidthNonJoinerPattern)
 
@@ -55,7 +53,7 @@ func TestZeroWidthNonJoinerCharFilter(t *testing.T) {
 	}{
 		{
 			input:  []byte("water\u200Cunder\u200Cthe\u200Cbridge"),
-			output: []byte("water   under   the   bridge"),
+			output: []byte("water under the bridge"),
 		},
 	}
 
@@ -65,5 +63,21 @@ func TestZeroWidthNonJoinerCharFilter(t *testing.T) {
 		if !reflect.DeepEqual(output, test.output) {
 			t.Errorf("Expected:\n`%s`\ngot:\n`%s`\nfor:\n`%s`\n", string(test.output), string(output), string(test.input))
 		}
+	}
+}
+
+func TestRegexpCustomReplace(t *testing.T) {
+	regexStr := `([a-z])\s+(\d)`
+	replace := []byte(`$1-$2`)
+
+	regex := regexp.MustCompile(regexStr)
+	filter := New(regex, replace)
+
+	input := []byte("temp 1")
+	expectOutput := []byte("temp-1")
+
+	output := filter.Filter(input)
+	if !reflect.DeepEqual(output, expectOutput) {
+		t.Errorf("Expected: %s, Got: %s\n", string(expectOutput), string(output))
 	}
 }

--- a/analysis/char/regexp/regexp_test.go
+++ b/analysis/char/regexp/regexp_test.go
@@ -67,17 +67,51 @@ func TestZeroWidthNonJoinerCharFilter(t *testing.T) {
 }
 
 func TestRegexpCustomReplace(t *testing.T) {
-	regexStr := `([a-z])\s+(\d)`
-	replace := []byte(`$1-$2`)
+	tests := []struct {
+		regexStr string
+		replace  []byte
+		input    []byte
+		output   []byte
+	}{
+		{
+			regexStr: `([a-z])\s+(\d)`,
+			replace:  []byte(`$1-$2`),
+			input:    []byte(`temp 1`),
+			output:   []byte(`temp-1`),
+		},
+		{
+			regexStr: `foo.?`,
+			replace:  []byte(`X`),
+			input:    []byte(`seafood, fool`),
+			output:   []byte(`seaX, X`),
+		},
+		{
+			regexStr: `def`,
+			replace:  []byte(`_`),
+			input:    []byte(`abcdefghi`),
+			output:   []byte(`abc_ghi`),
+		},
+		{
+			regexStr: `456`,
+			replace:  []byte(`000000`),
+			input:    []byte(`123456789`),
+			output:   []byte(`123000000789`),
+		},
+		{
+			regexStr: `“|”`,
+			replace:  []byte(`"`),
+			input:    []byte(`“hello”`),
+			output:   []byte(`"hello"`),
+		},
+	}
 
-	regex := regexp.MustCompile(regexStr)
-	filter := New(regex, replace)
+	for i := range tests {
+		regex := regexp.MustCompile(tests[i].regexStr)
+		filter := New(regex, tests[i].replace)
 
-	input := []byte("temp 1")
-	expectOutput := []byte("temp-1")
-
-	output := filter.Filter(input)
-	if !reflect.DeepEqual(output, expectOutput) {
-		t.Errorf("Expected: %s, Got: %s\n", string(expectOutput), string(output))
+		output := filter.Filter(tests[i].input)
+		if !reflect.DeepEqual(tests[i].output, output) {
+			t.Errorf("[%d] Expected: `%s`, Got: `%s`\n", i, string(tests[i].output), string(output))
+		}
 	}
 }

--- a/search/highlight/fragmenter/simple/simple.go
+++ b/search/highlight/fragmenter/simple/simple.go
@@ -58,6 +58,11 @@ OUTER:
 		// push back towards beginning
 		// without cross maxbegin
 		for start > 0 && used < s.fragmentSize {
+			if start > len(orig) {
+				// bail if out of bounds, possibly due to token replacement
+				// e.g with a regexp replacement
+				continue OUTER
+			}
 			r, size := utf8.DecodeLastRune(orig[0:start])
 			if r == utf8.RuneError {
 				continue OUTER // bail

--- a/search_test.go
+++ b/search_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blevesearch/bleve/analysis/analyzer/custom"
 	"github.com/blevesearch/bleve/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/analysis/analyzer/standard"
+	regexp_char_filter "github.com/blevesearch/bleve/analysis/char/regexp"
 	"github.com/blevesearch/bleve/analysis/token/length"
 	"github.com/blevesearch/bleve/analysis/token/lowercase"
 	"github.com/blevesearch/bleve/analysis/token/shingle"
@@ -38,6 +39,7 @@ import (
 	"github.com/blevesearch/bleve/index/upsidedown"
 	"github.com/blevesearch/bleve/mapping"
 	"github.com/blevesearch/bleve/search"
+	"github.com/blevesearch/bleve/search/highlight/highlighter/ansi"
 	"github.com/blevesearch/bleve/search/highlight/highlighter/html"
 	"github.com/blevesearch/bleve/search/query"
 )
@@ -1637,5 +1639,71 @@ func TestGeoDistanceIssue1301(t *testing.T) {
 
 	if sr.Total != 3 {
 		t.Fatalf("Size expected: 3, actual %d\n", sr.Total)
+	}
+}
+
+func TestSearchHighlightingWithRegexpReplacement(t *testing.T) {
+	idxMapping := NewIndexMapping()
+	if err := idxMapping.AddCustomCharFilter(regexp_char_filter.Name, map[string]interface{}{
+		"regexp":  `([a-z])\s+(\d)`,
+		"replace": "ooooo$1-$2",
+		"type":    regexp_char_filter.Name,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idxMapping.AddCustomAnalyzer("regexp_replace", map[string]interface{}{
+		"type":      custom.Name,
+		"tokenizer": "unicode",
+		"char_filters": []string{
+			regexp_char_filter.Name,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	idxMapping.DefaultAnalyzer = "regexp_replace"
+	idxMapping.StoreDynamic = true
+	idx, err := NewUsing("testidx", idxMapping, scorch.Name, Config.DefaultKVStore, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = os.RemoveAll("testidx")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	doc := map[string]interface{}{
+		"status": "fool 10",
+	}
+
+	batch := idx.NewBatch()
+	if err = batch.Index("doc", doc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = idx.Batch(batch); err != nil {
+		t.Fatal(err)
+	}
+
+	query := NewMatchQuery("fool 10")
+	sreq := NewSearchRequest(query)
+	sreq.Fields = []string{"*"}
+	sreq.Highlight = NewHighlightWithStyle(ansi.Name)
+
+	sres, err := idx.Search(sreq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sres.Total != 1 {
+		t.Fatalf("Expected 1 hit, got: %v", sres.Total)
 	}
 }


### PR DESCRIPTION
+ regexp filter's should replace a match with a
  single entry of replace and not by a number of times.
+ For example ..
    - Consider the following regex:
        ([a-z])\s+(\d)
    - For the string "temp 1", the above regex matches:
        "p 1"
    - Let the replacement be "$1-$2", so the expectation
      is that "p 1" gets replaced by "p-1".
    - The code before the fix replaces "p 1" with:
        "$1-$2$1-$2$1-$2"