### PR TITLE
Shutdown analysis queue

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,7 +43,14 @@ type configuration struct {
 }
 
 func (c *configuration) SetAnalysisQueueSize(n int) {
+	if c.analysisQueue != nil {
+		c.analysisQueue.Close()
+	}
 	c.analysisQueue = index.NewAnalysisQueue(n)
+}
+
+func (c *configuration) Shutdown() {
+	c.SetAnalysisQueueSize(0)
 }
 
 func newConfiguration() *configuration {


### PR DESCRIPTION
Hi!

In package `bleve` function `init` runs several goroutines for procession analysis queue.
In some cases we need to shutdown this goroutines. For example, it triggers goleak tool.

```
package main

import (
	"testing"
	"github.com/blevesearch/bleve"
	"go.uber.org/goleak"
)

func main() {
	var idx bleve.Index
	_ = idx
}

func TestMain(m *testing.M) {
	goleak.VerifyTestMain(m)
}
```

Causes:
```
goleak: Errors on successful test run: found unexpected goroutines:
...
```

Also, when `SetAnalysisQueueSize` is called analysis queue size not set to specified size, but increased on this number because exited workers isn't closed.

This PR adds `Shutdown` function that closes analysis queue from user's code and closes queue when new size is set.