### PR TITLE
Account for bytesRead in the event of MultiSearch

### DIFF
--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -500,6 +500,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Se
 			} else {
 				// merge with previous
 				sr.Merge(asr.Result)
+				sr.BytesRead += asr.Result.BytesRead
 			}
 		} else {
 			indexErrors[asr.Name] = asr.Err


### PR DESCRIPTION
MultiSearch runs when the index is partitioned, and the results of individual search requests need to
be merged before sending the response to the caller.