### PR TITLE
perf: Use pointer-based `sync.Pool` for optimized memory management

### DIFF
--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -124,16 +124,16 @@ func (i *IndexReader) documentVisitFieldTerms(id index.IndexInternalID, fields [
 	}
 
 	keyBuf := GetRowBuffer()
-	if tempRow.KeySize() > len(keyBuf) {
-		keyBuf = make([]byte, 2*tempRow.KeySize())
+	if tempRow.KeySize() > len(keyBuf.buf) {
+		keyBuf.buf = make([]byte, 2*tempRow.KeySize())
 	}
 	defer PutRowBuffer(keyBuf)
-	keySize, err := tempRow.KeyTo(keyBuf)
+	keySize, err := tempRow.KeyTo(keyBuf.buf)
 	if err != nil {
 		return err
 	}
 
-	value, err := i.kvreader.Get(keyBuf[:keySize])
+	value, err := i.kvreader.Get(keyBuf.buf[:keySize])
 	if err != nil {
 		return err
 	}

--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -134,23 +134,23 @@ func (udc *UpsideDownCouch) loadSchema(kvreader store.KVReader) (err error) {
 	return
 }
 
-type RowBuffer struct {
+type rowBuffer struct {
     buf []byte
 }
 
 var rowBufferPool sync.Pool
 
-func GetRowBuffer() *RowBuffer {
-    	if rb, ok := rowBufferPool.Get().(*RowBuffer); ok {
-        	return rb
-    	} else {
-        	buf := make([]byte, RowBufferSize)
-        	return &RowBuffer{buf: buf}
-    	}
+func GetRowBuffer() *rowBuffer {
+    if rb, ok := rowBufferPool.Get().(*rowBuffer); ok {
+        return rb
+    } else {
+        buf := make([]byte, RowBufferSize)
+        return &rowBuffer{buf: buf}
+    }
 }
 
-func PutRowBuffer(rb *RowBuffer) {
-	rowBufferPool.Put(rb)
+func PutRowBuffer(rb *rowBuffer) {
+    rowBufferPool.Put(rb)
 }
 
 func (udc *UpsideDownCouch) batchRows(writer store.KVWriter, addRowsAll [][]UpsideDownCouchRow, updateRowsAll [][]UpsideDownCouchRow, deleteRowsAll [][]UpsideDownCouchRow) (err error) {

--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -134,18 +134,23 @@ func (udc *UpsideDownCouch) loadSchema(kvreader store.KVReader) (err error) {
 	return
 }
 
-var rowBufferPool sync.Pool
-
-func GetRowBuffer() []byte {
-	if rb, ok := rowBufferPool.Get().([]byte); ok {
-		return rb
-	} else {
-		return make([]byte, RowBufferSize)
-	}
+type RowBuffer struct {
+    buf *[]byte
 }
 
-func PutRowBuffer(buf []byte) {
-	rowBufferPool.Put(buf)
+var rowBufferPool sync.Pool
+
+func GetRowBuffer() *RowBuffer {
+    	if rb, ok := rowBufferPool.Get().(*RowBuffer); ok {
+        	return rb
+    	} else {
+        	buf := make([]byte, RowBufferSize)
+        	return &RowBuffer{buf: &buf}
+    	}
+}
+
+func PutRowBuffer(rb *RowBuffer) {
+	rowBufferPool.Put(rb)
 }
 
 func (udc *UpsideDownCouch) batchRows(writer store.KVWriter, addRowsAll [][]UpsideDownCouchRow, updateRowsAll [][]UpsideDownCouchRow, deleteRowsAll [][]UpsideDownCouchRow) (err error) {


### PR DESCRIPTION
## Description

This pull request replaces the existing `sync.Pool` implementation with a more optimized version that uses pointers to objects. Specifically, the `GetRowBuffer()` function now returns a pointer to a `RowBuffer` object that contains a byte slice, instead of returning the byte slice directly. The `PutRowBuffer()` function now takes a pointer to a `RowBuffer` object instead of a byte slice.

Storing pointers instead of values can help reduce memory usage and avoid unnecessary copying of buffer data. Additionally, using pointers can reduce the overhead of creating and copying data, which can improve performance.
