### PR TITLE
Introducing indexingOptions for configurable frequency/norm.

### DIFF
--- a/document/field_boolean.go
+++ b/document/field_boolean.go
@@ -69,7 +69,13 @@ func (b *BooleanField) Analyze() (int, analysis.TokenFrequencies) {
 	})
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, b.arrayPositions, b.options.IncludeTermVectors())
+	var tokenFreqs analysis.TokenFrequencies
+	if b.options.SkipFreqNorm() {
+		tokenFreqs = analysis.TokenWithoutFrequencyNorm(tokens, b.arrayPositions, b.options.IncludeTermVectors())
+	} else {
+		tokenFreqs = analysis.TokenFrequency(tokens, b.arrayPositions, b.options.IncludeTermVectors())
+	}
+
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_datetime.go
+++ b/document/field_datetime.go
@@ -96,7 +96,13 @@ func (n *DateTimeField) Analyze() (int, analysis.TokenFrequencies) {
 	}
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	var tokenFreqs analysis.TokenFrequencies
+	if n.options.SkipFreqNorm() {
+		tokenFreqs = analysis.TokenWithoutFrequencyNorm(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	} else {
+		tokenFreqs = analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	}
+
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_geopoint.go
+++ b/document/field_geopoint.go
@@ -91,7 +91,13 @@ func (n *GeoPointField) Analyze() (int, analysis.TokenFrequencies) {
 	}
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	var tokenFreqs analysis.TokenFrequencies
+	if n.options.SkipFreqNorm() {
+		tokenFreqs = analysis.TokenWithoutFrequencyNorm(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	} else {
+		tokenFreqs = analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	}
+
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_numeric.go
+++ b/document/field_numeric.go
@@ -92,7 +92,12 @@ func (n *NumericField) Analyze() (int, analysis.TokenFrequencies) {
 	}
 
 	fieldLength := len(tokens)
-	tokenFreqs := analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	var tokenFreqs analysis.TokenFrequencies
+	if n.options.SkipFreqNorm() {
+		tokenFreqs = analysis.TokenWithoutFrequencyNorm(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	} else {
+		tokenFreqs = analysis.TokenFrequency(tokens, n.arrayPositions, n.options.IncludeTermVectors())
+	}
 	return fieldLength, tokenFreqs
 }
 

--- a/document/field_text.go
+++ b/document/field_text.go
@@ -82,7 +82,13 @@ func (t *TextField) Analyze() (int, analysis.TokenFrequencies) {
 		}
 	}
 	fieldLength := len(tokens) // number of tokens in this doc field
-	tokenFreqs := analysis.TokenFrequency(tokens, t.arrayPositions, t.options.IncludeTermVectors())
+	var tokenFreqs analysis.TokenFrequencies
+	if t.options.SkipFreqNorm() {
+		tokenFreqs = analysis.TokenWithoutFrequencyNorm(tokens, t.arrayPositions, t.options.IncludeTermVectors())
+	} else {
+		tokenFreqs = analysis.TokenFrequency(tokens, t.arrayPositions, t.options.IncludeTermVectors())
+	}
+
 	return fieldLength, tokenFreqs
 }
 

--- a/document/indexing_options.go
+++ b/document/indexing_options.go
@@ -21,6 +21,7 @@ const (
 	StoreField
 	IncludeTermVectors
 	DocValues
+	SkipFreqNorm
 )
 
 func (o IndexingOptions) IsIndexed() bool {
@@ -37,6 +38,10 @@ func (o IndexingOptions) IncludeTermVectors() bool {
 
 func (o IndexingOptions) IncludeDocValues() bool {
 	return o&DocValues != 0
+}
+
+func (o IndexingOptions) SkipFreqNorm() bool {
+	return o&SkipFreqNorm != 0
 }
 
 func (o IndexingOptions) String() string {
@@ -61,6 +66,12 @@ func (o IndexingOptions) String() string {
 			rv += ", "
 		}
 		rv += "DV"
+	}
+	if !o.SkipFreqNorm() {
+		if rv != "" {
+			rv += ", "
+		}
+		rv += "FN"
 	}
 	return rv
 }

--- a/document/indexing_options_test.go
+++ b/document/indexing_options_test.go
@@ -25,6 +25,7 @@ func TestIndexingOptions(t *testing.T) {
 		isStored           bool
 		includeTermVectors bool
 		docValues          bool
+		skipFreqNorm       bool
 	}{
 		{
 			options:            IndexField | StoreField | IncludeTermVectors,
@@ -75,6 +76,18 @@ func TestIndexingOptions(t *testing.T) {
 			includeTermVectors: true,
 			docValues:          true,
 		},
+		{
+			options:      SkipFreqNorm,
+			skipFreqNorm: true,
+		},
+		{
+			options:            IndexField | StoreField | SkipFreqNorm | DocValues,
+			isIndexed:          true,
+			isStored:           true,
+			skipFreqNorm:       true,
+			docValues:          true,
+			includeTermVectors: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -93,6 +106,10 @@ func TestIndexingOptions(t *testing.T) {
 		actuallyDocValues := test.options.IncludeDocValues()
 		if actuallyDocValues != test.docValues {
 			t.Errorf("expected docValue to be %v, got %v for %d", test.docValues, actuallyDocValues, test.options)
+		}
+		actuallyFreqNormValues := test.options.SkipFreqNorm()
+		if actuallyFreqNormValues != test.skipFreqNorm {
+			t.Errorf("expected docValue to be %v, got %v for %d", test.skipFreqNorm, actuallyFreqNormValues, test.options)
 		}
 	}
 }

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -59,6 +59,12 @@ type FieldMapping struct {
 	// DocValues, if true makes the index uninverting possible for this field
 	// It is useful for faceting and sorting queries.
 	DocValues bool `json:"docvalues,omitempty"`
+
+	// SkipFreqNorm, if true, avoids the indexing of frequency and norm values
+	// of the tokens for this field. This option would be useful for saving
+	// the processing of freq/norm details when the default score based relevancy
+	// isn't needed.
+	SkipFreqNorm bool `json:"skip_freq_norm,omitempty"`
 }
 
 // NewTextFieldMapping returns a default field mapping for text
@@ -163,6 +169,9 @@ func (fm *FieldMapping) Options() document.IndexingOptions {
 	}
 	if fm.DocValues {
 		rv |= document.DocValues
+	}
+	if fm.SkipFreqNorm {
+		rv |= document.SkipFreqNorm
 	}
 	return rv
 }
@@ -327,6 +336,11 @@ func (fm *FieldMapping) UnmarshalJSON(data []byte) error {
 			}
 		case "docvalues":
 			err := json.Unmarshal(v, &fm.DocValues)
+			if err != nil {
+				return err
+			}
+		case "skip_freq_norm":
+			err := json.Unmarshal(v, &fm.SkipFreqNorm)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Adding an indexing option to skip freq/norm processing with
indexes for use cases where score relevancy isn't needed
for the search requests.

A special frequency value of zero/0 is used for skipping
the freq/norm.