### PR TITLE
Fix mishandled error within NewNumericRangeSearcher

### DIFF
--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -74,9 +74,8 @@ func NewNumericRangeSearcher(indexReader index.IndexReader,
 	terms := termRanges.Enumerate(isIndexed)
 	if fieldDict != nil {
 		if fd, ok := fieldDict.(index.FieldDict); ok {
-			cerr := fd.Close()
-			if cerr != nil {
-				err = cerr
+			if err = fd.Close(); err != nil {
+				return nil, err
 			}
 		}
 	}


### PR DESCRIPTION
+ Return the error upon failure to close the field dictionary
  obtained from the IndexReader.
+ Fixes: https://github.com/blevesearch/bleve/issues/1444