### PR TITLE
perf: Optimize `sync.Pool` usage by storing pointers instead of non-pointer values

### DIFF
--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -145,7 +145,7 @@ func GetRowBuffer() []byte {
 }
 
 func PutRowBuffer(buf []byte) {
-	rowBufferPool.Put(buf)
+	rowBufferPool.Put(&buf)
 }
 
 func (udc *UpsideDownCouch) batchRows(writer store.KVWriter, addRowsAll [][]UpsideDownCouchRow, updateRowsAll [][]UpsideDownCouchRow, deleteRowsAll [][]UpsideDownCouchRow) (err error) {


### PR DESCRIPTION
## Description

By storing the pointer to the slice in the `sync.Pool`, the function is able to reuse the same memory without allocating additional memory.
