### PR TITLE
Updating the s2/geo version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/bits-and-blooms/bitset v1.2.0
 	github.com/blevesearch/bleve_index_api v1.0.2-0.20220328092731-fdf526452081
-	github.com/blevesearch/geo v0.1.9
+	github.com/blevesearch/geo v0.1.10
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/blevesearch/bleve_index_api v1.0.2-0.20220328092731-fdf526452081 h1:f
 github.com/blevesearch/bleve_index_api v1.0.2-0.20220328092731-fdf526452081/go.mod h1:fiwKS0xLEm+gBRgv5mumf0dhgFr2mDgZah1pqv1c1M4=
 github.com/blevesearch/geo v0.1.9 h1:3PkWcg/Os+AVezVKptfHVv6HbIL0qZ9hodQTnoBnLn8=
 github.com/blevesearch/geo v0.1.9/go.mod h1:XqONL2MSA0A3hDWq35mX+dkXbJwq+LNdSgDHvqOhQZM=
+github.com/blevesearch/geo v0.1.10 h1:KgUEYKPPz8uwzIIpUpotWiBAVCqI+xAM8qWad0UKIf0=
+github.com/blevesearch/geo v0.1.10/go.mod h1:XqONL2MSA0A3hDWq35mX+dkXbJwq+LNdSgDHvqOhQZM=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=


### PR DESCRIPTION
This version bump primarily includes a porting fix
in s2/loop.go in the original golang port version.

This change also includes a unit test that covers
the case.