### PR TITLE
Resetting closeCh with Open api

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -223,6 +223,7 @@ func (s *Scorch) openBolt() error {
 	s.introducerNotifier = make(chan *epochWatcher, 1)
 	s.revertToSnapshots = make(chan *snapshotReversion)
 	s.persisterNotifier = make(chan *epochWatcher, 1)
+	s.closeCh = make(chan struct{})
 
 	if !s.readOnly && s.path != "" {
 		err := s.removeOldZapFiles() // Before persister or merger create any new files.


### PR DESCRIPTION
Fix for issue #1352 
Resetting the closeCh in Open api so that scorch
index's main routine trio remains in their active
work loops.