### PR TITLE
Improve Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Discuss usage and development of bleve in the [google group](https://groups.goog
 ## Indexing
 
 ```go
+indexName := "example.bleve"
 message := struct{
 	Id   string
 	From string
@@ -49,9 +50,9 @@ message := struct{
 }
 
 mapping := bleve.NewIndexMapping()
-index, err := bleve.New("example.bleve", mapping)
-if err != nil {
-    index, err = bleve.Open("example.bleve")
+index, err := bleve.New(indexName, mapping)
+if err == bleve.ErrorIndexPathExists {
+    index, err = bleve.Open(indexName)
     if err != nil {
         panic(err)
     }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ message := struct{
 mapping := bleve.NewIndexMapping()
 index, err := bleve.New("example.bleve", mapping)
 if err != nil {
-	panic(err)
+    index, err = bleve.Open("example.bleve")
+    if err != nil {
+        panic(err)
+    }
 }
 index.Index(message.Id, message)
 ```


### PR DESCRIPTION
The current example can only be run once, running again attempts to create an index in the same location, ending in an error:

```
panic: cannot create new index, path already exists

goroutine 1 [running]:
main.main()
        /Users/code/refs/bleve/main.go:21 +0x1bf
exit status 2
```

The proposed fix attempts to `Open` if an error occurred.