### PR TITLE
fix: delete redundant Done call

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -93,7 +93,6 @@ func (s *Scorch) persisterLoop() {
 	po, err := s.parsePersisterOptions()
 	if err != nil {
 		s.fireAsyncError(fmt.Errorf("persisterOptions json parsing err: %v", err))
-		s.asyncTasks.Done()
 		return
 	}
 


### PR DESCRIPTION
https://github.com/blevesearch/bleve/blob/ae28975038cb25655da968e3f043210749ba382b/index/scorch/persister.go#L85
`Done` already called using `defer`.