### PR TITLE
Index is always left closed when opening process fails

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -112,6 +112,11 @@ func newIndexUsing(path string, mapping mapping.IndexMapping, indexType string, 
 		}
 		return nil, err
 	}
+	defer func() {
+		if !rv.open {
+			rv.i.Close()
+		}
+	}()
 
 	// now persist the mapping
 	mappingBytes, err := json.Marshal(mapping)
@@ -177,6 +182,11 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 		}
 		return nil, err
 	}
+	defer func() {
+		if !rv.open {
+			rv.i.Close()
+		}
+	}()
 
 	// now load the mapping
 	indexReader, err := rv.i.Reader()


### PR DESCRIPTION
When index opening fails in some later stage, after storage is opened, `nil` and `error` are returned, but the index remains open. There is no way for the user to close the index, because of `nil`.

The fix closes the index when `nil` is going to be returned. 