### PR TITLE
improve reliability of test on mac

### DIFF
--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -913,8 +913,6 @@ func TestMultiSearchTimeoutPartial(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(50 * time.Millisecond):
-				return nil
 			}
 		},
 		err: nil,


### PR DESCRIPTION
observed this test failing frequently on mac
environment through github actions

simple change seems to still test the same behavior
instead of arranging for one request to sleep longer
than the context timeout, instead arrange for it
to never return.  that way no matter when the context
timeout eventually happens, we correctly observe
partial results.