### PR TITLE
make ErrUnknownIndexType upsidedown specific

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,7 +20,6 @@ const (
 	ErrorIndexPathDoesNotExist
 	ErrorIndexMetaMissing
 	ErrorIndexMetaCorrupt
-	ErrorUnknownStorageType
 	ErrorIndexClosed
 	ErrorAliasMulti
 	ErrorAliasEmpty
@@ -42,7 +41,6 @@ var errorMessages = map[Error]string{
 	ErrorIndexPathDoesNotExist:  "cannot open index, path does not exist",
 	ErrorIndexMetaMissing:       "cannot open index, metadata missing",
 	ErrorIndexMetaCorrupt:       "cannot open index, metadata corrupt",
-	ErrorUnknownStorageType:     "unknown storage type",
 	ErrorIndexClosed:            "index is closed",
 	ErrorAliasMulti:             "cannot perform single index operation on multiple index alias",
 	ErrorAliasEmpty:             "cannot perform operation on empty alias",

--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -48,6 +48,8 @@ const Version uint8 = 7
 
 var IncompatibleVersion = fmt.Errorf("incompatible version, %d is supported", Version)
 
+var ErrorUnknownStorageType = fmt.Errorf("unknown storage type")
+
 type UpsideDownCouch struct {
 	version       uint8
 	path          string
@@ -299,7 +301,7 @@ func (udc *UpsideDownCouch) Open() (err error) {
 	// open the kv store
 	storeConstructor := registry.KVStoreConstructorByName(udc.storeName)
 	if storeConstructor == nil {
-		err = index.ErrorUnknownStorageType
+		err = ErrorUnknownStorageType
 		return
 	}
 

--- a/index_impl.go
+++ b/index_impl.go
@@ -106,9 +106,6 @@ func newIndexUsing(path string, mapping mapping.IndexMapping, indexType string, 
 	}
 	err = rv.i.Open()
 	if err != nil {
-		if err == index.ErrorUnknownStorageType {
-			return nil, ErrorUnknownStorageType
-		}
 		return nil, err
 	}
 	defer func(rv *indexImpl) {
@@ -176,9 +173,6 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 	}
 	err = rv.i.Open()
 	if err != nil {
-		if err == index.ErrorUnknownStorageType {
-			return nil, ErrorUnknownStorageType
-		}
 		return nil, err
 	}
 	defer func(rv *indexImpl) {

--- a/index_test.go
+++ b/index_test.go
@@ -280,8 +280,8 @@ func TestIndexOpenMetaMissingOrCorrupt(t *testing.T) {
 	}
 
 	index, err = Open(tmpIndexPath)
-	if err != ErrorUnknownStorageType {
-		t.Fatalf("expected error unknown storage type, got %v", err)
+	if err == nil {
+		t.Fatalf("expected error for unknown storage type, got %v", err)
 	}
 
 	// now intentionally corrupt the metadata


### PR DESCRIPTION
this removes the top-level bleve err ErrUnknownIndexType
instead, now the upsidedown specific error is returned.

users who actually care and are checking for this error type
still can, only now it is defined in the upsidedown package.