### PR TITLE
Remove default from text description

### DIFF
--- a/cmd/bleve/cmd/bulk.go
+++ b/cmd/bleve/cmd/bulk.go
@@ -112,6 +112,6 @@ func randomString(n int) string {
 func init() {
 	RootCmd.AddCommand(bulkCmd)
 
-	bulkCmd.Flags().IntVarP(&batchSize, "batch", "b", 1000, "Batch size for loading, default 1000.")
-	bulkCmd.Flags().BoolVarP(&parseJSON, "json", "j", true, "Parse the contents as JSON, defaults true.")
+	bulkCmd.Flags().IntVarP(&batchSize, "batch", "b", 1000, "Batch size for loading.")
+	bulkCmd.Flags().BoolVarP(&parseJSON, "json", "j", true, "Parse the contents as JSON.")
 }

--- a/cmd/bleve/cmd/check.go
+++ b/cmd/bleve/cmd/check.go
@@ -126,6 +126,6 @@ func getDictionary(index bleve.Index, field string) (map[string]uint64, error) {
 
 func init() {
 	RootCmd.AddCommand(checkCmd)
-	checkCmd.Flags().StringVarP(&checkFieldName, "field", "f", "", "Restrict check to the specified field name, by default check all fields.")
-	checkCmd.Flags().IntVarP(&checkCount, "count", "c", 100, "Check this many terms, default 100.")
+	checkCmd.Flags().StringVarP(&checkFieldName, "field", "f", "", "Restrict check to the specified field name.")
+	checkCmd.Flags().IntVarP(&checkCount, "count", "c", 100, "Check this many terms.")
 }

--- a/cmd/bleve/cmd/index.go
+++ b/cmd/bleve/cmd/index.go
@@ -111,7 +111,7 @@ func getAllFiles(args []string, rv chan file) {
 func init() {
 	RootCmd.AddCommand(indexCmd)
 
-	indexCmd.Flags().BoolVarP(&keepDir, "keepDir", "d", false, "Keep the directory in the document id, defaults false.")
-	indexCmd.Flags().BoolVarP(&keepExt, "keepExt", "x", false, "Keep the extension in the document id, defaults false.")
-	indexCmd.Flags().BoolVarP(&parseJSON, "json", "j", true, "Parse the contents as JSON, defaults true.")
+	indexCmd.Flags().BoolVarP(&keepDir, "keepDir", "d", false, "Keep the directory in the document id.")
+	indexCmd.Flags().BoolVarP(&keepExt, "keepExt", "x", false, "Keep the extension in the document id.")
+	indexCmd.Flags().BoolVarP(&parseJSON, "json", "j", true, "Parse the contents as JSON.")
 }

--- a/cmd/bleve/cmd/query.go
+++ b/cmd/bleve/cmd/query.go
@@ -89,13 +89,13 @@ func buildQuery(args []string) query.Query {
 func init() {
 	RootCmd.AddCommand(queryCmd)
 
-	queryCmd.Flags().IntVarP(&repeat, "repeat", "r", 1, "Repeat the query this many times, default 1.")
-	queryCmd.Flags().IntVarP(&limit, "limit", "l", 10, "Limit number of results returned, default 10.")
-	queryCmd.Flags().IntVarP(&skip, "skip", "s", 0, "Skip the first N results, default 0.")
-	queryCmd.Flags().BoolVarP(&explain, "explain", "x", false, "Explain the result scoring, default false.")
-	queryCmd.Flags().BoolVar(&highlight, "highlight", true, "Highlight matching text in results, default true.")
-	queryCmd.Flags().BoolVar(&fields, "fields", false, "Load stored fields, default false.")
-	queryCmd.Flags().StringVarP(&qtype, "type", "t", "query_string", "Type of query to run, defaults to 'query_string'")
-	queryCmd.Flags().StringVarP(&qfield, "field", "f", "", "Restrict query to field, by default no restriction, not applicable to query_string queries.")
+	queryCmd.Flags().IntVarP(&repeat, "repeat", "r", 1, "Repeat the query this many times.")
+	queryCmd.Flags().IntVarP(&limit, "limit", "l", 10, "Limit number of results returned.")
+	queryCmd.Flags().IntVarP(&skip, "skip", "s", 0, "Skip the first N results.")
+	queryCmd.Flags().BoolVarP(&explain, "explain", "x", false, "Explain the result scoring.")
+	queryCmd.Flags().BoolVar(&highlight, "highlight", true, "Highlight matching text in results.")
+	queryCmd.Flags().BoolVar(&fields, "fields", false, "Load stored fields.")
+	queryCmd.Flags().StringVarP(&qtype, "type", "t", "query_string", "Type of query to run.")
+	queryCmd.Flags().StringVarP(&qfield, "field", "f", "", "Restrict query to field, not applicable to query_string queries.")
 	queryCmd.Flags().StringVarP(&sortby, "sort-by", "b", "", "Sort by field.")
 }


### PR DESCRIPTION
Default is added to the output automatically by the flags package, so having it in the text as well is redundant. Closes #1488.