### PR TITLE
Including the IO stats as part of metadata

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -543,6 +543,12 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 		}
 	}
 
+	val := make([]byte, 8)
+	bytesWritten := atomic.LoadUint64(&snapshot.parent.stats.TotBytesWrittenAtIndexTime)
+	binary.LittleEndian.PutUint64(val, bytesWritten)
+
+	internalBucket.Put(TotBytesWrittenKey, val)
+
 	var filenames []string
 	newSegmentPaths := make(map[uint64]string)
 
@@ -697,6 +703,7 @@ var boltMetaDataKey = []byte{'m'}
 var boltMetaDataSegmentTypeKey = []byte("type")
 var boltMetaDataSegmentVersionKey = []byte("version")
 var boltMetaDataTimeStamp = []byte("timeStamp")
+var TotBytesWrittenKey = []byte("TotBytesWritten")
 
 func (s *Scorch) loadFromBolt() error {
 	return s.rootBolt.View(func(tx *bolt.Tx) error {

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -543,11 +543,12 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 		}
 	}
 
-	val := make([]byte, 8)
-	bytesWritten := atomic.LoadUint64(&snapshot.parent.stats.TotBytesWrittenAtIndexTime)
-	binary.LittleEndian.PutUint64(val, bytesWritten)
-
-	internalBucket.Put(TotBytesWrittenKey, val)
+	if snapshot.parent != nil {
+		val := make([]byte, 8)
+		bytesWritten := atomic.LoadUint64(&snapshot.parent.stats.TotBytesWrittenAtIndexTime)
+		binary.LittleEndian.PutUint64(val, bytesWritten)
+		internalBucket.Put(TotBytesWrittenKey, val)
+	}
 
 	var filenames []string
 	newSegmentPaths := make(map[uint64]string)


### PR DESCRIPTION
This change aims to make the IO Stats part of internal keys such that on rollback to a checkpoint, the IO stats can be retrieved using GetInternal() API after the rollback.