### PR TITLE
Display 0 bytesRead in search responses

### DIFF
--- a/search.go
+++ b/search.go
@@ -490,7 +490,7 @@ type SearchResult struct {
 	Request   *SearchRequest                 `json:"request"`
 	Hits      search.DocumentMatchCollection `json:"hits"`
 	Total     uint64                         `json:"total_hits"`
-	BytesRead uint64                         `json:"bytesRead,omitempty"`
+	BytesRead uint64                         `json:"bytesRead"`
 	MaxScore  float64                        `json:"max_score"`
 	Took      time.Duration                  `json:"took"`
 	Facets    search.FacetResults            `json:"facets"`


### PR DESCRIPTION
Currently, when firing multiple queries with "score" : "none", the first query response displays the non-zero bytesRead as part of the JSON response. Subsequent queries do not display it as part of the response since the bytesRead is 0.
This PR fixes it such that even if the bytesRead is 0, it displays it as part of the response.