### PR TITLE
Introduce online Copy for scorch indexes.

### DIFF
--- a/index.go
+++ b/index.go
@@ -16,6 +16,8 @@ package bleve
 
 import (
 	"context"
+	"io"
+
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
 
 	"github.com/blevesearch/bleve/v2/document"
@@ -305,4 +307,17 @@ type Builder interface {
 // using the specified mapping and options.
 func NewBuilder(path string, mapping mapping.IndexMapping, config map[string]interface{}) (Builder, error) {
 	return newBuilder(path, mapping, config)
+}
+
+// IndexCopyable is an index which supports an online copy operation
+// of the index. This is an experimental api and could potentially get
+// changed or deprecated in future.
+type IndexCopyable interface {
+	// CopyTo creates a fully functional copy of the index using the
+	// specified destination writer builder callback.
+	// The index implementation would trigger the given builder callback for
+	// each index file and it is the callback implementation's responsibilty
+	// to build and return the respective target writer for the file given
+	// in the callback.
+	CopyTo(func(string) io.WriteCloser) error
 }

--- a/index.go
+++ b/index.go
@@ -16,7 +16,6 @@ package bleve
 
 import (
 	"context"
-	"io"
 
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
 
@@ -310,14 +309,13 @@ func NewBuilder(path string, mapping mapping.IndexMapping, config map[string]int
 }
 
 // IndexCopyable is an index which supports an online copy operation
-// of the index. This is an experimental api and could potentially get
-// changed or deprecated in future.
+// of the index.
 type IndexCopyable interface {
-	// CopyTo creates a fully functional copy of the index using the
-	// specified destination writer builder callback.
-	// The index implementation would trigger the given builder callback for
-	// each index file and it is the callback implementation's responsibilty
-	// to build and return the respective target writer for the file given
-	// in the callback.
-	CopyTo(func(string) io.WriteCloser) error
+	// CopyTo creates a fully functional copy of the index at the
+	// specified destination directory implementation.
+	CopyTo(d index.Directory) error
 }
+
+// FileSystemDirectory is the default implementation for the
+// index.Directory interface.
+type FileSystemDirectory string

--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -304,7 +304,7 @@ func (o *Builder) Close() error {
 	}
 
 	// fill the root bolt with this fake index snapshot
-	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin)
+	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil)
 	if err != nil {
 		_ = tx.Rollback()
 		_ = rootBolt.Close()

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"math"
@@ -427,8 +428,31 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot) (
 	return true, nil
 }
 
+func copyFile(src string, dest io.WriteCloser) (int64, error) {
+	if dest == nil {
+		return 0, fmt.Errorf("invalid writer for file: %s", src)
+	}
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+	defer dest.Close()
+	return io.Copy(dest, source)
+}
+
 func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
-	segPlugin SegmentPlugin) ([]string, map[uint64]string, error) {
+	segPlugin SegmentPlugin, getWriter func(string) io.WriteCloser) (
+	[]string, map[uint64]string, error) {
 	snapshotsBucket, err := tx.CreateBucketIfNotExists(boltSnapshotsBucket)
 	if err != nil {
 		return nil, nil, err
@@ -481,7 +505,13 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 		switch seg := segmentSnapshot.segment.(type) {
 		case segment.PersistedSegment:
 			segPath := seg.Path()
-			filename := strings.TrimPrefix(segPath, path+string(os.PathSeparator))
+			if getWriter != nil {
+				_, err := copyFile(segPath, getWriter(segPath))
+				if err != nil {
+					return nil, nil, fmt.Errorf("segment: %s copy err: %v", segPath, err)
+				}
+			}
+			filename := filepath.Base(segPath)
 			err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
 			if err != nil {
 				return nil, nil, err
@@ -489,9 +519,15 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 			filenames = append(filenames, filename)
 		case segment.UnpersistedSegment:
 			// need to persist this to disk
+			var err error
 			filename := zapFileName(segmentSnapshot.id)
 			path := path + string(os.PathSeparator) + filename
-			err = seg.Persist(path)
+			if getWriter != nil {
+				err = seg.PersistToWriter(getWriter(path))
+			} else {
+				err = seg.Persist(path)
+			}
+
 			if err != nil {
 				return nil, nil, fmt.Errorf("error persisting segment: %v", err)
 			}
@@ -534,7 +570,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 		}
 	}()
 
-	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin)
+	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, nil)
 	if err != nil {
 		return err
 	}

