### PR TITLE
fix utf8 out of bounds

### DIFF
--- a/search/highlight/fragmenter/simple/simple.go
+++ b/search/highlight/fragmenter/simple/simple.go
@@ -123,9 +123,15 @@ OUTER:
 		// if there were no terms to highlight
 		// produce a single fragment from the beginning
 		start := 0
-		end := start + s.fragmentSize
-		if end > len(orig) {
-			end = len(orig)
+		end := start
+		used := 0
+		for end < len(orig) && used < s.fragmentSize {
+			r, size := utf8.DecodeRune(orig[end:])
+			if r == utf8.RuneError {
+				break
+			}
+			end += size
+			used++
 		}
 		rv = append(rv, &highlight.Fragment{Orig: orig, Start: start, End: end})
 	}

--- a/search/highlight/fragmenter/simple/simple_test.go
+++ b/search/highlight/fragmenter/simple/simple_test.go
@@ -285,6 +285,17 @@ func TestSimpleFragmenterWithSize(t *testing.T) {
 				},
 			},
 		},
+		{
+			orig: []byte("避免出现 rune 越界问题"),
+			fragments: []*highlight.Fragment{
+				{
+					Orig:  []byte("避免出现 rune 越界问题"),
+					Start: 0,
+					End:   13,
+				},
+			},
+			ot: nil,
+		},
 	}
 
 	fragmenter := NewFragmenter(5)


### PR DESCRIPTION
Fix simple fragmenter utf8 out of bounds when `highlight.TermLocations` is nil