### PR TITLE
[Backport] Improving ownership handling during merge introductions

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -312,6 +312,8 @@ func (s *Scorch) introducePersist(persist *persistIntroduction) {
 	close(persist.applied)
 }
 
+// The introducer should definitely handle the segmentMerge.notify
+// channel before exiting the introduceMerge.
 func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	atomic.AddUint64(&s.stats.TotIntroduceMergeBeg, 1)
 	defer atomic.AddUint64(&s.stats.TotIntroduceMergeEnd, 1)

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -98,10 +98,12 @@ type Stats struct {
 	TotFileSegmentsAtRoot     uint64
 	TotFileMergeWrittenBytes  uint64
 
-	TotFileMergeZapBeg  uint64
-	TotFileMergeZapEnd  uint64
-	TotFileMergeZapTime uint64
-	MaxFileMergeZapTime uint64
+	TotFileMergeZapBeg              uint64
+	TotFileMergeZapEnd              uint64
+	TotFileMergeZapTime             uint64
+	MaxFileMergeZapTime             uint64
+	TotFileMergeZapIntroductionTime uint64
+	MaxFileMergeZapIntroductionTime uint64
 
 	TotFileMergeIntroductions        uint64
 	TotFileMergeIntroductionsDone    uint64


### PR DESCRIPTION
As a part of notifying the merger during the merge
introductions, the introducer bumps the newer
snapshot's reference count. But in situations
where the index is getting closed, there is a
chance that the merge requested merger(file/in memory)
routines would have already exited.
This would cause the newly introduced, ref count
bumped snapshot to leak as there is none to decrement
the bumped up reference count.

The fix is about tighening the merge introduction
notifications handling at the merger side.
As the introducer non-preemptively handles the
intro notify channel, its safe for the merger
to blockingly awaits for each of those merge introduction
notifications and decrements the reference counts
where applicable.

Unlike earlier, merger is processing each of the merge
tasks and awaits its introductions to complete before
proceeding to the next merge task. We don't expect any serious
performance wrinkles here as the introducer ought to be
faster with the merge introductions compared to the merge
tasks.

Added a few introduction related stats to track any
performance considerations raising out of this.