### PR TITLE
MB-41541: [BP] Enabling score/id based search_after/before paginations

### DIFF
--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"context"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/blevesearch/bleve/index"
@@ -90,6 +91,18 @@ func NewTopNCollectorAfter(size int, sort search.SortOrder, after []string) *Top
 	rv.searchAfter = &search.DocumentMatch{
 		Sort: after,
 	}
+
+	for pos, ss := range sort {
+		if ss.RequiresDocID() {
+			rv.searchAfter.ID = after[pos]
+		}
+		if ss.RequiresScoring() {
+			if score, err := strconv.ParseFloat(after[pos], 64); err == nil {
+				rv.searchAfter.Score = score
+			}
+		}
+	}
+
 	return rv
 }
 

--- a/test/tests/sort/data/d.json
+++ b/test/tests/sort/data/d.json
@@ -2,6 +2,6 @@
 	"id": "d",
 	"age": 65,
   "born": "1978-12-02",
-	"title": "agent",
+	"title": "agent d is desperately trying out to be successful rapster!",
 	"tags": ["cats"]
 }

--- a/test/tests/sort/data/e.json
+++ b/test/tests/sort/data/e.json
@@ -2,6 +2,6 @@
 	"id": "e",
 	"name": "nancy",
   "born": "1954-10-22",
-	"title": "rapstar",
+	"title": "rapstar nancy rapster",
 	"tags": ["pain"]
 }

--- a/test/tests/sort/data/f.json
+++ b/test/tests/sort/data/f.json
@@ -2,6 +2,6 @@
 	"id": "f",
 	"name": "frank",
 	"age": 1,
-	"title": "taxman",
+	"title": "frank the taxman of cb, Rapster!",
 	"tags": ["vitamin","purple"]
 }

--- a/test/tests/sort/searches.json
+++ b/test/tests/sort/searches.json
@@ -458,5 +458,97 @@
         }
       ]
     }
+  },
+  {
+    "comment": "sort by ID, after doc d",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "match_all":{}
+      },
+      "sort": ["_id"],
+      "search_after": ["d"]
+    },
+    "result": {
+      "total_hits": 6,
+      "hits": [
+        {
+          "id": "e"
+        },
+        {
+          "id": "f"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "sort by ID, before doc d",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "match_all":{}
+      },
+      "sort": ["_id"],
+      "search_before": ["d"]
+    },
+    "result": {
+      "total_hits": 6,
+      "hits": [
+        {
+          "id": "a"
+        },
+        {
+          "id": "b"
+        },
+        {
+          "id": "c"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "sort by score, after score 0.286889[ e(299646) > f(286889) > d(222224)]",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "query":"rapster"
+      },
+      "sort": ["_score"],
+      "search_after": ["0.286889"]
+    },
+    "result": {
+      "total_hits": 3,
+      "hits": [
+        {
+          "id": "f"
+        },
+        {
+          "id": "e"
+        }
+      ]
+    }
+  },
+  {
+    "comment": "sort by score, before score f/0.286889[ e(299646) > f(286889) > d(222224)]",
+    "search": {
+      "from": 0,
+      "size": 10,
+      "query": {
+        "query":"rapster"
+      },
+      "sort": ["_score"],
+      "search_before": ["0.286889"]
+    },
+    "result": {
+      "total_hits": 3,
+      "hits": [
+        {
+          "id": "d"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This is a backport of: https://github.com/blevesearch/bleve/pull/1334

This change attempts to enable users provide the last
fetched document's score or ID values as keys in the
search after/before fields to make the deep pagination
works for the default _score or _id based sort orders.