### PR TITLE
Use of HTML character filter breaks highlighting

### DIFF
--- a/analysis/char/html/html.go
+++ b/analysis/char/html/html.go
@@ -15,10 +15,10 @@
 package html
 
 import (
+	"bytes"
 	"regexp"
 
 	"github.com/blevesearch/bleve/v2/analysis"
-	regexpCharFilter "github.com/blevesearch/bleve/v2/analysis/char/regexp"
 	"github.com/blevesearch/bleve/v2/registry"
 )
 
@@ -26,9 +26,27 @@ const Name = "html"
 
 var htmlCharFilterRegexp = regexp.MustCompile(`</?[!\w]+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)/?>`)
 
+type CharFilter struct {
+	r           *regexp.Regexp
+	replacement []byte
+}
+
+func New() *CharFilter {
+	return &CharFilter{
+		r:           htmlCharFilterRegexp,
+		replacement: []byte(" "),
+	}
+}
+
+func (s *CharFilter) Filter(input []byte) []byte {
+	return s.r.ReplaceAllFunc(
+		input, func(in []byte) []byte {
+			return bytes.Repeat(s.replacement, len(in))
+		})
+}
+
 func CharFilterConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.CharFilter, error) {
-	replaceBytes := []byte(" ")
-	return regexpCharFilter.New(htmlCharFilterRegexp, replaceBytes), nil
+	return New(), nil
 }
 
 func init() {


### PR DESCRIPTION
+ I've tracked this down as a regression that was introduced
   when I changed the regexp character filter's replacement
   behavior here - https://github.com/blevesearch/bleve/pull/1351
+ The above change is still necessary for highlighting to work
    correctly when regexp character filter is used and for
    replacements that involve '$' variables.

+ The HTML character filter which uses the regexp character
    filter will need to replace every character of the matched
    sequence with whitespace so that the number of whitespaces
    equals the length of the HTML tag.
+ Tracking ticket: https://issues.couchbase.com/browse/MB-50002