### PR TITLE
MB-31358: Estimation of memory needed for query with highlighting

### DIFF
--- a/search.go
+++ b/search.go
@@ -603,9 +603,11 @@ func MemoryNeededForSearchResult(req *SearchRequest) uint64 {
 	// overhead from fields, highlighting
 	var d document.Document
 	if len(req.Fields) > 0 || req.Highlight != nil {
-		for i := 0; i < numDocMatches; i++ {
-			estimate += d.Size()
+		numDocsApplicable := req.Size
+		if numDocsApplicable > collector.PreAllocSizeSkipCap {
+			numDocsApplicable = collector.PreAllocSizeSkipCap
 		}
+		estimate += numDocsApplicable * d.Size()
 	}
 
 	return uint64(estimate)

--- a/search.go
+++ b/search.go
@@ -600,11 +600,11 @@ func MemoryNeededForSearchResult(req *SearchRequest) uint64 {
 		estimate += len(req.Facets) * fr.Size()
 	}
 
-	// highlighting, store
+	// overhead from fields, highlighting
 	var d document.Document
 	if len(req.Fields) > 0 || req.Highlight != nil {
-		for i := 0; i < (req.Size + req.From); i++ {
-			estimate += (req.Size + req.From) * d.Size()
+		for i := 0; i < numDocMatches; i++ {
+			estimate += d.Size()
 		}
 	}
 


### PR DESCRIPTION
+ Check this test ..
```
func TestEstimate(t *testing.T) {
    q := []byte(`{"from":8996,"highlight":{},"query":{"bool":false,"field":"free_parking"},"size":405}`)
    var sr *SearchRequest
    err := json.Unmarshal(q, &sr)
    if err != nil {
        t.Fatal(err)
    }

    x := MemoryNeededForSearchResult(sr)
    fmt.Println(x)
}
```

+ For the query, the MemoryNeededForSearchResult API claims that it
  needs .. 6363433784 bytes (that's over 6GB!).
+ Fixing the size calculation estimate when the query requests for
  "fields" to be returned or "highlighting", basing the number of
  results returned on the collector's PreAllocSizeSkipCap.
+ Also removing the factor "numDocMatches" to the document size in
  this scenario.