### PR TITLE
MB-40730 - Sort by field returns incorrect results

### DIFF
--- a/search/sort.go
+++ b/search/sort.go
@@ -427,7 +427,8 @@ func (s *SortField) filterTermsByType(terms [][]byte) [][]byte {
 				allTermsPrefixCoded = false
 			}
 		}
-		if allTermsPrefixCoded {
+		// reset the terms only when valid zero shift terms are found.
+		if allTermsPrefixCoded && len(termsWithShiftZero) > 0 {
 			terms = termsWithShiftZero
 			s.tmp = termsWithShiftZero[:0]
 		}


### PR DESCRIPTION
Fixing the filterTermsByType method by resetting
the terms only when valid prefix coded, zero shifted
values are found to guard against any inadvertent overrides
of the original field values.
