### PR TITLE
MB-38957: Document mapping's analyzer to be inherited correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/blevesearch/snowballstem v0.9.0
 	github.com/blevesearch/zap/v11 v11.0.7
 	github.com/blevesearch/zap/v12 v12.0.7
+	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/couchbase/moss v0.1.0
 	github.com/couchbase/vellum v1.0.1
 	github.com/golang/protobuf v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/blevesearch/snowballstem v0.9.0
 	github.com/blevesearch/zap/v11 v11.0.7
 	github.com/blevesearch/zap/v12 v12.0.7
-	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/couchbase/moss v0.1.0
 	github.com/couchbase/vellum v1.0.1
 	github.com/golang/protobuf v1.3.2

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -251,7 +251,6 @@ func (dm *DocumentMapping) AddFieldMapping(fm *FieldMapping) {
 
 // UnmarshalJSON offers custom unmarshaling with optional strict validation
 func (dm *DocumentMapping) UnmarshalJSON(data []byte) error {
-
 	var tmp map[string]json.RawMessage
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
@@ -316,12 +315,10 @@ func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
 		if !ok {
 			break
 		}
-
 		if current.DefaultAnalyzer != "" {
 			rv = current.DefaultAnalyzer
 		}
 	}
-
 	return rv
 }
 

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -308,8 +308,8 @@ func (dm *DocumentMapping) UnmarshalJSON(data []byte) error {
 }
 
 func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
-	rv := ""
 	current := dm
+	rv := current.DefaultAnalyzer
 	for _, pathElement := range path {
 		var ok bool
 		current, ok = current.Properties[pathElement]
@@ -320,10 +320,6 @@ func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
 		if current.DefaultAnalyzer != "" {
 			rv = current.DefaultAnalyzer
 		}
-	}
-
-	if rv == "" {
-		rv = dm.DefaultAnalyzer
 	}
 
 	return rv

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -316,10 +316,16 @@ func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
 		if !ok {
 			break
 		}
+
 		if current.DefaultAnalyzer != "" {
 			rv = current.DefaultAnalyzer
 		}
 	}
