### PR TITLE
an optimization fix test was no longer helping

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -2135,6 +2135,11 @@ func testBatchRaceBug1149(t *testing.T, i Index) {
 }
 
 func TestOptimisedConjunctionSearchHits(t *testing.T) {
+	scorch.OptimizeDisjunctionUnadorned = false
+	defer func() {
+		scorch.OptimizeDisjunctionUnadorned = true
+	}()
+
 	defer func() {
 		err := os.RemoveAll("testidx")
 		if err != nil {


### PR DESCRIPTION
it was determined that this test was no longer testing what
it was designed to test, due to other changes.

this fix now correctly verifies the fix again by disabling
an optimization that interferes with the test

fixes #1458