### PR TITLE
Fix mishandled error within IndexSnapshot's newDocIDReader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/blevesearch/zap/v12 v12.0.9
 	github.com/blevesearch/zap/v13 v13.0.1
 	github.com/blevesearch/zap/v14 v14.0.0
-	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/couchbase/moss v0.1.0
 	github.com/couchbase/vellum v1.0.1
 	github.com/golang/protobuf v1.3.2

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -303,9 +303,12 @@ func (i *IndexSnapshot) newDocIDReader(results chan *asynchSegmentResult) (index
 	var err error
 	for count := 0; count < len(i.segment); count++ {
 		asr := <-results
-		if asr.err != nil && err != nil {
-			err = asr.err
-		} else {
+		if asr.err != nil {
+			if err == nil {
+				// returns the first error encountered
+				err = asr.err
+			}
+		} else if err == nil {
 			rv.iterators[asr.index] = asr.docs.Iterator()
 		}
 	}


### PR DESCRIPTION
+ Fixes https://github.com/blevesearch/bleve/issues/1442
+ Also removing unnecessary go.mod entry for ghistogram