### PR TITLE
MB-40730 - Sort by field returns incorrect results

### DIFF
--- a/search/sort.go
+++ b/search/sort.go
@@ -423,7 +423,8 @@ func (s *SortField) filterTermsByType(terms [][]byte) [][]byte {
 				allTermsPrefixCoded = false
 			}
 		}
-		if allTermsPrefixCoded {
+		// reset the terms only when valid zero shift terms are found.
+		if allTermsPrefixCoded && len(termsWithShiftZero) > 0 {
 			terms = termsWithShiftZero
 			s.tmp = termsWithShiftZero[:0]
 		}


### PR DESCRIPTION
Fixing the filterTermsByType method by resetting
the terms only when valid prefix coded, zero shifted
values are found to guard against any inadvertent overrides
of the original field values.

(cherry picked from commit 9a99dfbb79795c6bd5f0dad12242d572f6dc20f4)