### PR TITLE
MB-40916: Do not recycle unadorned term field readers for optimized conjunctions/disjunctions

### DIFF
--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -266,10 +266,6 @@ OUTER:
 			bm.And(actualBM)
 		}
 
-		// On closure, do not recycle this optimized TermFieldReader -
-		// as the roaring.Bitmap created above needs to be released.
-		oTFR.doNotRecycle = true
-
 		oTFR.iterators[i] = segment.NewUnadornedPostingsIteratorFromBitmap(bm)
 	}
 
@@ -402,10 +398,6 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		}
 
 		bm.AddMany(docNums)
-
-		// On closure, do not recycle this optimized TermFieldReader -
-		// as the roaring.Bitmap created above needs to be released.
-		oTFR.doNotRecycle = true
 
 		oTFR.iterators[i] = segment.NewUnadornedPostingsIteratorFromBitmap(bm)
 	}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -283,7 +283,7 @@ func (s *IndexSnapshotTermFieldReader) optimizeDisjunctionUnadorned(
 	octx index.OptimizableContext, minChildCardinality uint64) (index.OptimizableContext, error) {
 	if octx == nil {
 		octx = &OptimizeTFRDisjunctionUnadorned{
-			snapshot: s.snapshot,
+			snapshot:            s.snapshot,
 			minChildCardinality: minChildCardinality,
 		}
 	}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -266,6 +266,10 @@ OUTER:
 			bm.And(actualBM)
 		}
 
+		// On closure, do not recycle this optimized TermFieldReader -
+		// as the roaring.Bitmap created above needs to be released.
+		oTFR.doNotRecycle = true
+
 		oTFR.iterators[i] = segment.NewUnadornedPostingsIteratorFromBitmap(bm)
 	}
 
@@ -398,6 +402,10 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		}
 
 		bm.AddMany(docNums)
+
+		// On closure, do not recycle this optimized TermFieldReader -
+		// as the roaring.Bitmap created above needs to be released.
+		oTFR.doNotRecycle = true
 
 		oTFR.iterators[i] = segment.NewUnadornedPostingsIteratorFromBitmap(bm)
 	}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -165,16 +165,8 @@ func (o *OptimizeTFRConjunctionUnadorned) Finish() (rv index.Optimized, err erro
 
 	// We use an artificial term and field because the optimized
 	// termFieldReader can represent multiple terms and fields.
-	oTFR := &IndexSnapshotTermFieldReader{
-		term:               OptimizeTFRConjunctionUnadornedTerm,
-		field:              OptimizeTFRConjunctionUnadornedField,
-		snapshot:           o.snapshot,
-		iterators:          make([]segment.PostingsIterator, len(o.snapshot.segment)),
-		segmentOffset:      0,
-		includeFreq:        false,
-		includeNorm:        false,
-		includeTermVectors: false,
-	}
+	oTFR := o.snapshot.unadornedTermFieldReader(
+		OptimizeTFRConjunctionUnadornedTerm, OptimizeTFRConjunctionUnadornedField)
 
 	var actualBMs []*roaring.Bitmap // Collected from regular posting lists.
 
@@ -349,16 +341,8 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 
 	// We use an artificial term and field because the optimized
 	// termFieldReader can represent multiple terms and fields.
-	oTFR := &IndexSnapshotTermFieldReader{
-		term:               OptimizeTFRDisjunctionUnadornedTerm,
-		field:              OptimizeTFRDisjunctionUnadornedField,
-		snapshot:           o.snapshot,
-		iterators:          make([]segment.PostingsIterator, len(o.snapshot.segment)),
-		segmentOffset:      0,
-		includeFreq:        false,
-		includeNorm:        false,
-		includeTermVectors: false,
-	}
+	oTFR := o.snapshot.unadornedTermFieldReader(
+		OptimizeTFRDisjunctionUnadornedTerm, OptimizeTFRDisjunctionUnadornedField)
 
 	var docNums []uint32            // Collected docNum's from 1-hit posting lists.
 	var actualBMs []*roaring.Bitmap // Collected from regular posting lists.
@@ -404,4 +388,23 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 
 	atomic.AddUint64(&o.snapshot.parent.stats.TotTermSearchersStarted, uint64(1))
 	return oTFR, nil
+}
+
+// ----------------------------------------------------------------
+
+func (i *IndexSnapshot) unadornedTermFieldReader(
+	term []byte, field string) *IndexSnapshotTermFieldReader {
+	// This IndexSnapshotTermFieldReader will not be recycled, more
+	// conversation here: https://github.com/blevesearch/bleve/pull/1438
+	return &IndexSnapshotTermFieldReader{
+		term:               term,
+		field:              field,
+		snapshot:           i,
+		iterators:          make([]segment.PostingsIterator, len(i.segment)),
+		segmentOffset:      0,
+		includeFreq:        false,
+		includeNorm:        false,
+		includeTermVectors: false,
+		recycle:            false,
+	}
 }

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -2458,7 +2458,6 @@ func TestIndexSeekBackwardsStats(t *testing.T) {
 		t.Fatalf("error closing term field reader: %v", err)
 	}
 
