### PR TITLE
fix Complete method to hand empty field name

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -265,14 +265,12 @@ func (dm *DocumentMatch) Complete(prealloc []Location) []Location {
 		}
 		prealloc = prealloc[:nlocs]
 
-		var firstField = true
 		var lastField string
 		var tlm TermLocationMap
 		var needsDedupe bool
 
 		for i, ftl := range dm.FieldTermLocations {
-			if firstField || lastField != ftl.Field {
-				firstField = false
+			if i == 0 || lastField != ftl.Field {
 				lastField = ftl.Field
 
 				if dm.Locations == nil {

--- a/search/search.go
+++ b/search/search.go
@@ -265,12 +265,14 @@ func (dm *DocumentMatch) Complete(prealloc []Location) []Location {
 		}
 		prealloc = prealloc[:nlocs]
 
+		var firstField = true
 		var lastField string
 		var tlm TermLocationMap
 		var needsDedupe bool
 
 		for i, ftl := range dm.FieldTermLocations {
-			if lastField != ftl.Field {
+			if firstField || lastField != ftl.Field {
+				firstField = false
 				lastField = ftl.Field
 
 				if dm.Locations == nil {


### PR DESCRIPTION
Previously the implementation of Complete used the zero
value of a string to detect and handle the first time
though a loop iteration.  If however, we decide to support
the empty field name, this change is required to correctly
differentiate between first iteration of the loop and a
field with empty name.

relates to #1593