### PR TITLE
fix tests on go 1.15

### DIFF
--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -959,7 +959,7 @@ func TestMappingForGeo(t *testing.T) {
 	expect = append(expect, []float64{-71.34, 41.12})
 
 	for i, geopoint := range geopoints {
-		doc := document.NewDocument(string(i))
+		doc := document.NewDocument(fmt.Sprint(i))
 		err := mapping.MapDocument(doc, geopoint)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
`go test` fails on my macos (go 1.15.2), complaining:

    mapping/mapping_test.go:962:31: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)

This PR fixes the issue by just doing what the error suggests. But I didn't dig into whether this is the thing that should be done and what the code actually did before this change.