### PR TITLE
Fix DocValuesDynamic's json-ability within IndexMappingImpl

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -16,6 +16,7 @@ package bleve
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -2234,5 +2235,41 @@ func TestOptimisedConjunctionSearchHits(t *testing.T) {
 	err = idx.Close()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestIndexMappingDocValuesDynamic(t *testing.T) {
+	im := NewIndexMapping()
+	// DocValuesDynamic's default is true
+	// Now explicitly set it to false
+	im.DocValuesDynamic = false
+
+	// Next, retrieve the JSON dump of the index mapping
+	var data []byte
+	data, err = json.Marshal(im)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, edit an unrelated setting in the index mapping
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m["index_dynamic"] = false
+	data, err = json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unmarshal back the changes into the index mapping struct
+	if err = im.UnmarshalJSON(data); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect DocValuesDynamic to remain false!
+	if im.DocValuesDynamic {
+		t.Fatalf("Expected DocValuesDynamic to remain false after the index mapping edit")
 	}
 }

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -50,7 +50,7 @@ type IndexMappingImpl struct {
 	DefaultField          string                      `json:"default_field"`
 	StoreDynamic          bool                        `json:"store_dynamic"`
 	IndexDynamic          bool                        `json:"index_dynamic"`
-	DocValuesDynamic      bool                        `json:"docvalues_dynamic,omitempty"`
+	DocValuesDynamic      bool                        `json:"docvalues_dynamic"`
 	CustomAnalysis        *customAnalysis             `json:"analysis,omitempty"`
 	cache                 *registry.Cache
 }


### PR DESCRIPTION
    + DocValuesDynamic defaults to "true" if unset.
    + Now, because of the "omitempty" json setting for the attribute,
      we incorrectly flip a "false" setting for the attribute (which is
      omitted as it's the zero value for boolean) to "true" (it's default).
    + Dropping the omitempty setting for this attribute corrects the
      behavior to this:
        - when unset, DocValuesDynamic will default to true (like before)
        - when set, DocValuesDynamic will take that value and will retain
          the value until an index definition update for the setting.
    + Fixes https://github.com/blevesearch/bleve/issues/1484
        (where the scenario is highlighted better)