### PR TITLE
optimize FacetsBuilder

### DIFF
--- a/search/facet/facet_builder_datetime.go
+++ b/search/facet/facet_builder_datetime.go
@@ -87,23 +87,21 @@ func (fb *DateTimeFacetBuilder) Field() string {
 	return fb.field
 }
 
-func (fb *DateTimeFacetBuilder) UpdateVisitor(field string, term []byte) {
-	if field == fb.field {
-		fb.sawValue = true
-		// only consider the values which are shifted 0
-		prefixCoded := numeric.PrefixCoded(term)
-		shift, err := prefixCoded.Shift()
-		if err == nil && shift == 0 {
-			i64, err := prefixCoded.Int64()
-			if err == nil {
-				t := time.Unix(0, i64)
+func (fb *DateTimeFacetBuilder) UpdateVisitor(term []byte) {
+	fb.sawValue = true
+	// only consider the values which are shifted 0
+	prefixCoded := numeric.PrefixCoded(term)
+	shift, err := prefixCoded.Shift()
+	if err == nil && shift == 0 {
+		i64, err := prefixCoded.Int64()
+		if err == nil {
+			t := time.Unix(0, i64)
 
-				// look at each of the ranges for a match
-				for rangeName, r := range fb.ranges {
-					if (r.start.IsZero() || t.After(r.start) || t.Equal(r.start)) && (r.end.IsZero() || t.Before(r.end)) {
-						fb.termsCount[rangeName] = fb.termsCount[rangeName] + 1
-						fb.total++
-					}
+			// look at each of the ranges for a match
+			for rangeName, r := range fb.ranges {
+				if (r.start.IsZero() || t.After(r.start) || t.Equal(r.start)) && (r.end.IsZero() || t.Before(r.end)) {
+					fb.termsCount[rangeName] = fb.termsCount[rangeName] + 1
+					fb.total++
 				}
 			}
 		}

--- a/search/facet/facet_builder_numeric.go
+++ b/search/facet/facet_builder_numeric.go
@@ -86,23 +86,21 @@ func (fb *NumericFacetBuilder) Field() string {
 	return fb.field
 }
 
-func (fb *NumericFacetBuilder) UpdateVisitor(field string, term []byte) {
-	if field == fb.field {
-		fb.sawValue = true
-		// only consider the values which are shifted 0
-		prefixCoded := numeric.PrefixCoded(term)
-		shift, err := prefixCoded.Shift()
-		if err == nil && shift == 0 {
-			i64, err := prefixCoded.Int64()
-			if err == nil {
-				f64 := numeric.Int64ToFloat64(i64)
+func (fb *NumericFacetBuilder) UpdateVisitor(term []byte) {
+	fb.sawValue = true
+	// only consider the values which are shifted 0
+	prefixCoded := numeric.PrefixCoded(term)
+	shift, err := prefixCoded.Shift()
+	if err == nil && shift == 0 {
+		i64, err := prefixCoded.Int64()
+		if err == nil {
+			f64 := numeric.Int64ToFloat64(i64)
 
-				// look at each of the ranges for a match
-				for rangeName, r := range fb.ranges {
-					if (r.min == nil || f64 >= *r.min) && (r.max == nil || f64 < *r.max) {
-						fb.termsCount[rangeName] = fb.termsCount[rangeName] + 1
-						fb.total++
-					}
+			// look at each of the ranges for a match
+			for rangeName, r := range fb.ranges {
+				if (r.min == nil || f64 >= *r.min) && (r.max == nil || f64 < *r.max) {
+					fb.termsCount[rangeName] = fb.termsCount[rangeName] + 1
+					fb.total++
 				}
 			}
 		}

--- a/search/facet/facet_builder_numeric_test.go
+++ b/search/facet/facet_builder_numeric_test.go
@@ -52,7 +52,7 @@ func numericFacetN(b *testing.B, numTerms int) {
 
 		for _, pv := range pcodedvalues {
 			nfb.StartDoc()
-			nfb.UpdateVisitor(field, pv)
+			nfb.UpdateVisitor(pv)
 			nfb.EndDoc()
 		}
 	}

--- a/search/facet/facet_builder_terms.go
+++ b/search/facet/facet_builder_terms.go
@@ -62,12 +62,10 @@ func (fb *TermsFacetBuilder) Field() string {
 	return fb.field
 }
 
-func (fb *TermsFacetBuilder) UpdateVisitor(field string, term []byte) {
-	if field == fb.field {
-		fb.sawValue = true
-		fb.termsCount[string(term)] = fb.termsCount[string(term)] + 1
-		fb.total++
-	}
+func (fb *TermsFacetBuilder) UpdateVisitor(term []byte) {
+	fb.sawValue = true
+	fb.termsCount[string(term)] = fb.termsCount[string(term)] + 1
+	fb.total++
 }
 
 func (fb *TermsFacetBuilder) StartDoc() {

--- a/search/facet/facet_builder_terms_test.go
+++ b/search/facet/facet_builder_terms_test.go
@@ -60,7 +60,7 @@ func termsFacetN(b *testing.B, numTerms int) {
 		j := i % termsLen
 		term := terms[j]
 		tfb.StartDoc()
-		tfb.UpdateVisitor(field, []byte(term))
+		tfb.UpdateVisitor([]byte(term))
 		tfb.EndDoc()
 		i++
 	}

--- a/search/facets_builder.go
+++ b/search/facets_builder.go
@@ -43,7 +43,7 @@ func init() {
 
 type FacetBuilder interface {
 	StartDoc()
-	UpdateVisitor(field string, term []byte)
+	UpdateVisitor(term []byte)
 	EndDoc()
 
 	Result() *FacetResult
@@ -110,7 +110,7 @@ func (fb *FacetsBuilder) EndDoc() {
 func (fb *FacetsBuilder) UpdateVisitor(field string, term []byte) {
 	if facetBuilders, ok := fb.facetsByField[field]; ok {
 		for _, facetBuilder := range facetBuilders {
-			facetBuilder.UpdateVisitor(field, term)
+			facetBuilder.UpdateVisitor(term)
 		}
 	}
 }


### PR DESCRIPTION
Replace O(n) implementation in FacetsBuilder.UpdateVisitor

The existing implementation iterated over every facet in the search request and called `UpdateVisitor` along with the field name.

The new implementation maintains a map of FacetBuilders referencing each field and only calls `UpdateVisitor` on the relevant FacetBuilders.