### PR TITLE
Fix Dropped searcher Test Errors

### DIFF
--- a/search/searcher/search_boolean_test.go
+++ b/search/searcher/search_boolean_test.go
@@ -205,7 +205,9 @@ func TestBooleanSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 	conjunctionSearcher7, err := NewConjunctionSearcher(twoDocIndexReader, []search.Searcher{martyTermSearcher7, booleanSearcher7}, explainTrue)
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	// test 7
 	beerTermSearcher8, err := NewTermSearcher(twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -394,6 +394,9 @@ func testScorchCompositeSearchOptimizationsHelper(
 			}
 
 			next, err = cs.Next(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
 			i++
 		}
 

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -253,6 +253,9 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 		got = append(got, extId)
 		ctx.DocumentMatchPool.Put(next)
 		next, err = searcher.Next(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
 		i++
 	}
 	if err != nil {


### PR DESCRIPTION
This fixes three dropped `err` variables in `search/searcher`.