+
+	if rv == "" {
+		rv = dm.DefaultAnalyzer
+	}
+
 	return rv
 }
 

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -1111,7 +1111,6 @@ func TestClosestDocDynamicMapping(t *testing.T) {
 }
 
 func TestMappingPointerToTimeBug1152(t *testing.T) {
-
 	when, err := time.Parse(time.RFC3339, "2019-03-06T15:04:05Z")
 	if err != nil {
 		t.Fatal(err)
@@ -1139,5 +1138,16 @@ func TestMappingPointerToTimeBug1152(t *testing.T) {
 	}
 	if _, ok := doc.Fields[0].(*document.DateTimeField); !ok {
 		t.Fatalf("expected field to be type *document.DateTimeField, got %T", doc.Fields[0])
+	}
+}
+
+func TestDefaultAnalyzerInheritance(t *testing.T) {
+	docMapping := NewDocumentMapping()
+	docMapping.DefaultAnalyzer = "xyz"
+	childMapping := NewTextFieldMapping()
+	docMapping.AddFieldMappingsAt("field", childMapping)
+
+	if analyzer := docMapping.defaultAnalyzerName([]string{"field"}); analyzer != "xyz" {
+		t.Fatalf("Expected analyzer: xyz to be inherited by field, but got: '%v'", analyzer)
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -1693,3 +1693,47 @@ func TestSearchHighlightingWithRegexpReplacement(t *testing.T) {
 		t.Fatalf("Expected 1 hit, got: %v", sres.Total)
 	}
 }
+
+func TestAnalyzerInheritance(t *testing.T) {
+	dMapping := mapping.NewDocumentStaticMapping()
+	dMapping.DefaultAnalyzer = keyword.Name
+
+	fMapping := mapping.NewTextFieldMapping()
+	dMapping.AddFieldMappingsAt("city", fMapping)
+
+	idxMapping := NewIndexMapping()
+	idxMapping.DefaultMapping = dMapping
+
+	tmpIndexPath := createTmpIndexPath(t)
+	idx, err := New(tmpIndexPath, idxMapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	doc := map[string]interface{}{
+		"city": "San Francisco",
+	}
+
+	if err = idx.Index("doc", doc); err != nil {
+		t.Fatal(err)
+	}
+
+	q := NewTermQuery("San Francisco")
+	q.SetField("city")
+
+	res, err := idx.Search(NewSearchRequest(q))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Hits) != 1 {
+		t.Fatalf("unexpected number of hits: %v", len(res.Hits))
+	}
+}

--- a/search_test.go
+++ b/search_test.go
@@ -1696,6 +1696,7 @@ func TestSearchHighlightingWithRegexpReplacement(t *testing.T) {
 
 func TestAnalyzerInheritance(t *testing.T) {
 	tests := []struct {
+		name       string
 		mappingStr string
 		doc        map[string]interface{}
 		queryField string
@@ -1707,6 +1708,7 @@ func TestAnalyzerInheritance(t *testing.T) {
 				default_mapping: ""
 					-> child field (should inherit keyword)
 			*/
+			name: "Child field to inherit index mapping's default analyzer",
 			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
 				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
 				`"store":false,"index":true}]}}},"default_analyzer":"keyword"}`,
@@ -1720,6 +1722,7 @@ func TestAnalyzerInheritance(t *testing.T) {
 				default_mapping: keyword
 				    -> child field (should inherit keyword)
 			*/
+			name: "Child field to inherit default mapping's default analyzer",
 			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
 				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
 				`"index":true}]}},"default_analyzer":"keyword"},"default_analyzer":"standard"}`,
@@ -1734,6 +1737,7 @@ func TestAnalyzerInheritance(t *testing.T) {
 				    -> child mapping: ""
 					    -> child field: (should inherit keyword)
 			*/
+			name: "Nested child field to inherit default mapping's default analyzer",
 			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"default_analyzer":` +
 				`"keyword","properties":{"address":{"enabled":true,"dynamic":false,"properties":` +
 				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
@@ -1752,6 +1756,7 @@ func TestAnalyzerInheritance(t *testing.T) {
 					    -> child mapping: ""
 						    -> child field: (should inherit keyword)
 			*/
+			name: "Nested child field to inherit first child mapping's default analyzer",
 			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
 				`{"address":{"enabled":true,"dynamic":false,"default_analyzer":"keyword",` +
 				`"properties":{"state":{"enabled":true,"dynamic":false,"properties":{"city":` +
@@ -1768,37 +1773,39 @@ func TestAnalyzerInheritance(t *testing.T) {
 	}
 
 	for i := range tests {
-		idxMapping := NewIndexMapping()
-		if err := idxMapping.UnmarshalJSON([]byte(tests[i].mappingStr)); err != nil {
-			t.Fatal(err)
-		}
-
-		tmpIndexPath := createTmpIndexPath(t)
-		idx, err := New(tmpIndexPath, idxMapping)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defer func() {
-			if err := idx.Close(); err != nil {
+		t.Run(fmt.Sprintf("%s", tests[i].name), func(t *testing.T) {
+			idxMapping := NewIndexMapping()
+			if err := idxMapping.UnmarshalJSON([]byte(tests[i].mappingStr)); err != nil {
 				t.Fatal(err)
 			}
-		}()
 
-		if err = idx.Index("doc", tests[i].doc); err != nil {
-			t.Fatal(err)
-		}
+			tmpIndexPath := createTmpIndexPath(t)
+			idx, err := New(tmpIndexPath, idxMapping)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		q := NewTermQuery(tests[i].queryTerm)
-		q.SetField(tests[i].queryField)
+			defer func() {
+				if err := idx.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}()
 
-		res, err := idx.Search(NewSearchRequest(q))
-		if err != nil {
-			t.Fatal(err)
-		}
+			if err = idx.Index("doc", tests[i].doc); err != nil {
+				t.Fatal(err)
+			}
 
-		if len(res.Hits) != 1 {
-			t.Errorf("[%d] Unexpected number of hits: %v", i, len(res.Hits))
-		}
+			q := NewTermQuery(tests[i].queryTerm)
+			q.SetField(tests[i].queryField)
+
+			res, err := idx.Search(NewSearchRequest(q))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(res.Hits) != 1 {
+				t.Errorf("Unexpected number of hits: %v", len(res.Hits))
+			}
+		})
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -1695,45 +1695,110 @@ func TestSearchHighlightingWithRegexpReplacement(t *testing.T) {
 }
 
 func TestAnalyzerInheritance(t *testing.T) {
-	dMapping := mapping.NewDocumentStaticMapping()
-	dMapping.DefaultAnalyzer = keyword.Name
-
-	fMapping := mapping.NewTextFieldMapping()
-	dMapping.AddFieldMappingsAt("city", fMapping)
-
-	idxMapping := NewIndexMapping()
-	idxMapping.DefaultMapping = dMapping
-
-	tmpIndexPath := createTmpIndexPath(t)
-	idx, err := New(tmpIndexPath, idxMapping)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		mappingStr string
+		doc        map[string]interface{}
+		queryField string
+		queryTerm  string
+	}{
+		{
+			/*
+				index_mapping: keyword
+				default_mapping: ""
+					-> child field (should inherit keyword)
+			*/
+			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
+				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
+				`"store":false,"index":true}]}}},"default_analyzer":"keyword"}`,
+			doc:        map[string]interface{}{"city": "San Francisco"},
+			queryField: "city",
+			queryTerm:  "San Francisco",
+		},
+		{
+			/*
+				index_mapping: standard
+				default_mapping: keyword
+				    -> child field (should inherit keyword)
+			*/
+			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
+				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
+				`"index":true}]}},"default_analyzer":"keyword"},"default_analyzer":"standard"}`,
+			doc:        map[string]interface{}{"city": "San Francisco"},
+			queryField: "city",
+			queryTerm:  "San Francisco",
+		},
+		{
+			/*
+				index_mapping: standard
+				default_mapping: keyword
+				    -> child mapping: ""
+					    -> child field: (should inherit keyword)
+			*/
+			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"default_analyzer":` +
+				`"keyword","properties":{"address":{"enabled":true,"dynamic":false,"properties":` +
+				`{"city":{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
+				`"index":true}]}}}}},"default_analyzer":"standard"}`,
+			doc: map[string]interface{}{
+				"address": map[string]interface{}{"city": "San Francisco"},
+			},
+			queryField: "address.city",
+			queryTerm:  "San Francisco",
+		},
+		{
+			/*
+				index_mapping: standard
+				default_mapping: ""
+				    -> child mapping: "keyword"
+					    -> child mapping: ""
+						    -> child field: (should inherit keyword)
+			*/
+			mappingStr: `{"default_mapping":{"enabled":true,"dynamic":false,"properties":` +
+				`{"address":{"enabled":true,"dynamic":false,"default_analyzer":"keyword",` +
+				`"properties":{"state":{"enabled":true,"dynamic":false,"properties":{"city":` +
+				`{"enabled":true,"dynamic":false,"fields":[{"name":"city","type":"text",` +
+				`"store":false,"index":true}]}}}}}}},"default_analyer":"standard"}`,
+			doc: map[string]interface{}{
+				"address": map[string]interface{}{
+					"state": map[string]interface{}{"city": "San Francisco"},
+				},
+			},
+			queryField: "address.state.city",
+			queryTerm:  "San Francisco",
+		},
 	}
 
-	defer func() {
-		err := idx.Close()
+	for i := range tests {
+		idxMapping := NewIndexMapping()
+		if err := idxMapping.UnmarshalJSON([]byte(tests[i].mappingStr)); err != nil {
+			t.Fatal(err)
+		}
+
+		tmpIndexPath := createTmpIndexPath(t)
+		idx, err := New(tmpIndexPath, idxMapping)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
 
-	doc := map[string]interface{}{
-		"city": "San Francisco",
-	}
+		defer func() {
+			if err := idx.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
 
-	if err = idx.Index("doc", doc); err != nil {
-		t.Fatal(err)
-	}
+		if err = idx.Index("doc", tests[i].doc); err != nil {
+			t.Fatal(err)
+		}
 
-	q := NewTermQuery("San Francisco")
-	q.SetField("city")
+		q := NewTermQuery(tests[i].queryTerm)
+		q.SetField(tests[i].queryField)
 
-	res, err := idx.Search(NewSearchRequest(q))
-	if err != nil {
-		t.Fatal(err)
-	}
+		res, err := idx.Search(NewSearchRequest(q))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if len(res.Hits) != 1 {
-		t.Fatalf("unexpected number of hits: %v", len(res.Hits))
+		if len(res.Hits) != 1 {
+			t.Errorf("[%d] Unexpected number of hits: %v", i, len(res.Hits))
+		}
 	}
 }


### PR DESCRIPTION
Check if the top level document mapping's (default mapping or a
type mapping) default analyzer is available while determining the
analyzer to use for a child field in the event that neither the child
field has an analyzer set nor any of the intermediate child mappings.

Fixes: https://github.com/blevesearch/bleve/issues/1390