### PR TITLE
introduce online backup for scorch indexes

### DIFF
--- a/index.go
+++ b/index.go
@@ -249,6 +249,14 @@ type Index interface {
 	Advanced() (index.Index, error)
 }
 
+// IndexBackupable is an Index which supports an online backup operation.
+type IndexBackupable interface {
+
+	// Backup creates a fully functional backup copy of the index at the
+	// specified destination path.
+	Backup(string) error
+}
+
 // New index at the specified path, must not exist.
 // The provided mapping will be used for all
 // Index/Search operations.

--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -304,7 +304,7 @@ func (o *Builder) Close() error {
 	}
 
 	// fill the root bolt with this fake index snapshot
-	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin)
+	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil)
 	if err != nil {
 		_ = tx.Rollback()
 		_ = rootBolt.Close()

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -429,7 +429,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot) (
 }
 
 func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
-	segPlugin SegmentPlugin) ([]string, map[uint64]string, error) {
+	segPlugin SegmentPlugin, backupHelper func(string, uint64) (string, error)) ([]string, map[uint64]string, error) {
 	snapshotsBucket, err := tx.CreateBucketIfNotExists(boltSnapshotsBucket)
 	if err != nil {
 		return nil, nil, err
@@ -482,6 +482,12 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 		switch seg := segmentSnapshot.segment.(type) {
 		case segment.PersistedSegment:
 			segPath := seg.Path()
+			if backupHelper != nil {
+				segPath, err = backupHelper(segPath, segmentSnapshot.id)
+				if err != nil {
+					return nil, nil, fmt.Errorf("error backing up segment: %v", err)
+				}
+			}
 			filename := strings.TrimPrefix(segPath, path+string(os.PathSeparator))
 			err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
 			if err != nil {
@@ -535,7 +541,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 		}
 	}()
 
-	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin)
+	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
approach used is to acquire an index snapshot
and reuse existing code for persisting
snapshot segments and recording snapshot
information into the root bolt, with minimal changes
to record items into a new backup directory