### PR TITLE
Inheriting the correct analyzer when default mapping is in use

### DIFF
--- a/mapping/index.go
+++ b/mapping/index.go
@@ -364,6 +364,7 @@ func (im *IndexMappingImpl) AnalyzerNameForPath(path string) string {
 			return analyzerName
 		}
 	}
+
 	// now try the default mapping
 	pathMapping := im.DefaultMapping.documentMappingForPath(path)
 	if pathMapping != nil {
@@ -377,7 +378,16 @@ func (im *IndexMappingImpl) AnalyzerNameForPath(path string) string {
 	// next we will try default analyzers for the path
 	pathDecoded := decodePath(path)
 	for _, docMapping := range im.TypeMapping {
-		rv := docMapping.defaultAnalyzerName(pathDecoded)
+		if docMapping.Enabled {
+			rv := docMapping.defaultAnalyzerName(pathDecoded)
+			if rv != "" {
+				return rv
+			}
+		}
+	}
+	// now the default analyzer for the default mapping
+	if im.DefaultMapping.Enabled {
+		rv := im.DefaultMapping.defaultAnalyzerName(pathDecoded)
 		if rv != "" {
 			return rv
 		}

--- a/search_test.go
+++ b/search_test.go
@@ -2113,3 +2113,44 @@ func TestGeoShapePolygonContainsPoint(t *testing.T) {
 		}
 	}
 }
+
+func TestAnalyzerInheritanceForDefaultDynamicMapping(t *testing.T) {
+	tmpIndexPath := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, tmpIndexPath)
+
+	imap := mapping.NewIndexMapping()
+	imap.DefaultMapping.DefaultAnalyzer = keyword.Name
+
+	idx, err := New(tmpIndexPath, imap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = idx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	doc := map[string]interface{}{
+		"fieldX": "AbCdEf",
+	}
+
+	if err = idx.Index("doc", doc); err != nil {
+		t.Fatal(err)
+	}
+
+	// Match query to apply keyword analyzer to fieldX.
+	mq := NewMatchQuery("AbCdEf")
+	mq.SetField("fieldX")
+
+	sr := NewSearchRequest(mq)
+	results, err := idx.Search(sr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results.Hits) != 1 {
+		t.Fatalf("expected 1 hit, got %d", len(results.Hits))
+	}
+}


### PR DESCRIPTION
Here's an unhandled situation:
- Say one defines a default dynamic mapping with a non-standard analyzer
- Field content is indexed correctly per this non-standard analyzer
- But, now let them run an analytic query over a field (that exists) - - This analytic query is incorrectly pulling the definition from the index's default_analyzer (`standard`) as opposed to the non-standard analyzer.

This situation is not handled properly only for the default mapping and not type mappings.

Also, https://issues.couchbase.com/browse/MB-56306