### PR TITLE
introduce new scorch config bolt_timeout

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -199,11 +199,9 @@ func (s *Scorch) openBolt() error {
 		s.unsafeBatch = true
 	}
 
-	var rootBoltOpt *bolt.Options
+	var rootBoltOpt = *bolt.DefaultOptions
 	if s.readOnly {
-		rootBoltOpt = &bolt.Options{
-			ReadOnly: true,
-		}
+		rootBoltOpt.ReadOnly = true
 	} else {
 		if s.path != "" {
 			err := os.MkdirAll(s.path, 0700)
@@ -213,10 +211,19 @@ func (s *Scorch) openBolt() error {
 		}
 	}
 
+	if boltTimeoutStr, ok := s.config["bolt_timeout"].(string); ok {
+		var err error
+		boltTimeout, err := time.ParseDuration(boltTimeoutStr)
+		if err != nil {
+			return fmt.Errorf("invalid duration specified for bolt_timeout: %v", err)
+		}
+		rootBoltOpt.Timeout = boltTimeout
+	}
+
 	rootBoltPath := s.path + string(os.PathSeparator) + "root.bolt"
 	var err error
 	if s.path != "" {
-		s.rootBolt, err = bolt.Open(rootBoltPath, 0600, rootBoltOpt)
+		s.rootBolt, err = bolt.Open(rootBoltPath, 0600, &rootBoltOpt)
 		if err != nil {
 			return err
 		}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -2557,10 +2557,14 @@ func TestOpenBoltTimeout(t *testing.T) {
 		t.Errorf("error opening index: %v", err)
 	}
 
-	// use timeout for second open of same
-	cfg["bolt_timeout"] = "100ms"
+	// new config
+	cfg2 := CreateConfig("TestIndexOpenReopen")
+	// copy path from original config
+	cfg2["path"] = cfg["path"]
+	// set timeout in this cfg
+	cfg2["bolt_timeout"] = "100ms"
 
-	idx2, err := NewScorch("storeName", cfg, analysisQueue)
+	idx2, err := NewScorch("storeName", cfg2, analysisQueue)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Users can specify the config setting bolt_timeout with a string,
this string will be parsed using time.ParseDuration.  The
resulting time.Duration will be set as the bolt option Timeout
when the bolt database is opened.

For more information about this bolt setting see:

https://github.com/etcd-io/bbolt/blob/f6be82302843a215152f5a1daf652c1ee5503f85/db.go#L1020-L1023

fixes #1491