### PR TITLE
Fixed ASCII folding of \u24A2

### DIFF
--- a/analysis/char/asciifolding/asciifolding.go
+++ b/analysis/char/asciifolding/asciifolding.go
@@ -874,7 +874,7 @@ func foldToASCII(input []rune, inputPos int, output []rune, outputPos int, lengt
 				outputPos++
 
 			case '\u24A2': // ⒢ [PARENTHESIZED LATIN SMALL LETTER G]
-				output = output[:(len(output) + 1)]
+				output = output[:(len(output) + 2)]
 				output[outputPos] = '('
 				outputPos++
 				output[outputPos] = 'g'

--- a/analysis/char/asciifolding/asciifolding_test.go
+++ b/analysis/char/asciifolding/asciifolding_test.go
@@ -49,7 +49,7 @@ func TestAsciiFoldingFilter(t *testing.T) {
 			input:  []byte(`Ápple Àpple Äpple Âpple Ãpple Åpple`),
 			output: []byte(`Apple Apple Apple Apple Apple Apple`),
 		}, {
-			// apples from https://issues.couchbase.com/browse/MB-33486
+			// Fix ASCII folding of \u24A2
 			input:  []byte(`⒢`),
 			output: []byte(`(g)`),
 		},

--- a/analysis/char/asciifolding/asciifolding_test.go
+++ b/analysis/char/asciifolding/asciifolding_test.go
@@ -48,6 +48,10 @@ func TestAsciiFoldingFilter(t *testing.T) {
 			// apples from https://issues.couchbase.com/browse/MB-33486
 			input:  []byte(`Ápple Àpple Äpple Âpple Ãpple Åpple`),
 			output: []byte(`Apple Apple Apple Apple Apple Apple`),
+		}, {
+			// apples from https://issues.couchbase.com/browse/MB-33486
+			input:  []byte(`⒢`),
+			output: []byte(`(g)`),
 		},
 	}
 


### PR DESCRIPTION
Hi, following error happened in my application:
```
panic: runtime error: index out of range [189006] with length 189006
goroutine 9 [running]:
github.com/blevesearch/bleve/analysis/char/asciifolding.foldToASCII(0xc00720c000, 0x2e155, 0x2e800, 0x0, 0xc007f16000, 0x2e155, 0xb8554, 0
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/analysis/char/asciifolding/asciifolding.go:65 +0x84a9
github.com/blevesearch/bleve/analysis/char/asciifolding.(*AsciiFoldingFilter).Filter(0x14617e8, 0xc004bf0000, 0x4976c, 0x4a000, 0x2, 0x1, 
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/analysis/char/asciifolding/asciifolding.go:44 +0x162
github.com/blevesearch/bleve/analysis.(*Analyzer).Analyze(0xc001c0a0c0, 0xc004bf0000, 0x4976c, 0x4a000, 0xc003348000, 0xc003349a00, 0x0)
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/analysis/type.go:83 +0x9c
github.com/blevesearch/bleve/document.(*TextField).Analyze(0xc00344de60, 0xd, 0xa)
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/document/field_text.go:72 +0x79
github.com/blevesearch/bleve/index/scorch.analyze(0xc012bd6fc0, 0x2)
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/index/scorch/scorch.go:599 +0x1c1
github.com/blevesearch/bleve/index/scorch.(*Scorch).Analyze(0xc04d3f3000, 0xc012bd6fc0, 0x2)
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/index/scorch/scorch.go:587 +0x2b
github.com/blevesearch/bleve/index.AnalysisWorker(0xc0004c87e0, 0xc0004c8840)
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/index/analysis.go:106 +0x55
created by github.com/blevesearch/bleve/index.NewAnalysisQueue
~/go/pkg/mod/github.com/blevesearch/bleve@v1.0.9/index/analysis.go:94 +0xc8
```
I do not have the processed data, but I checked asciifolding.go and found a little bug.