### PR TITLE
allow segment type/version override to work

### DIFF
--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -106,7 +106,7 @@ func (o *Builder) parseConfig(config map[string]interface{}) (err error) {
 	if forcedSegmentType != "" && forcedSegmentVersion != 0 {
 		segPlugin, err := chooseSegmentPlugin(forcedSegmentType,
 			uint32(forcedSegmentVersion))
-		if err != nil {
+		if err == nil {
 			o.segPlugin = segPlugin
 		}
 	}

--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -106,9 +106,10 @@ func (o *Builder) parseConfig(config map[string]interface{}) (err error) {
 	if forcedSegmentType != "" && forcedSegmentVersion != 0 {
 		segPlugin, err := chooseSegmentPlugin(forcedSegmentType,
 			uint32(forcedSegmentVersion))
-		if err == nil {
-			o.segPlugin = segPlugin
+		if err != nil {
+			return err
 		}
+		o.segPlugin = segPlugin
 	}
 
 	return nil


### PR DESCRIPTION
logic was reversed, preventing correct configuration
from actually switching the segment plugin used

fixes #1406