### PR TITLE
fix ineffectual assignment

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -184,7 +184,7 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 		calcBudget = CalcBudget
 	}
 
-	budgetNumSegments := CalcBudget(eligiblesLiveSize, minLiveSize, o)
+	budgetNumSegments := calcBudget(eligiblesLiveSize, minLiveSize, o)
 
 	scoreSegments := o.ScoreSegments
 	if scoreSegments == nil {


### PR DESCRIPTION
Intention was for calcBudget local var to either use
the CalcBudget provided in the Options, or fall back
to the default mergeplan.CalcBudget method.  However,
after assigning the correct impl to the calcBudget
local var, the code always invoked
mergeplan.CalcBudget anwyay.

This change allows the CalcBudget option to work as
intended.