### PR TITLE
reduce index and segment API surface area

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -190,21 +190,55 @@ func (i *IndexSnapshot) newIndexSnapshotFieldDict(field string,
 
 func (i *IndexSnapshot) FieldDict(field string) (index.FieldDict, error) {
 	return i.newIndexSnapshotFieldDict(field, func(i segment.TermDictionary) segment.DictionaryIterator {
-		return i.Iterator()
+		return i.AutomatonIterator(nil, nil, nil)
 	}, false)
+}
+
+func exclusiveEndFromInclusiveEnd(inclusiveEnd []byte) []byte {
+	if len(inclusiveEnd) > 0 {
+		if inclusiveEnd[len(inclusiveEnd)-1] < 0xff {
+			// last byte can be incremented by one
+			inclusiveEnd[len(inclusiveEnd)-1]++
+		} else {
+			// last byte is already 0xff, so append 0
+			// next key is simply one byte longer
+			inclusiveEnd = append(inclusiveEnd, 0x0)
+		}
+	}
+	return inclusiveEnd
 }
 
 func (i *IndexSnapshot) FieldDictRange(field string, startTerm []byte,
 	endTerm []byte) (index.FieldDict, error) {
 	return i.newIndexSnapshotFieldDict(field, func(i segment.TermDictionary) segment.DictionaryIterator {
-		return i.RangeIterator(string(startTerm), string(endTerm))
+		endTermExclusive := exclusiveEndFromInclusiveEnd(endTerm)
+		return i.AutomatonIterator(nil, startTerm, endTermExclusive)
 	}, false)
+}
+
+// incrementBytesPrefix produces the first key that does not
+// have the same prefix as the input bytes, suitable to use
+// as the end key in a traditional (inclusive, exclusive]
+// start/end range
+func exclusiveEndFromPrefix(in []byte) []byte {
+	rv := make([]byte, len(in))
+	copy(rv, in)
+	for i := len(rv) - 1; i >= 0; i-- {
+		rv[i] = rv[i] + 1
+		if rv[i] != 0 {
+			return rv // didn't overflow, so stop
+		}
+	}
+	// all bytes were 0xff, so return nil
+	// as there is no end key for this prefix
+	return nil
 }
 
 func (i *IndexSnapshot) FieldDictPrefix(field string,
 	termPrefix []byte) (index.FieldDict, error) {
+	termPrefixEnd := exclusiveEndFromPrefix(termPrefix)
 	return i.newIndexSnapshotFieldDict(field, func(i segment.TermDictionary) segment.DictionaryIterator {
-		return i.PrefixIterator(string(termPrefix))
+		return i.AutomatonIterator(nil, termPrefix, termPrefixEnd)
 	}, false)
 }
 
@@ -248,13 +282,6 @@ func (i *IndexSnapshot) FieldDictFuzzy(field string,
 
 	return i.newIndexSnapshotFieldDict(field, func(i segment.TermDictionary) segment.DictionaryIterator {
 		return i.AutomatonIterator(a, prefixBeg, prefixEnd)
-	}, false)
-}
-
-func (i *IndexSnapshot) FieldDictOnly(field string,
-	onlyTerms [][]byte, includeCount bool) (index.FieldDict, error) {
-	return i.newIndexSnapshotFieldDict(field, func(i segment.TermDictionary) segment.DictionaryIterator {
-		return i.OnlyIterator(onlyTerms, includeCount)
 	}, false)
 }
 

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -195,17 +195,20 @@ func (i *IndexSnapshot) FieldDict(field string) (index.FieldDict, error) {
 }
 
 func exclusiveEndFromInclusiveEnd(inclusiveEnd []byte) []byte {
+	rv := inclusiveEnd
 	if len(inclusiveEnd) > 0 {
-		if inclusiveEnd[len(inclusiveEnd)-1] < 0xff {
+		rv = make([]byte, len(inclusiveEnd))
+		copy(rv, inclusiveEnd)
+		if rv[len(rv)-1] < 0xff {
 			// last byte can be incremented by one
-			inclusiveEnd[len(inclusiveEnd)-1]++
+			rv[len(rv)-1]++
 		} else {
 			// last byte is already 0xff, so append 0
 			// next key is simply one byte longer
-			inclusiveEnd = append(inclusiveEnd, 0x0)
+			rv = append(rv, 0x0)
 		}
 	}
-	return inclusiveEnd
+	return rv
 }
 
 func (i *IndexSnapshot) FieldDictRange(field string, startTerm []byte,

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -147,7 +147,7 @@ func (cfd *cachedFieldDocs) prepareField(field string, ss *SegmentSnapshot) {
 	var postings segment.PostingsList
 	var postingsItr segment.PostingsIterator
 
-	dictItr := dict.Iterator()
+	dictItr := dict.AutomatonIterator(nil, nil, nil)
 	next, err := dictItr.Next()
 	for err == nil && next != nil {
 		var err1 error

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -106,24 +106,6 @@ func NewNumericRangeSearcher(indexReader index.IndexReader,
 func filterCandidateTerms(indexReader index.IndexReader,
 	terms [][]byte, field string) (rv [][]byte, err error) {
 
-	if ir, ok := indexReader.(index.IndexReaderOnly); ok {
-		fieldDict, err := ir.FieldDictOnly(field, terms, false)
-		if err != nil {
-			return nil, err
-		}
-		// enumerate the terms (no need to check them again)
-		tfd, err := fieldDict.Next()
-		for err == nil && tfd != nil {
-			rv = append(rv, []byte(tfd.Term))
-			tfd, err = fieldDict.Next()
-		}
-		if cerr := fieldDict.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-
-		return rv, err
-	}
-
 	fieldDict, err := indexReader.FieldDictRange(field, terms[0], terms[len(terms)-1])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Logic inside segment implementations has been
moved up the stack into scorch, so that fewer
methods are required in the API.

- Iterator() becomes AutomatonIterator(nil, nil, nil)
- RangeIterator(start, end) now computes an end key
  compatible with traditional inclusive start, exclusive
  end keys.  Then becomes:
  AutomatonIterator(nil, start, endExclusive)
- PrefixIterator(prefix) now computes an end key
  and becomes:
  AutomatonIterator(nil, prefix, prefixEnd)

NumericRangeSearcher updated to no longer require
the IndexReaderOnly interface.  This interface
was only used for non-scorch indexes, but only
scorch actually implemented it.  Removing this
also meant we can remove the OnlyIterator method
from the segment dictionary API.