### PR TITLE
MB-40962: Dropping the heuristic to skip disjunction optimizations

### DIFF
--- a/search/searcher/search_multi_term.go
+++ b/search/searcher/search_multi_term.go
@@ -112,7 +112,7 @@ func optimizeMultiTermSearcher(indexReader index.IndexReader, terms []string,
 				}
 			}
 		}
-		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned-force",
+		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned",
 			indexReader, batch, options)
 		// all searchers in batch should be closed, regardless of error or optimization failure
 		// either we're returning, or continuing and only finalSearcher is needed for next loop
@@ -177,7 +177,7 @@ func optimizeMultiTermSearcherBytes(indexReader index.IndexReader, terms [][]byt
 				}
 			}
 		}
-		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned-force",
+		finalSearcher, err = optimizeCompositeSearcher("disjunction:unadorned",
 			indexReader, batch, options)
 		// all searchers in batch should be closed, regardless of error or optimization failure
 		// either we're returning, or continuing and only finalSearcher is needed for next loop


### PR DESCRIPTION
+ Getting rid of the minChildCardinality heuristic for optimized
  unadorned disjunctions where we previously used to skip the
  optimization in case of low-cardinality bitmaps.
+ Removing this heuristic showed tremendous improvement for certain
  types of queries which involved a conjunction of disjunctions of
  fuzzy queries.
+ However, here's something worth noting from the commit that introduced
  this heuristic .. https://github.com/blevesearch/bleve/commit/58e6641d13844e212687bd35823914c5e26b04dd
  ```
   Regarding perf microbenchmarks (bleve-query) on a 200K en-wiki docs scorch index...

    for a high number of high-frequency terms...

    - wildcard search on "th*" (~31K hits)...
        before the change, with normal scoring         -  ~4.7 q/sec
        w/ NoScore:true                                -  ~5.1 q/sec
        w/ NoScore:true & unadorned disj. optimization - ~11.6 q/sec

    for a low number of high-frequency terms...

    - query-string search on "http www com" (~25K hits)...
        before the change, with normal scoring         - ~190 q/sec
        w/ NoScore:true                                - ~260 q/sec
        w/ NoScore:true & unadorned disj. optimization - ~415 q/sec

    for a low number of low-frequency terms...

    - query-string search on "marty shoch" (207 hits)...
        before the change, with normal scoring         - ~15.0K q/sec
        w/ NoScore:true                                - ~21.3K q/sec
        w/ NoScore:true & unadorned disj. optimization - ~16.1K q/sec
  ```