### PR TITLE
MB-47476: JSON marshalers cannot work on `0xff` (HighTerm)

### DIFF
--- a/search/search_test.go
+++ b/search/search_test.go
@@ -15,6 +15,7 @@
 package search
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -72,5 +73,22 @@ func TestLocationsDedupe(t *testing.T) {
 		if !reflect.DeepEqual(res, test.expect) {
 			t.Errorf("testi: %d, test: %+v, res: %+v", testi, test, res)
 		}
+	}
+}
+
+func TestMarshallingHighTerm(t *testing.T) {
+	highTermBytes, err := json.Marshal(HighTerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var unmarshalledHighTerm string
+	err = json.Unmarshal(highTermBytes, &unmarshalledHighTerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshalledHighTerm != HighTerm {
+		t.Fatalf("unexpected %x != %x", unmarshalledHighTerm, HighTerm)
 	}
 }

--- a/search/sort.go
+++ b/search/sort.go
@@ -27,7 +27,7 @@ import (
 	"github.com/blevesearch/bleve/v2/numeric"
 )
 
-var HighTerm = string(utf8.MaxRune)
+var HighTerm = strings.Repeat(string(utf8.MaxRune), 3)
 var LowTerm = string([]byte{0x00})
 
 type SearchSort interface {

--- a/search/sort.go
+++ b/search/sort.go
@@ -21,12 +21,13 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/numeric"
 )
 
-var HighTerm = strings.Repeat(string([]byte{0xff}), 10)
+var HighTerm = string(utf8.MaxRune)
 var LowTerm = string([]byte{0x00})
 
 type SearchSort interface {


### PR DESCRIPTION
Using unicode/utf8's MaxRune as the `HighTerm` for sort while
missing values.