### PR TITLE
Added intersects unit tests and fixed existing tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/bits-and-blooms/bitset v1.2.0
 	github.com/blevesearch/bleve_index_api v1.0.3
-	github.com/blevesearch/geo v0.1.13
+	github.com/blevesearch/geo v0.1.14
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjL
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/blevesearch/bleve_index_api v1.0.3 h1:DDSWaPXOZZJ2BB73ZTWjKxydAugjwywcqU+91AAqcAg=
 github.com/blevesearch/bleve_index_api v1.0.3/go.mod h1:fiwKS0xLEm+gBRgv5mumf0dhgFr2mDgZah1pqv1c1M4=
-github.com/blevesearch/geo v0.1.13 h1:RsY1vfFm81iv1g+uoCQtsOFvKAhZnpOdTOK8JRA6pqw=
-github.com/blevesearch/geo v0.1.13/go.mod h1:cRIvqCdk3cgMhGeHNNe6yPzb+w56otxbfo1FBJfR2Pc=
+github.com/blevesearch/geo v0.1.14 h1:TTDpJN6l9ck/cUYbXSn4aCElNls0Whe44rcQKsB7EfU=
+github.com/blevesearch/geo v0.1.14/go.mod h1:cRIvqCdk3cgMhGeHNNe6yPzb+w56otxbfo1FBJfR2Pc=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=

--- a/search/searcher/geoshape_within_test.go
+++ b/search/searcher/geoshape_within_test.go
@@ -15,6 +15,7 @@
 package searcher
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -23,19 +24,24 @@ import (
 )
 
 var (
-	leftRect             [][][]float64   = [][][]float64{{{-1, 0}, {0, 0}, {0, 1}, {-1, 1}, {-1, 0}}}
-	leftRectPoint        []float64       = []float64{-0.5, 0.5}
-	rightRect            [][][]float64   = [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}}
-	rightRectPoint       []float64       = []float64{0.5, 0.5}
-	overLappingRightRect [][][][]float64 = [][][][]float64{{{{-1, 0}, {1, 0}, {1, 1}, {-0.1, 1}, {-1, 0}}}}
-	middleLine           [][]float64     = [][]float64{{-0.5, 0.5}, {0.5, 0.5}}
+	leftRect       [][][]float64 = [][][]float64{{{-1, 0}, {0, 0}, {0, 1}, {-1, 1}, {-1, 0}}}
+	leftRectPoint  []float64     = []float64{-0.5, 0.5}
+	rightRect      [][][]float64 = [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}}
+	rightRectPoint []float64     = []float64{0.5, 0.5}
 )
 
 func testCaseSetupGeometryCollection(t *testing.T, docShapeName string, types []string, docShapeVertices [][][][][]float64,
 	i index.Index) (index.IndexReader, func() error, error) {
 	doc := document.NewDocument(docShapeName)
-	doc.AddField(document.NewGeometryCollectionFieldWithIndexingOptions("geometry",
-		[]uint64{}, docShapeVertices, types, document.DefaultGeoShapeIndexingOptions))
+	gcField := document.NewGeometryCollectionFieldWithIndexingOptions("geometry",
+		[]uint64{}, docShapeVertices, types, document.DefaultGeoShapeIndexingOptions)
+	if gcField == nil {
+		return nil, nil, fmt.Errorf("the GC field is nil")
+	}
+	doc.AddField(gcField)
+	if doc == nil {
+		return nil, nil, fmt.Errorf("the doc is nil")
+	}
 	err := i.Update(doc)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -675,7 +681,6 @@ func TestLinestringGeometryCollectionWithin(t *testing.T) {
 			Types:            []string{"point"},
 			QueryType:        "within",
 		},
-		{},
 	}
 
 	i := setupIndex(t)
@@ -1210,14 +1215,14 @@ func TestGeometryCollectionWithin(t *testing.T) {
 		DocShapeTypes    []string
 	}{
 		{
-			QueryShape:       nil,
-			DocShapeVertices: nil,
+			QueryShape:       [][][][][]float64{{{{}}}},
+			DocShapeVertices: [][][][][]float64{{{{}}}},
 			DocShapeName:     "geometrycollection1",
 			Desc:             "empty geometry collections",
 			Expected:         nil,
 			QueryType:        "within",
-			QueryShapeTypes:  nil,
-			DocShapeTypes:    nil,
+			QueryShapeTypes:  []string{""},
+			DocShapeTypes:    []string{""},
 		},
 		{
 			QueryShape:       [][][][][]float64{{{{{1, 2}, {2, 3}}}}},
@@ -1281,11 +1286,11 @@ func TestGeometryCollectionPointWithin(t *testing.T) {
 	}{
 		{
 			QueryShape:       []float64{1.0, 2.0},
-			DocShapeVertices: nil,
+			DocShapeVertices: [][][][][]float64{{{{}}}},
 			DocShapeName:     "geometrycollection1",
 			Desc:             "empty geometry collection not within a point",
 			Expected:         nil,
-			Types:            nil,
+			Types:            []string{""},
 			QueryType:        "within",
 		},
 	}


### PR DESCRIPTION
This PR extends the unit tests for 'intersects', particularly polygon-linestring tests. 
It also fixes some issues with geometry collection unit tests across relations.