### PR TITLE
index/scorch: fix dropped errors

### DIFF
--- a/index/scorch/reader_test.go
+++ b/index/scorch/reader_test.go
@@ -289,10 +289,16 @@ func TestIndexDocIdReader(t *testing.T) {
 	}()
 
 	id, err := reader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
 	count := uint64(0)
 	for id != nil {
 		count++
 		id, err = reader.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if count != expectedCount {
 		t.Errorf("expected %d, got %d", expectedCount, count)
@@ -417,6 +423,9 @@ func TestIndexDocIdOnlyReader(t *testing.T) {
 	}()
 
 	id, err := reader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
 	count := uint64(0)
 	for id != nil {
 		count++
@@ -477,10 +486,16 @@ func TestIndexDocIdOnlyReader(t *testing.T) {
 	}()
 
 	id, err = reader3.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
 	count = uint64(0)
 	for id != nil {
 		count++
 		id, err = reader3.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if count != 1 {
 		t.Errorf("expected 1, got %d", count)

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -1299,7 +1299,10 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 	}
 
 	// now delete the document
-	err = idx.Delete("1")
+	if err := idx.Delete("1"); err != nil {
+		t.Fatal(err)
+	}
+
 	expectedCount--
 
 	// expected doc count shouldn't have changed
@@ -1541,6 +1544,9 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 			t.Errorf("expected to find document id 1")
 		}
 		tfd, err = termFieldReader.Next(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This fixes dropped test errors in `index/scorch`.