### PR TITLE
MatchOperator should be that type instead of int

### DIFF
--- a/search/query/match.go
+++ b/search/query/match.go
@@ -37,9 +37,9 @@ type MatchQueryOperator int
 
 const (
 	// Document must satisfy AT LEAST ONE of term searches.
-	MatchQueryOperatorOr = 0
+	MatchQueryOperatorOr = MatchQueryOperator(0)
 	// Document must satisfy ALL of term searches.
-	MatchQueryOperatorAnd = 1
+	MatchQueryOperatorAnd = MatchQueryOperator(1)
 )
 
 func (o MatchQueryOperator) MarshalJSON() ([]byte, error) {

--- a/search/query/query_test.go
+++ b/search/query/query_test.go
@@ -84,10 +84,30 @@ func TestParseQuery(t *testing.T) {
 			}(),
 		},
 		{
+			input: []byte(`{"match":"beer","field":"desc","operator":"and"}`),
+			output: func() Query {
+				operator := MatchQueryOperatorAnd
+				q := NewMatchQuery("beer")
+				q.SetOperator(operator)
+				q.SetField("desc")
+				return q
+			}(),
+		},
+		{
 			input: []byte(`{"match":"beer","field":"desc","operator":"or"}`),
 			output: func() Query {
 				q := NewMatchQuery("beer")
 				q.SetOperator(MatchQueryOperatorOr)
+				q.SetField("desc")
+				return q
+			}(),
+		},
+		{
+			input: []byte(`{"match":"beer","field":"desc","operator":"or"}`),
+			output: func() Query {
+				operator := MatchQueryOperatorOr
+				q := NewMatchQuery("beer")
+				q.SetOperator(operator)
 				q.SetField("desc")
 				return q
 			}(),


### PR DESCRIPTION
Right now `MatchOperator` constants are ints and when you're trying to
assign them to a variable you get an int. If you try to use those
variables as an operator you get the following error:

```
cannot use operator (type int) as type MatchQueryOperator in argument to q.SetOperator
```

So, to fix this problem we just need to create `MatchOperator` constants