--- a/index_impl.go
+++ b/index_impl.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -909,4 +910,36 @@ func (m *searchHitSorter) Swap(i, j int) { m.hits[i], m.hits[j] = m.hits[j], m.h
 func (m *searchHitSorter) Less(i, j int) bool {
 	c := m.sort.Compare(m.cachedScoring, m.cachedDesc, m.hits[i], m.hits[j])
 	return c < 0
+}
+
+func (i *indexImpl) CopyTo(getWriter func(string) io.WriteCloser) (err error) {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+
+	if !i.open {
+		return ErrorIndexClosed
+	}
+
+	indexReader, err := i.i.Reader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := indexReader.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+
+	irc, ok := indexReader.(IndexCopyable)
+	if !ok {
+		return fmt.Errorf("index implementation does not support copy")
+	}
+
+	err = irc.CopyTo(getWriter)
+	if err != nil {
+		return fmt.Errorf("error copying index metadata: %v", err)
+	}
+
+	// copy the metadata
+	return i.meta.SaveToWriter(getWriter)
 }

--- a/index_meta.go
+++ b/index_meta.go
@@ -17,12 +17,12 @@ package bleve
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
+	index "github.com/blevesearch/bleve_index_api"
 )
 
 const metaFilename = "index_meta.json"
@@ -94,15 +94,16 @@ func (i *indexMeta) Save(path string) (err error) {
 	return nil
 }
 