-
 	if idx.(*Scorch).stats.TotTermSearchersStarted != idx.(*Scorch).stats.TotTermSearchersFinished {
 		t.Errorf("expected term searchers started %d to equal term searchers finished %d",
 			idx.(*Scorch).stats.TotTermSearchersStarted,

--- a/index/scorch/segment/unadorned.go
+++ b/index/scorch/segment/unadorned.go
@@ -24,7 +24,6 @@ var reflectStaticSizeUnadornedPostingsIteratorBitmap int
 var reflectStaticSizeUnadornedPostingsIterator1Hit int
 var reflectStaticSizeUnadornedPosting int
 
-
 func init() {
 	var pib UnadornedPostingsIteratorBitmap
 	reflectStaticSizeUnadornedPostingsIteratorBitmap = int(reflect.TypeOf(pib).Size())
@@ -34,7 +33,7 @@ func init() {
 	reflectStaticSizeUnadornedPosting = int(reflect.TypeOf(up).Size())
 }
 
-type UnadornedPostingsIteratorBitmap struct{
+type UnadornedPostingsIteratorBitmap struct {
 	actual   roaring.IntPeekable
 	actualBM *roaring.Bitmap
 }
@@ -72,15 +71,15 @@ func (i *UnadornedPostingsIteratorBitmap) Size() int {
 	return reflectStaticSizeUnadornedPostingsIteratorBitmap
 }
 
-func (i *UnadornedPostingsIteratorBitmap)  ActualBitmap() *roaring.Bitmap {
+func (i *UnadornedPostingsIteratorBitmap) ActualBitmap() *roaring.Bitmap {
 	return i.actualBM
 }
 
-func (i *UnadornedPostingsIteratorBitmap)  DocNum1Hit() (uint64, bool) {
+func (i *UnadornedPostingsIteratorBitmap) DocNum1Hit() (uint64, bool) {
 	return 0, false
 }
 
-func (i *UnadornedPostingsIteratorBitmap)  ReplaceActual(actual *roaring.Bitmap) {
+func (i *UnadornedPostingsIteratorBitmap) ReplaceActual(actual *roaring.Bitmap) {
 	i.actualBM = actual
 	i.actual = actual.Iterator()
 }
@@ -88,13 +87,13 @@ func (i *UnadornedPostingsIteratorBitmap)  ReplaceActual(actual *roaring.Bitmap)
 func NewUnadornedPostingsIteratorFromBitmap(bm *roaring.Bitmap) PostingsIterator {
 	return &UnadornedPostingsIteratorBitmap{
 		actualBM: bm,
-		actual: bm.Iterator(),
+		actual:   bm.Iterator(),
 	}
 }
 
 const docNum1HitFinished = math.MaxUint64
 
-type UnadornedPostingsIterator1Hit struct{
+type UnadornedPostingsIterator1Hit struct {
 	docNum uint64
 }
 

--- a/index/scorch/segment_plugin.go
+++ b/index/scorch/segment_plugin.go
@@ -81,11 +81,11 @@ func chooseSegmentPlugin(forcedSegmentType string,
 
 func (s *Scorch) loadSegmentPlugin(forcedSegmentType string,
 	forcedSegmentVersion uint32) error {
-		segPlugin, err := chooseSegmentPlugin(forcedSegmentType,
-			forcedSegmentVersion)
-		if err != nil {
-			return err
-		}
-		s.segPlugin = segPlugin
-		return nil
+	segPlugin, err := chooseSegmentPlugin(forcedSegmentType,
+		forcedSegmentVersion)
+	if err != nil {
+		return err
+	}
+	s.segPlugin = segPlugin
+	return nil
 }

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -511,10 +511,20 @@ func (i *IndexSnapshot) allocTermFieldReaderDicts(field string) (tfr *IndexSnaps
 		}
 	}
 	i.m2.Unlock()
-	return &IndexSnapshotTermFieldReader{}
+	return &IndexSnapshotTermFieldReader{
+		recycle: true,
+	}
 }
 
 func (i *IndexSnapshot) recycleTermFieldReader(tfr *IndexSnapshotTermFieldReader) {
+	if !tfr.recycle {
+		// Do not recycle an optimized unadorned term field reader (used for
+		// ConjunctionUnadorned or DisjunctionUnadorned), during when a fresh
+		// roaring.Bitmap is built by AND-ing or OR-ing individual bitmaps,
+		// and we'll need to release them for GC. (See MB-40916)
+		return
+	}
+
 	i.parent.rootLock.RLock()
 	obsolete := i.parent.root != i
 	i.parent.rootLock.RUnlock()

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -45,7 +45,6 @@ type IndexSnapshotTermFieldReader struct {
 	includeTermVectors bool
 	currPosting        segment.Posting
 	currID             index.IndexInternalID
-	doNotRecycle       bool
 }
 
 func (i *IndexSnapshotTermFieldReader) Size() int {
@@ -187,7 +186,8 @@ func (i *IndexSnapshotTermFieldReader) Close() error {
 		// fresh roaring.Bitmap is built by AND-ing or OR-ing individual
 		// bitmaps, and we'll need to release them for GC.
 		// (See MB-40916)
-		if !i.doNotRecycle {
+		if !(bytes.Equal(i.term, OptimizeTFRConjunctionUnadornedTerm) ||
+			bytes.Equal(i.term, OptimizeTFRDisjunctionUnadornedTerm)) {
 			i.snapshot.recycleTermFieldReader(i)
 		}
 	}

--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -33,7 +33,7 @@ func NewMultiTermSearcher(indexReader index.IndexReader, terms []string,
 		}
 	}
 
-	qsearchers, err  := makeBatchSearchers(indexReader, terms, field, boost, options)
+	qsearchers, err := makeBatchSearchers(indexReader, terms, field, boost, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func NewMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byte,
 		}
 	}
 
-	qsearchers, err  := makeBatchSearchersBytes(indexReader, terms, field, boost, options)
+	qsearchers, err := makeBatchSearchersBytes(indexReader, terms, field, boost, options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func optimizeMultiTermSearcher(indexReader index.IndexReader, terms []string,
 				}
 			}
 		}
-		finalSearcher, err =  optimizeCompositeSearcher("disjunction:unadorned-force",
+		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned-force",
 			indexReader, batch, options)
 		// all searchers in batch should be closed, regardless of error or optimization failure
 		// either we're returning, or continuing and only finalSearcher is needed for next loop
@@ -177,7 +177,7 @@ func optimizeMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byt
 				}
 			}
 		}
-		finalSearcher, err =  optimizeCompositeSearcher("disjunction:unadorned-force",
+		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned-force",
 			indexReader, batch, options)
 		// all searchers in batch should be closed, regardless of error or optimization failure
 		// either we're returning, or continuing and only finalSearcher is needed for next loop

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -280,5 +280,4 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("expected: %#v, got %#v", want, got)
 	}
-
 }


### PR DESCRIPTION
When a conjunction or a disjunction query is eligible to be optimized
to conjunctionUnadorned or disjunctionUnadorned, roaring.Bitmaps are
created by AND-ing or OR-ing the individual bitmaps. These'll need
to be released - for GC.