### PR TITLE
MB-55637: Adapting signature of scorch's async onError callback

### DIFF
--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -18,7 +18,7 @@ import "time"
 
 // RegistryAsyncErrorCallbacks should be treated as read-only after
 // process init()'ialization.
-var RegistryAsyncErrorCallbacks = map[string]func(error){}
+var RegistryAsyncErrorCallbacks = map[string]func(error, string){}
 
 // RegistryEventCallbacks should be treated as read-only after
 // process init()'ialization.

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -70,7 +70,7 @@ type Scorch struct {
 	asyncTasks               sync.WaitGroup
 
 	onEvent      func(event Event)
-	onAsyncError func(err error)
+	onAsyncError func(err error, path string)
 
 	forceMergeRequestCh chan *mergerCtrl
 
@@ -185,7 +185,7 @@ func (s *Scorch) fireEvent(kind EventKind, dur time.Duration) {
 
 func (s *Scorch) fireAsyncError(err error) {
 	if s.onAsyncError != nil {
-		s.onAsyncError(err)
+		s.onAsyncError(err, s.path)
 	}
 	atomic.AddUint64(&s.stats.TotOnErrors, 1)
 }


### PR DESCRIPTION
+ This change in signature is necessary to introduce some more context in the user application to associate the scorch index with the error.