### PR TITLE
Public scorer

### DIFF
--- a/search/scorer/scorer_conjunction.go
+++ b/search/scorer/scorer_conjunction.go
@@ -24,25 +24,30 @@ import (
 var reflectStaticSizeConjunctionQueryScorer int
 
 func init() {
-	var cqs ConjunctionQueryScorer
+	var cqs conjunctionQueryScorer
 	reflectStaticSizeConjunctionQueryScorer = int(reflect.TypeOf(cqs).Size())
 }
 
-type ConjunctionQueryScorer struct {
+type ConjunctionQueryScorer interface {
+	Size() int
+	Score(ctx *search.SearchContext, constituents []*search.DocumentMatch) *search.DocumentMatch
+}
+
+type conjunctionQueryScorer struct {
 	options search.SearcherOptions
 }
 
-func (s *ConjunctionQueryScorer) Size() int {
+func (s *conjunctionQueryScorer) Size() int {
 	return reflectStaticSizeConjunctionQueryScorer + size.SizeOfPtr
 }
 
-func NewConjunctionQueryScorer(options search.SearcherOptions) *ConjunctionQueryScorer {
-	return &ConjunctionQueryScorer{
+func NewConjunctionQueryScorer(options search.SearcherOptions) ConjunctionQueryScorer {
+	return &conjunctionQueryScorer{
 		options: options,
 	}
 }
 
-func (s *ConjunctionQueryScorer) Score(ctx *search.SearchContext, constituents []*search.DocumentMatch) *search.DocumentMatch {
+func (s *conjunctionQueryScorer) Score(ctx *search.SearchContext, constituents []*search.DocumentMatch) *search.DocumentMatch {
 	var sum float64
 	var childrenExplanations []*search.Explanation
 	if s.options.Explain {

--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -25,25 +25,30 @@ import (
 var reflectStaticSizeDisjunctionQueryScorer int
 
 func init() {
-	var dqs DisjunctionQueryScorer
+	var dqs disjunctionQueryScorer
 	reflectStaticSizeDisjunctionQueryScorer = int(reflect.TypeOf(dqs).Size())
 }
 
-type DisjunctionQueryScorer struct {
+type DisjunctionQueryScorer interface {
+	Size() int
+	Score(ctx *search.SearchContext, constituents []*search.DocumentMatch, countMatch, countTotal int) *search.DocumentMatch
+}
+
+type disjunctionQueryScorer struct {
 	options search.SearcherOptions
 }
 
-func (s *DisjunctionQueryScorer) Size() int {
+func (s *disjunctionQueryScorer) Size() int {
 	return reflectStaticSizeDisjunctionQueryScorer + size.SizeOfPtr
 }
 
-func NewDisjunctionQueryScorer(options search.SearcherOptions) *DisjunctionQueryScorer {
-	return &DisjunctionQueryScorer{
+func NewDisjunctionQueryScorer(options search.SearcherOptions) DisjunctionQueryScorer {
+	return &disjunctionQueryScorer{
 		options: options,
 	}
 }
 
-func (s *DisjunctionQueryScorer) Score(ctx *search.SearchContext, constituents []*search.DocumentMatch, countMatch, countTotal int) *search.DocumentMatch {
+func (s *disjunctionQueryScorer) Score(ctx *search.SearchContext, constituents []*search.DocumentMatch, countMatch, countTotal int) *search.DocumentMatch {
 	var sum float64
 	var childrenExplanations []*search.Explanation
 	if s.options.Explain {

--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -448,3 +448,7 @@ func (s *BooleanSearcher) DocumentMatchPoolSize() int {
 	}
 	return rv
 }
+
+func (s *BooleanSearcher) SetScorer(scorer scorer.ConjunctionQueryScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_boolean.go
+++ b/search/searcher/search_boolean.go
@@ -42,7 +42,7 @@ type BooleanSearcher struct {
 	currMustNot     *search.DocumentMatch
 	currentID       index.IndexInternalID
 	min             uint64
-	scorer          *scorer.ConjunctionQueryScorer
+	scorer          scorer.ConjunctionQueryScorer
 	matches         []*search.DocumentMatch
 	initialized     bool
 	done            bool

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -38,7 +38,7 @@ type ConjunctionSearcher struct {
 	queryNorm   float64
 	currs       []*search.DocumentMatch
 	maxIDIdx    int
-	scorer      *scorer.ConjunctionQueryScorer
+	scorer      scorer.ConjunctionQueryScorer
 	initialized bool
 	options     search.SearcherOptions
 }

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -282,3 +282,7 @@ func (s *ConjunctionSearcher) DocumentMatchPoolSize() int {
 	}
 	return rv
 }
+
+func (s *ConjunctionSearcher) SetScorer(scorer scorer.ConjunctionQueryScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -46,7 +46,7 @@ type DisjunctionHeapSearcher struct {
 	indexReader index.IndexReader
 
 	numSearchers int
-	scorer       *scorer.DisjunctionQueryScorer
+	scorer       scorer.DisjunctionQueryScorer
 	min          int
 	queryNorm    float64
 	initialized  bool

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -341,3 +341,7 @@ func (s *DisjunctionHeapSearcher) Pop() interface{} {
 	s.heap = old[0 : n-1]
 	return x
 }
+
+func (s *DisjunctionHeapSearcher) SetScorer(scorer scorer.DisjunctionQueryScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -38,7 +38,7 @@ type DisjunctionSliceSearcher struct {
 	numSearchers int
 	queryNorm    float64
 	currs        []*search.DocumentMatch
-	scorer       *scorer.DisjunctionQueryScorer
+	scorer       scorer.DisjunctionQueryScorer
 	min          int
 	matching     []*search.DocumentMatch
 	matchingIdxs []int

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -282,6 +282,10 @@ func (s *DisjunctionSliceSearcher) DocumentMatchPoolSize() int {
 	return rv
 }
 
+func (s *DisjunctionSliceSearcher) SetScorer(scorer scorer.DisjunctionQueryScorer) {
+	s.scorer = scorer
+}
+
 // a disjunction searcher implements the index.Optimizable interface
 // but only activates on an edge case where the disjunction is a
 // wrapper around a single Optimizable child searcher

--- a/search/searcher/search_docid.go
+++ b/search/searcher/search_docid.go
@@ -107,3 +107,7 @@ func (s *DocIDSearcher) Min() int {
 func (s *DocIDSearcher) DocumentMatchPoolSize() int {
 	return 1
 }
+
+func (s *DocIDSearcher) SetScorer(scorer scorer.ConstantScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_docid.go
+++ b/search/searcher/search_docid.go
@@ -33,7 +33,7 @@ func init() {
 // DocIDSearcher returns documents matching a predefined set of identifiers.
 type DocIDSearcher struct {
 	reader index.DocIDReader
-	scorer *scorer.ConstantScorer
+	scorer scorer.ConstantScorer
 	count  int
 }
 

--- a/search/searcher/search_match_all.go
+++ b/search/searcher/search_match_all.go
@@ -33,7 +33,7 @@ func init() {
 type MatchAllSearcher struct {
 	indexReader index.IndexReader
 	reader      index.DocIDReader
-	scorer      *scorer.ConstantScorer
+	scorer      scorer.ConstantScorer
 	count       uint64
 }
 

--- a/search/searcher/search_match_all.go
+++ b/search/searcher/search_match_all.go
@@ -119,3 +119,7 @@ func (s *MatchAllSearcher) Min() int {
 func (s *MatchAllSearcher) DocumentMatchPoolSize() int {
 	return 1
 }
+
+func (s *MatchAllSearcher) SetScorer(scorer scorer.ConstantScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -139,3 +139,7 @@ func (s *TermSearcher) Optimize(kind string, octx index.OptimizableContext) (
 
 	return octx, nil
 }
+
+func (s *TermSearcher) SetScorer(scorer scorer.TermQueryScorer) {
+	s.scorer = scorer
+}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -33,7 +33,7 @@ func init() {
 type TermSearcher struct {
 	indexReader index.IndexReader
 	reader      index.TermFieldReader
-	scorer      *scorer.TermQueryScorer
+	scorer      scorer.TermQueryScorer
 	tfd         index.TermFieldDoc
 }
 


### PR DESCRIPTION
Hi,

I'd like to be able to set the scorer of disjunction query to a custom one.

The reason is, that disjunction query scorer currently divides overall score of matched Disjuncts by the number of Disjuncts. Such behavior is reasonable for boolean query, but not for my use case (I need to get max score of Disjuncts). Unfortunately, the scorer is private property of a searcher.

To make it changeable, I renamed `DisjunctionScorer struct` to `disjunctionScorer` and created an `interface DisjunctionScorer` instead. Then I added `func SetScorer(scorer scorer.DisjunctionQueryScorer)` to disjunction searchers, which I use in my app.
For consistency, I did similar changes to other scorers as well (not needed by me now).

Please see a proposal how such change could be done. I do not know the naming rules of bleve project well, no problem to change anything.

Best regards
