### PR TITLE
new FormatSpecifier option for FieldMapping

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -458,7 +458,12 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		if subDocMapping != nil {
 			// index by explicit mapping
 			for _, fieldMapping := range subDocMapping.Fields {
-				fieldMapping.processFloat64(propertyValFloat, pathString, path, indexes, context)
+				if fieldMapping.Type == "text" && fieldMapping.FormatSpecifier != "" {
+					fieldMapping.processString(fmt.Sprintf(fieldMapping.FormatSpecifier, propertyValFloat),
+						pathString, path, indexes, context)
+				} else {
+					fieldMapping.processFloat64(propertyValFloat, pathString, path, indexes, context)
+				}
 			}
 		} else if closestDocMapping.Dynamic {
 			// automatic indexing behavior

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -59,6 +59,8 @@ type FieldMapping struct {
 	// DocValues, if true makes the index uninverting possible for this field
 	// It is useful for faceting and sorting queries.
 	DocValues bool `json:"docvalues,omitempty"`
+
+	FormatSpecifier string `json:"format_specifier,omitempty"`
 }
 
 // NewTextFieldMapping returns a default field mapping for text

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -1151,3 +1151,53 @@ func TestDefaultAnalyzerInheritance(t *testing.T) {
 		t.Fatalf("Expected analyzer: xyz to be inherited by field, but got: '%v'", analyzer)
 	}
 }
+
+func TestNumericValueWithFormatSpecifier(t *testing.T) {
+	numericTextField := NewTextFieldMapping()
+	numericTextField.FormatSpecifier = "%.0f"
+	mapping := NewIndexMapping()
+	mapping.DefaultMapping.AddFieldMappingsAt("productId", numericTextField)
+
+	doc := document.NewDocument("x")
+	err := mapping.MapDocument(doc, map[string]interface{}{
+		"productId": float64(20201001),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(doc.Fields) != 1 {
+		t.Fatalf("expected 1 field, got: %d", len(doc.Fields))
+	}
+	if _, ok := doc.Fields[0].(*document.TextField); !ok {
+		t.Fatalf("expected field to be type *document.TextField, got %T", doc.Fields[0])
+	}
+	if string(doc.Fields[0].(*document.TextField).Value()) != "20201001" {
+		t.Fatalf("expected string value 20201001, got %s", string(doc.Fields[0].(*document.TextField).Value()))
+	}
+}
+
+func TestNumericValueWithFormatSpecifierZeroPadding(t *testing.T) {
+	numericTextField := NewTextFieldMapping()
+	numericTextField.FormatSpecifier = "%03.0f"
+	mapping := NewIndexMapping()
+	mapping.DefaultMapping.AddFieldMappingsAt("age", numericTextField)
+
+	doc := document.NewDocument("x")
+	err := mapping.MapDocument(doc, map[string]interface{}{
+		"age": float64(9),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(doc.Fields) != 1 {
+		t.Fatalf("expected 1 field, got: %d", len(doc.Fields))
+	}
+	if _, ok := doc.Fields[0].(*document.TextField); !ok {
+		t.Fatalf("expected field to be type *document.TextField, got %T", doc.Fields[0])
+	}
+	if string(doc.Fields[0].(*document.TextField).Value()) != "009" {
+		t.Fatalf("expected string value 009, got %s", string(doc.Fields[0].(*document.TextField).Value()))
+	}
+}


### PR DESCRIPTION
This new FormatSpecifier option allows us to convert numeric
values into strings suitable for indexing in a text field.

Format specifiers are relatively limited, but do allow for basic
conversion, as well as fixed width padding.