-func (i *indexMeta) SaveToWriter(getWriter func(string) io.WriteCloser) (err error) {
+func (i *indexMeta) CopyTo(d index.Directory) (err error) {
 	metaBytes, err := json.Marshal(i)
 	if err != nil {
 		return err
 	}
 
-	w := getWriter(metaFilename)
-	if w == nil {
-		return fmt.Errorf("invalid writer for file: %s", metaFilename)
+	w, err := d.GetWriter(metaFilename)
+	if w == nil || err != nil {
+		return fmt.Errorf("invalid writer for file: %s, err: %v",
+			metaFilename, err)
 	}
 	defer w.Close()
 

--- a/index_meta.go
+++ b/index_meta.go
@@ -16,6 +16,8 @@ package bleve
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -90,6 +92,22 @@ func (i *indexMeta) Save(path string) (err error) {
 		return err
 	}
 	return nil
+}
+
+func (i *indexMeta) SaveToWriter(getWriter func(string) io.WriteCloser) (err error) {
+	metaBytes, err := json.Marshal(i)
+	if err != nil {
+		return err
+	}
+
+	w := getWriter(metaFilename)
+	if w == nil {
+		return fmt.Errorf("invalid writer for file: %s", metaFilename)
+	}
+	defer w.Close()
+
+	_, err = w.Write(metaBytes)
+	return err
 }
 
 func indexMetaPath(path string) string {

--- a/index_test.go
+++ b/index_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"math"
@@ -2259,5 +2260,248 @@ func TestIndexMappingDocValuesDynamic(t *testing.T) {
 	// Expect DocValuesDynamic to remain false!
 	if im.DocValuesDynamic {
 		t.Fatalf("Expected DocValuesDynamic to remain false after the index mapping edit")
+	}
+}
+
+func TestCopyIndex(t *testing.T) {
+	tmpIndexPath := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, tmpIndexPath)
+
+	idx, err := New(tmpIndexPath, NewIndexMapping())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	doca := map[string]interface{}{
+		"name": "tester",
+		"desc": "gophercon india testing",
+	}
+	err = idx.Index("a", doca)
+	if err != nil {
+		t.Error(err)
+	}
+
+	docy := map[string]interface{}{
+		"name": "jasper",
+		"desc": "clojure",
+	}
+	err = idx.Index("y", docy)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = idx.Delete("y")
+	if err != nil {
+		t.Error(err)
+	}
+
+	docx := map[string]interface{}{
+		"name": "rose",
+		"desc": "xoogler",
+	}
+	err = idx.Index("x", docx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = idx.SetInternal([]byte("status"), []byte("pending"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	docb := map[string]interface{}{
+		"name": "sree",
+		"desc": "cbft janitor",
+	}
+	batch := idx.NewBatch()
+	err = batch.Index("b", docb)
+	if err != nil {
+		t.Error(err)
+	}
+	batch.Delete("x")
+	batch.SetInternal([]byte("batchi"), []byte("batchv"))
+	batch.DeleteInternal([]byte("status"))
+	err = idx.Batch(batch)
+	if err != nil {
+		t.Error(err)
+	}
+	val, err := idx.GetInternal([]byte("batchi"))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(val) != "batchv" {
+		t.Errorf("expected 'batchv', got '%s'", val)
+	}
+	val, err = idx.GetInternal([]byte("status"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got '%s'", val)
+	}
+
+	err = idx.SetInternal([]byte("seqno"), []byte("7"))
+	if err != nil {
+		t.Error(err)
+	}
+	err = idx.SetInternal([]byte("status"), []byte("ready"))
+	if err != nil {
+		t.Error(err)
+	}
+	err = idx.DeleteInternal([]byte("status"))
+	if err != nil {
+		t.Error(err)
+	}
+	val, err = idx.GetInternal([]byte("status"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got '%s'", val)
+	}
+
+	val, err = idx.GetInternal([]byte("seqno"))
+	if err != nil {
+		t.Error(err)
+	}
+	if string(val) != "7" {
+		t.Errorf("expected '7', got '%s'", val)
+	}
+
+	count, err := idx.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("expected doc count 2, got %d", count)
+	}
+
+	doc, err := idx.Document("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundNameField := false
+	doc.VisitFields(func(field index.Field) {
+		if field.Name() == "name" && string(field.Value()) == "tester" {
+			foundNameField = true
+		}
+	})
+	if !foundNameField {
+		t.Errorf("expected to find field named 'name' with value 'tester'")
+	}
+
+	fields, err := idx.Fields()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFields := map[string]bool{
+		"_all": false,
+		"name": false,
+		"desc": false,
+	}
+	if len(fields) < len(expectedFields) {
+		t.Fatalf("expected %d fields got %d", len(expectedFields), len(fields))
+	}
+	for _, f := range fields {
+		expectedFields[f] = true
+	}
+	for ef, efp := range expectedFields {
+		if !efp {
+			t.Errorf("field %s is missing", ef)
+		}
+	}
+
+	// now create a copy of the index, and repeat assertions on it
+	copyableIndex, ok := idx.(IndexCopyable)
+	if !ok {
+		t.Fatal("index doesn't support copy")
+	}
+	backupIndexPath := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, backupIndexPath)
+
+	getWriter := func(filePath string) io.WriteCloser {
+		var path string
+		if strings.Contains(filePath, "store") ||
+			strings.Contains(filePath, "root.bolt") {
+			path = filepath.Join(backupIndexPath, "store",
+				filepath.Base(filePath))
+			_ = os.MkdirAll(filepath.Join(backupIndexPath, "store"), 0700)
+		} else {
+			path = filepath.Join(backupIndexPath,
+				filepath.Base(filePath))
+		}
+		f, err := os.OpenFile(path,
+			os.O_RDWR|os.O_CREATE, 0600)
+		if err != nil {
+			return nil
+		}
+		return f
+	}
+
+	err = copyableIndex.CopyTo(getWriter)
+	if err != nil {
+		t.Fatalf("error backing up index: %v", err)
+	}
+
+	// open the copied  index
+	idxBackup, err := Open(backupIndexPath)
+	if err != nil {
+		t.Fatalf("unable to open backup index")
+	}
+	defer func() {
+		err := idxBackup.Close()
+		if err != nil {
+			t.Fatalf("error closing backup index: %v", err)
+		}
+	}()
+
+	// assertions on copied index
+	backupCount, err := idxBackup.DocCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backupCount != 2 {
+		t.Errorf("expected doc count 2, got %d", backupCount)
+	}
+
+	backupDoc, err := idxBackup.Document("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupFoundNameField := false
+	backupDoc.VisitFields(func(field index.Field) {
+		if field.Name() == "name" && string(field.Value()) == "tester" {
+			backupFoundNameField = true
+		}
+	})
+	if !backupFoundNameField {
+		t.Errorf("expected backup to find field named 'name' with value 'tester'")
+	}
+
+	backupFields, err := idx.Fields()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupExpectedFields := map[string]bool{
+		"_all": false,
+		"name": false,
+		"desc": false,
+	}
+	if len(backupFields) < len(backupExpectedFields) {
+		t.Fatalf("expected %d fields got %d", len(backupExpectedFields), len(backupFields))
+	}
+	for _, f := range backupFields {
+		backupExpectedFields[f] = true
+	}
+	for ef, efp := range backupExpectedFields {
+		if !efp {
+			t.Errorf("backup field %s is missing", ef)
+		}
 	}
 }


### PR DESCRIPTION
Approach used is to acquire an index snapshot
and reuse existing code for persisting
snapshot segments and recording snapshot
information into the root bolt.