### PR TITLE
remove use of dump methods from index reader

### DIFF
--- a/cmd/bleve/cmd/dump.go
+++ b/cmd/bleve/cmd/dump.go
@@ -37,8 +37,12 @@ var dumpCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error getting index reader: %v", err)
 		}
+		upsideDownReader, ok := r.(*upsidedown.IndexReader)
+		if !ok {
+			return fmt.Errorf("dump is only supported by index type upsidedown")
+		}
 
-		dumpChan := r.DumpAll()
+		dumpChan := upsideDownReader.DumpAll()
 		for rowOrErr := range dumpChan {
 			switch rowOrErr := rowOrErr.(type) {
 			case error:

--- a/cmd/bleve/cmd/dumpDoc.go
+++ b/cmd/bleve/cmd/dumpDoc.go
@@ -39,8 +39,12 @@ var dumpDocCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error getting index reader: %v", err)
 		}
+		upsideDownReader, ok := r.(*upsidedown.IndexReader)
+		if !ok {
+			return fmt.Errorf("dump doc is only supported by index type upsidedown")
+		}
 
-		dumpChan := r.DumpDoc(args[1])
+		dumpChan := upsideDownReader.DumpDoc(args[1])
 		for rowOrErr := range dumpChan {
 			switch rowOrErr := rowOrErr.(type) {
 			case error:

--- a/cmd/bleve/cmd/dumpFields.go
+++ b/cmd/bleve/cmd/dumpFields.go
@@ -35,8 +35,12 @@ var dumpFieldsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error getting index reader: %v", err)
 		}
+		upsideDownReader, ok := r.(*upsidedown.IndexReader)
+		if !ok {
+			return fmt.Errorf("dump fields is only supported by index type upsidedown")
+		}
 
-		dumpChan := r.DumpFields()
+		dumpChan := upsideDownReader.DumpFields()
 		for rowOrErr := range dumpChan {
 			switch rowOrErr := rowOrErr.(type) {
 			case error:

--- a/http/debug.go
+++ b/http/debug.go
@@ -67,9 +67,14 @@ func (h *DebugDocumentHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		showError(w, req, fmt.Sprintf("error operning index reader: %v", err), 500)
 		return
 	}
+	upsideDownReader, ok := internalIndexReader.(*upsidedown.IndexReader)
+	if !ok {
+		showError(w, req, fmt.Sprintf("dump is only supported by index type upsidedown"), 500)
+		return
+	}
 
 	var rv []interface{}
-	rowChan := internalIndexReader.DumpDoc(docID)
+	rowChan := upsideDownReader.DumpDoc(docID)
 	for row := range rowChan {
 		switch row := row.(type) {
 		case error:

--- a/index/upsidedown/dump_test.go
+++ b/index/upsidedown/dump_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	index "github.com/blevesearch/bleve_index_api"
 	"github.com/blevesearch/bleve/index/upsidedown/store/boltdb"
+	index "github.com/blevesearch/bleve_index_api"
 
 	"github.com/blevesearch/bleve/document"
 )
@@ -96,7 +96,11 @@ func TestDump(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fieldsRows := reader.DumpFields()
+	upsideDownReader, ok := reader.(*IndexReader)
+	if !ok {
+		t.Fatal("dump is only supported by index type upsidedown")
+	}
+	fieldsRows := upsideDownReader.DumpFields()
 	for range fieldsRows {
 		fieldsCount++
 	}
@@ -110,7 +114,7 @@ func TestDump(t *testing.T) {
 	// 3 stored fields
 	expectedDocRowCount := int(1 + (2 * (64 / document.DefaultPrecisionStep)) + 3)
 	docRowCount := 0
-	docRows := reader.DumpDoc("1")
+	docRows := upsideDownReader.DumpDoc("1")
 	for range docRows {
 		docRowCount++
 	}
@@ -119,7 +123,7 @@ func TestDump(t *testing.T) {
 	}
 
 	docRowCount = 0
-	docRows = reader.DumpDoc("2")
+	docRows = upsideDownReader.DumpDoc("2")
 	for range docRows {
 		docRowCount++
 	}
@@ -136,7 +140,7 @@ func TestDump(t *testing.T) {
 	// 16 date term row counts (shared for both docs, same date value)
 	expectedAllRowCount := int(1 + fieldsCount + (2 * expectedDocRowCount) + 2 + 2 + int((2 * (64 / document.DefaultPrecisionStep))))
 	allRowCount := 0
-	allRows := reader.DumpAll()
+	allRows := upsideDownReader.DumpAll()
 	for range allRows {
 		allRowCount++
 	}


### PR DESCRIPTION
the dump methods were only ever supposed by upsidedown
now, users of this method must type-assert that their reader
is from the upsidedown package, where these methods remain,
unchanged.