### PR TITLE
use parallel Quicksort in MultiSearch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,20 +5,32 @@ go 1.13
 require (
 	github.com/RoaringBitmap/roaring v0.4.21
 	github.com/blevesearch/blevex v0.0.0-20190916190636-152f0fe5c040
+	github.com/blevesearch/cld2 v0.0.0-20200327141045-8b5f551d37f5 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/segment v0.9.0
 	github.com/blevesearch/snowballstem v0.9.0
 	github.com/blevesearch/zap/v11 v11.0.7
 	github.com/blevesearch/zap/v12 v12.0.7
-	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/couchbase/moss v0.1.0
 	github.com/couchbase/vellum v1.0.1
+	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
+	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
+	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
+	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
+	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
+	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/ikawaha/kagome.ipadic v1.1.2 // indirect
+	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/kljensen/snowball v0.6.0
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
+	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/steveyen/gtreap v0.1.0
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/tebeka/snowball v0.4.2 // indirect
+	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
+	github.com/twotwotwo/sorts v0.0.0-20160814051341-bf5c1f2b8553
 	github.com/willf/bitset v1.1.10
 	go.etcd.io/bbolt v1.3.4
 	golang.org/x/text v0.3.0

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blevesearch/bleve/index/store"
 	"github.com/blevesearch/bleve/mapping"
 	"github.com/blevesearch/bleve/search"
+	"github.com/twotwotwo/sorts"
 )
 
 type indexAliasImpl struct {
@@ -524,7 +525,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 	// sort all hits with the requested order
 	if len(req.Sort) > 0 {
 		sorter := newSearchHitSorter(req.Sort, sr.Hits)
-		sort.Sort(sorter)
+		sorts.Quicksort(sorter)
 	}
 
 	// now skip over the correct From


### PR DESCRIPTION
I noticed that MultiSearch fully utilizes all cores on
my machine for only the first 40% of total search time.
Then only a single core is fully utilized for the remainder.

I tracked it down to the call to sort.Sort. I frequently run
searches that return over 1 million hits. Replacing the call
to sort.Sort with a parallel Quicksort dropped sort
latency on my queries from 18 seconds to 5 seconds.