### PR TITLE
switch default index to scorch with latest zap

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,14 +20,11 @@ import (
 	"log"
 	"time"
 
+	"github.com/blevesearch/bleve/index/scorch"
 	"github.com/blevesearch/bleve/index/upsidedown/store/gtreap"
-	"github.com/blevesearch/bleve/index/upsidedown"
 	"github.com/blevesearch/bleve/registry"
 	"github.com/blevesearch/bleve/search/highlight/highlighter/html"
 	index "github.com/blevesearch/bleve_index_api"
-
-	// force import of scorch so its accessible by default
-	_ "github.com/blevesearch/bleve/index/scorch"
 )
 
 var bleveExpVar = expvar.NewMap("bleve")
@@ -79,7 +76,7 @@ func init() {
 	Config.DefaultMemKVStore = gtreap.Name
 
 	// default index
-	Config.DefaultIndexType = upsidedown.Name
+	Config.DefaultIndexType = scorch.Name
 
 	bootDuration := time.Since(bootStart)
 	bleveExpVar.Add("bootDuration", int64(bootDuration))

--- a/examples_test.go
+++ b/examples_test.go
@@ -449,6 +449,7 @@ func ExampleSearchRequest_SortByCustom() {
 			Field:   "Age",
 			Missing: search.SortFieldMissingFirst,
 		},
+		&search.SortDocID{},
 	})
 	searchResults, err := exampleIndex.Search(searchRequest)
 	if err != nil {

--- a/index.go
+++ b/index.go
@@ -16,6 +16,7 @@ package bleve
 
 import (
 	"context"
+	"github.com/blevesearch/bleve/index/upsidedown"
 
 	"github.com/blevesearch/bleve/document"
 	"github.com/blevesearch/bleve/mapping"
@@ -261,7 +262,7 @@ func New(path string, mapping mapping.IndexMapping) (Index, error) {
 // The provided mapping will be used for all
 // Index/Search operations.
 func NewMemOnly(mapping mapping.IndexMapping) (Index, error) {
-	return newIndexUsing("", mapping, Config.DefaultIndexType, Config.DefaultMemKVStore, nil)
+	return newIndexUsing("", mapping, upsidedown.Name, Config.DefaultMemKVStore, nil)
 }
 
 // NewUsing creates index at the specified path,

--- a/index/scorch/segment_plugin.go
+++ b/index/scorch/segment_plugin.go
@@ -71,11 +71,11 @@ var defaultSegmentPlugin SegmentPlugin
 
 func init() {
 	ResetSegmentPlugins()
-	RegisterSegmentPlugin(&zapv15.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv15.ZapPlugin{}, true)
 	RegisterSegmentPlugin(&zapv14.ZapPlugin{}, false)
 	RegisterSegmentPlugin(&zapv13.ZapPlugin{}, false)
 	RegisterSegmentPlugin(&zapv12.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv11.ZapPlugin{}, true)
+	RegisterSegmentPlugin(&zapv11.ZapPlugin{}, false)
 }
 
 func ResetSegmentPlugins() {


### PR DESCRIPTION
one example required updating as it's custom sort contained a
tie (both fields with age 0).  upsidedown always returned the
results in a particular order, which was not guaranteed by scorch.
to address this, the exmaple has been updated to include the
doc id as an additional sort criteria (ensuring the original
order expected is kept by scorch)