### PR TITLE
Introduce `NewKeywordFieldMapping()`.

### DIFF
--- a/mapping.go
+++ b/mapping.go
@@ -45,6 +45,11 @@ func NewTextFieldMapping() *mapping.FieldMapping {
 	return mapping.NewTextFieldMapping()
 }
 
+// NewKeywordFieldMapping returns a default field mapping for text
+func NewKeywordFieldMapping() *mapping.FieldMapping {
+	return mapping.NewKeywordFieldMapping()
+}
+
 // NewNumericFieldMapping returns a default field mapping for numbers
 func NewNumericFieldMapping() *mapping.FieldMapping {
 	return mapping.NewNumericFieldMapping()

--- a/mapping.go
+++ b/mapping.go
@@ -45,12 +45,8 @@ func NewTextFieldMapping() *mapping.FieldMapping {
 	return mapping.NewTextFieldMapping()
 }
 
-// NewKeywordFieldMapping returns a default field mapping for structured
-// content which are typically used for filtering, sorting, aggregations.
-// Keyword fields are only searchable by their exact value.
-// For example, IDs, email addresses, hostnames, tags, etc.
-// Avoid using keyword fields for full-text search (use the `text` field type
-// instead).
+// NewKeywordFieldMapping returns a field mapping for text using the keyword
+// analyzer, which essentially doesn't apply any specific text analysis.
 func NewKeywordFieldMapping() *mapping.FieldMapping {
 	return mapping.NewKeywordFieldMapping()
 }

--- a/mapping.go
+++ b/mapping.go
@@ -45,7 +45,12 @@ func NewTextFieldMapping() *mapping.FieldMapping {
 	return mapping.NewTextFieldMapping()
 }
 
-// NewKeywordFieldMapping returns a default field mapping for text
+// NewKeywordFieldMapping returns a default field mapping for structured
+// content which are typically used for filtering, sorting, aggregations.
+// Keyword fields are only searchable by their exact value.
+// For example, IDs, email addresses, hostnames, tags, etc.
+// Avoid using keyword fields for full-text search (use the `text` field type
+// instead).
 func NewKeywordFieldMapping() *mapping.FieldMapping {
 	return mapping.NewKeywordFieldMapping()
 }

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -76,7 +76,7 @@ func (dm *DocumentMapping) Validate(cache *registry.Cache) error {
 			}
 		}
 		switch field.Type {
-		case "text", "keyword", "datetime", "number", "boolean", "geopoint":
+		case "text", "datetime", "number", "boolean", "geopoint":
 		default:
 			return fmt.Errorf("unknown field type: '%s'", field.Type)
 		}
@@ -528,7 +528,7 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 			switch property := property.(type) {
 			case encoding.TextMarshaler:
 				// ONLY process TextMarshaler if there is an explicit mapping
-				// AND all of the fiels are of type text
+				// AND all of the fields are of type text
 				// OTHERWISE process field without TextMarshaler
 				if subDocMapping != nil {
 					allFieldsText := true

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -76,7 +76,7 @@ func (dm *DocumentMapping) Validate(cache *registry.Cache) error {
 			}
 		}
 		switch field.Type {
-		case "text", "datetime", "number", "boolean", "geopoint":
+		case "text", "keyword", "datetime", "number", "boolean", "geopoint":
 		default:
 			return fmt.Errorf("unknown field type: '%s'", field.Type)
 		}

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -90,25 +90,17 @@ func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	return rv
 }
 
-// NewKeyworFieldMapping returns a default field mapping for []byte.
+// NewKeyworFieldMapping returns a default field mapping for text with analyzer "keyword".
 func NewKeywordFieldMapping() *FieldMapping {
 	return &FieldMapping{
-		Type:               "keyword",
+		Type:               "text",
+		Analyzer:           keyword.Name,
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: true,
 		IncludeInAll:       true,
 		DocValues:          true,
 	}
-}
-
-func newKeywordFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
-	rv := NewTextFieldMapping()
-	rv.Analyzer = keyword.Name
-	rv.Store = im.StoreDynamic
-	rv.Index = im.IndexDynamic
-	rv.DocValues = im.DocValuesDynamic
-	return rv
 }
 
 // NewNumericFieldMapping returns a default field mapping for numbers

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
 	index "github.com/blevesearch/bleve_index_api"
 
 	"github.com/blevesearch/bleve/v2/analysis"
@@ -83,6 +84,27 @@ func NewTextFieldMapping() *FieldMapping {
 
 func newTextFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
 	rv := NewTextFieldMapping()
+	rv.Store = im.StoreDynamic
+	rv.Index = im.IndexDynamic
+	rv.DocValues = im.DocValuesDynamic
+	return rv
+}
+
+// NewKeyworFieldMapping returns a default field mapping for []byte.
+func NewKeywordFieldMapping() *FieldMapping {
+	return &FieldMapping{
+		Type:               "keyword",
+		Store:              true,
+		Index:              true,
+		IncludeTermVectors: true,
+		IncludeInAll:       true,
+		DocValues:          true,
+	}
+}
+
+func newKeywordFieldMappingDynamic(im *IndexMappingImpl) *FieldMapping {
+	rv := NewTextFieldMapping()
+	rv.Analyzer = keyword.Name
 	rv.Store = im.StoreDynamic
 	rv.Index = im.IndexDynamic
 	rv.DocValues = im.DocValuesDynamic


### PR DESCRIPTION
A keyword field mapping is a text field with `keyword` analyzer. It will be easier for users who are migrating from ElasticSearch.

closes #1633 

Dear @abhinavdangeti, could you help review and give your opinions?

p.s. i signed the CLA.