### PR TITLE
Add SortImpl to SearchRequest

### DIFF
--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -16,7 +16,6 @@ package bleve
 
 import (
 	"context"
-	"sort"
 	"sync"
 	"time"
 
@@ -521,10 +520,11 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 		}
 	}
 
+	sortImpl := req.GetSortImpl()
 	// sort all hits with the requested order
 	if len(req.Sort) > 0 {
 		sorter := newSearchHitSorter(req.Sort, sr.Hits)
-		sort.Sort(sorter)
+		sortImpl(sorter)
 	}
 
 	// now skip over the correct From
@@ -549,7 +549,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 		req.Sort.Reverse()
 		// resort using the original order
 		mhs := newSearchHitSorter(req.Sort, sr.Hits)
-		sort.Sort(mhs)
+		sortImpl(mhs)
 		// reset request
 		req.SearchBefore = req.SearchAfter
 		req.SearchAfter = nil

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -520,11 +520,11 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 		}
 	}
 
-	sortImpl := req.GetSortImpl()
+	sortFunc := req.SortFunc()
 	// sort all hits with the requested order
 	if len(req.Sort) > 0 {
 		sorter := newSearchHitSorter(req.Sort, sr.Hits)
-		sortImpl(sorter)
+		sortFunc(sorter)
 	}
 
 	// now skip over the correct From
@@ -549,7 +549,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 		req.Sort.Reverse()
 		// resort using the original order
 		mhs := newSearchHitSorter(req.Sort, sr.Hits)
-		sortImpl(mhs)
+		sortFunc(mhs)
 		// reset request
 		req.SearchBefore = req.SearchAfter
 		req.SearchAfter = nil

--- a/index_impl.go
+++ b/index_impl.go
@@ -578,7 +578,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		req.Sort.Reverse()
 		// resort using the original order
 		mhs := newSearchHitSorter(req.Sort, hits)
-		req.GetSortImpl()(mhs)
+		req.SortFunc()(mhs)
 		// reset request
 		req.SearchBefore = req.SearchAfter
 		req.SearchAfter = nil

--- a/index_impl.go
+++ b/index_impl.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -579,7 +578,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		req.Sort.Reverse()
 		// resort using the original order
 		mhs := newSearchHitSorter(req.Sort, hits)
-		sort.Sort(mhs)
+		req.GetSortImpl()(mhs)
 		// reset request
 		req.SearchBefore = req.SearchAfter
 		req.SearchAfter = nil

--- a/search.go
+++ b/search.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/blevesearch/bleve/analysis"
@@ -264,6 +265,7 @@ func (h *HighlightRequest) AddField(field string) {
 // Score controls the kind of scoring performed
 // SearchAfter supports deep paging by providing a minimum sort key
 // SearchBefore supports deep paging by providing a maximum sort key
+// SortImpl specifies the sort implementation to use for sorting results.
 //
 // A special field named "*" can be used to return all fields.
 type SearchRequest struct {
@@ -279,6 +281,8 @@ type SearchRequest struct {
 	Score            string            `json:"score,omitempty"`
 	SearchAfter      []string          `json:"search_after"`
 	SearchBefore     []string          `json:"search_before"`
+
+	SortImpl func(sort.Interface) `json:"-"`
 }
 
 func (r *SearchRequest) Validate() error {
@@ -605,4 +609,23 @@ func MemoryNeededForSearchResult(req *SearchRequest) uint64 {
 	}
 
 	return uint64(estimate)
+}
+
+// SetSortFunc sets the sort implementation to use when sorting hits.
+//
+// SearchRequests can specify a custom sort implementation to meet
+// their needs. For instance, by specifying a parallel sort
+// that uses all available cores.
+func (r *SearchRequest) SetSortImpl(s func(sort.Interface)) {
+	r.SortImpl = s
+}
+
+// GetSortFunc returns the sort implementation to use when sorting hits.
+// Defaults to sort.Sort.
+func (r *SearchRequest) GetSortImpl() func(data sort.Interface) {
+	if r.SortImpl != nil {
+		return r.SortImpl
+	}
+
+	return sort.Sort
 }

--- a/search.go
+++ b/search.go
@@ -265,7 +265,7 @@ func (h *HighlightRequest) AddField(field string) {
 // Score controls the kind of scoring performed
 // SearchAfter supports deep paging by providing a minimum sort key
 // SearchBefore supports deep paging by providing a maximum sort key
-// SortImpl specifies the sort implementation to use for sorting results.
+// sortFunc specifies the sort implementation to use for sorting results.
 //
 // A special field named "*" can be used to return all fields.
 type SearchRequest struct {
@@ -282,7 +282,7 @@ type SearchRequest struct {
 	SearchAfter      []string          `json:"search_after"`
 	SearchBefore     []string          `json:"search_before"`
 
-	SortImpl func(sort.Interface) `json:"-"`
+	sortFunc func(sort.Interface)
 }
 
 func (r *SearchRequest) Validate() error {
@@ -616,15 +616,15 @@ func MemoryNeededForSearchResult(req *SearchRequest) uint64 {
 // SearchRequests can specify a custom sort implementation to meet
 // their needs. For instance, by specifying a parallel sort
 // that uses all available cores.
-func (r *SearchRequest) SetSortImpl(s func(sort.Interface)) {
-	r.SortImpl = s
+func (r *SearchRequest) SetSortFunc(s func(sort.Interface)) {
+	r.sortFunc = s
 }
 
-// GetSortFunc returns the sort implementation to use when sorting hits.
+// SortFunc returns the sort implementation to use when sorting hits.
 // Defaults to sort.Sort.
-func (r *SearchRequest) GetSortImpl() func(data sort.Interface) {
-	if r.SortImpl != nil {
-		return r.SortImpl
+func (r *SearchRequest) SortFunc() func(data sort.Interface) {
+	if r.sortFunc != nil {
+		return r.sortFunc
 	}
 
 	return sort.Sort


### PR DESCRIPTION
This allows SearchRequests to specify the sort implementation (defaults to sort.Sort) to use
when sorting hits.