### PR TITLE
New stats for reclaimable disk space from scorch index

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -515,41 +515,17 @@ func (s *Scorch) diskFileStats(rootSegmentPaths map[string]struct{}) (uint64,
 	return numFilesOnDisk, numBytesUsedDisk, numBytesOnDiskByRoot
 }
 
-// reClaimableDocsRatio gives a ratio about the obsoleted or
-// reclaimable documents present in a scorch index.
-func (s *Scorch) reClaimableDocsRatio() float64 {
-	var totalCount, liveCount uint64
-	s.rootLock.RLock()
-	indexSnapshot := s.root
-	s.rootLock.RUnlock()
-	for _, segmentSnapshot := range indexSnapshot.segment {
-		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
-			totalCount += uint64(segmentSnapshot.FullSize())
-			liveCount += uint64(segmentSnapshot.Count())
-		}
-	}
-
-	if totalCount > 0 {
-		return float64(totalCount-liveCount) / float64(totalCount)
-	}
-	return 0
-}
-
-func (s *Scorch) rootDiskSegmentsPaths() map[string]struct{} {
-	rv := make(map[string]struct{}, len(s.root.segment))
-	for _, segmentSnapshot := range s.root.segment {
-		if seg, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
-			rv[seg.Path()] = struct{}{}
-		}
-	}
-	return rv
-}
-
 func (s *Scorch) StatsMap() map[string]interface{} {
 	m := s.stats.ToMap()
 
+	indexSnapshot := s.currentSnapshot()
+	defer func() {
+		_ = indexSnapshot.Close()
+	}()
+
+	rootSegPaths := indexSnapshot.diskSegmentsPaths()
+
 	s.rootLock.RLock()
-	rootSegPaths := s.rootDiskSegmentsPaths()
 	m["CurFilesIneligibleForRemoval"] = uint64(len(s.ineligibleForRemoval))
 	s.rootLock.RUnlock()
 
@@ -578,7 +554,8 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_bytes_used_disk_by_root"] = numBytesOnDiskByRoot
 	// num_bytes_used_disk_by_root_reclaimable is an approximation about the
 	// reclaimable disk space in an index. (eg: from a full compaction)
-	m["num_bytes_used_disk_by_root_reclaimable"] = uint64(float64(numBytesOnDiskByRoot) * s.reClaimableDocsRatio())
+	m["num_bytes_used_disk_by_root_reclaimable"] = uint64(float64(numBytesOnDiskByRoot) *
+		indexSnapshot.reClaimableDocsRatio())
 	m["num_files_on_disk"] = numFilesOnDisk
 	m["num_root_memorysegments"] = m["TotMemorySegmentsAtRoot"]
 	m["num_root_filesegments"] = m["TotFileSegmentsAtRoot"]

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -695,6 +695,33 @@ func (i *IndexSnapshot) DumpFields() chan interface{} {
 	return rv
 }
 
+func (i *IndexSnapshot) diskSegmentsPaths() map[string]struct{} {
+	rv := make(map[string]struct{}, len(i.segment))
+	for _, segmentSnapshot := range i.segment {
+		if seg, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
+			rv[seg.Path()] = struct{}{}
+		}
+	}
+	return rv
+}
+
+// reClaimableDocsRatio gives a ratio about the obsoleted or
+// reclaimable documents present in a given index snapshot.
+func (i *IndexSnapshot) reClaimableDocsRatio() float64 {
+	var totalCount, liveCount uint64
+	for _, segmentSnapshot := range i.segment {
+		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
+			totalCount += uint64(segmentSnapshot.FullSize())
+			liveCount += uint64(segmentSnapshot.Count())
+		}
+	}
+
+	if totalCount > 0 {
+		return float64(totalCount-liveCount) / float64(totalCount)
+	}
+	return 0
+}
+
 // subtractStrings returns set a minus elements of set b.
 func subtractStrings(a, b []string) []string {
 	if len(b) == 0 {


### PR DESCRIPTION
Adding a new stat `num_bytes_used_disk_by_root_reclaimable`
which hints about the approximate amount of reclaimable disk space
from a scorch index. This could turn out to be a useful insight
into knowing the amount of disk space wasted due to tombstoned/obsoleted
contents across the segments and could potentially act as a trigger input
for the forceMerge api.
