### PR TITLE
recording the cost for different types of queries

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -588,6 +588,10 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m := s.stats.ToMap()
 
 	indexSnapshot := s.currentSnapshot()
+	if indexSnapshot == nil {
+		return nil
+	}
+
 	defer func() {
 		_ = indexSnapshot.Close()
 	}()

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -205,7 +205,7 @@ func (i *IndexSnapshotTermFieldReader) Close() error {
 			statsCallbackFn.(search.SearchIOStatsCallbackFunc)(i.bytesRead)
 		}
 
-		search.RecordSearchCost(i.ctx, "add", i.bytesRead)
+		search.RecordSearchCost(i.ctx, search.AddM, i.bytesRead)
 	}
 
 	if i.snapshot != nil {

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"reflect"
 	"sync/atomic"
 
@@ -112,10 +113,10 @@ func (i *IndexSnapshotTermFieldReader) Next(preAlloced *index.TermFieldDoc) (*in
 			// this is because there are chances of having a series of loadChunk calls,
 			// and they have to be added together before sending the bytesRead at this point
 			// upstream.
-			if delta := i.iterators[i.segmentOffset].BytesRead() - prevBytesRead; delta > 0 {
-				i.incrementBytesRead(delta)
+			bytesRead := i.iterators[i.segmentOffset].BytesRead()
+			if bytesRead > prevBytesRead {
+				i.incrementBytesRead(bytesRead - prevBytesRead)
 			}
-
 			return rv, nil
 		}
 		i.segmentOffset++

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -205,7 +205,6 @@ func (i *IndexSnapshotTermFieldReader) Close() error {
 			statsCallbackFn.(search.SearchIOStatsCallbackFunc)(i.bytesRead)
 		}
 
-		// todo: should this is be per hit?
 		search.RecordSearchCost(i.ctx, "add", i.bytesRead)
 	}
 

--- a/index_impl.go
+++ b/index_impl.go
@@ -501,7 +501,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 			sr.UpdateIOStats(totalSearchCost)
 		}
 
-		search.RecordSearchCost(ctx, "done", 0)
+		search.RecordSearchCost(ctx, search.DoneM, 0)
 	}()
 
 	if req.Facets != nil {
@@ -586,7 +586,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		}
 		totalSearchCost += storedFieldsBytes
 
-		search.RecordSearchCost(ctx, "add", storedFieldsBytes)
+		search.RecordSearchCost(ctx, search.AddM, storedFieldsBytes)
 	}
 
 	atomic.AddUint64(&i.stats.searches, 1)

--- a/index_impl.go
+++ b/index_impl.go
@@ -474,9 +474,9 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	//     accounted by invoking this callback when the TFR is closed.
 	//  2. the docvalues portion (accounted in collector) and the retrieval
 	//     of stored fields bytes (by LoadAndHighlightFields)
-	var totalBytesRead uint64
+	var totalSearchCost uint64
 	sendBytesRead := func(bytesRead uint64) {
-		totalBytesRead += bytesRead
+		totalSearchCost += bytesRead
 	}
 
 	ctx = context.WithValue(ctx, search.SearchIOStatsCallbackKey,
@@ -495,10 +495,10 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 			err = serr
 		}
 		if sr != nil {
-			sr.BytesRead = totalBytesRead
+			sr.Cost = totalSearchCost
 		}
 		if sr, ok := indexReader.(*scorch.IndexSnapshot); ok {
-			sr.UpdateIOStats(totalBytesRead)
+			sr.UpdateIOStats(totalSearchCost)
 		}
 
 		search.RecordSearchCost(ctx, "done", 0)
@@ -584,7 +584,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		if err != nil {
 			return nil, err
 		}
-		totalBytesRead += storedFieldsBytes
+		totalSearchCost += storedFieldsBytes
 
 		search.RecordSearchCost(ctx, "add", storedFieldsBytes)
 	}

--- a/index_impl.go
+++ b/index_impl.go
@@ -576,6 +576,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		}
 	}
 
+	var storedFieldsCost uint64
 	for _, hit := range hits {
 		if i.name != "" {
 			hit.Index = i.name
@@ -584,10 +585,11 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		if err != nil {
 			return nil, err
 		}
-		totalSearchCost += storedFieldsBytes
-
-		search.RecordSearchCost(ctx, search.AddM, storedFieldsBytes)
+		storedFieldsCost += storedFieldsBytes
 	}
+
+	totalSearchCost += storedFieldsCost
+	search.RecordSearchCost(ctx, search.AddM, storedFieldsCost)
 
 	atomic.AddUint64(&i.stats.searches, 1)
 	searchDuration := time.Since(searchStart)

--- a/index_test.go
+++ b/index_test.go
@@ -401,7 +401,7 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	prevBytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if prevBytesRead != 32349 && res.BytesRead == prevBytesRead {
+	if prevBytesRead != 32349 && res.Cost == prevBytesRead {
 		t.Fatalf("expected bytes read for query string 32349, got %v",
 			prevBytesRead)
 	}
@@ -415,7 +415,7 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 23 && res.BytesRead == bytesRead-prevBytesRead {
+	if bytesRead-prevBytesRead != 23 && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for query string 23, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -431,7 +431,7 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 8468 && res.BytesRead == bytesRead-prevBytesRead {
+	if bytesRead-prevBytesRead != 8468 && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for fuzzy query is 8468, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -448,7 +448,7 @@ func TestBytesRead(t *testing.T) {
 
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if !approxSame(bytesRead-prevBytesRead, 150) && res.BytesRead == bytesRead-prevBytesRead {
+	if !approxSame(bytesRead-prevBytesRead, 150) && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for faceted query is around 150, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -466,7 +466,7 @@ func TestBytesRead(t *testing.T) {
 
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 924 && res.BytesRead == bytesRead-prevBytesRead {
+	if bytesRead-prevBytesRead != 924 && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for numeric range query is 924, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -481,7 +481,7 @@ func TestBytesRead(t *testing.T) {
 
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 60 && res.BytesRead == bytesRead-prevBytesRead {
+	if bytesRead-prevBytesRead != 60 && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for query with highlighter is 60, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -498,7 +498,7 @@ func TestBytesRead(t *testing.T) {
 	// since it's created afresh and not reused
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 83 && res.BytesRead == bytesRead-prevBytesRead {
+	if bytesRead-prevBytesRead != 83 && res.Cost == bytesRead-prevBytesRead {
 		t.Fatalf("expected bytes read for disjunction query is 83, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -580,7 +580,7 @@ func TestBytesReadStored(t *testing.T) {
 
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead != 25928 && bytesRead == res.BytesRead {
+	if bytesRead != 25928 && bytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 25928, got %v", bytesRead)
 	}
 	prevBytesRead := bytesRead
@@ -592,7 +592,7 @@ func TestBytesReadStored(t *testing.T) {
 	}
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 15 && bytesRead-prevBytesRead == res.BytesRead {
+	if bytesRead-prevBytesRead != 15 && bytesRead-prevBytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 15, got %v", bytesRead-prevBytesRead)
 	}
 	prevBytesRead = bytesRead
@@ -607,7 +607,7 @@ func TestBytesReadStored(t *testing.T) {
 	stats, _ = idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
 
-	if bytesRead-prevBytesRead != 26478 && bytesRead-prevBytesRead == res.BytesRead {
+	if bytesRead-prevBytesRead != 26478 && bytesRead-prevBytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 26478, got %v",
 			bytesRead-prevBytesRead)
 	}
@@ -651,7 +651,7 @@ func TestBytesReadStored(t *testing.T) {
 
 	stats, _ = idx1.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead != 18114 && bytesRead == res.BytesRead {
+	if bytesRead != 18114 && bytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 18114, got %v", bytesRead)
 	}
 	prevBytesRead = bytesRead
@@ -662,7 +662,7 @@ func TestBytesReadStored(t *testing.T) {
 	}
 	stats, _ = idx1.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 12 && bytesRead-prevBytesRead == res.BytesRead {
+	if bytesRead-prevBytesRead != 12 && bytesRead-prevBytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 12, got %v", bytesRead-prevBytesRead)
 	}
 	prevBytesRead = bytesRead
@@ -675,7 +675,7 @@ func TestBytesReadStored(t *testing.T) {
 
 	stats, _ = idx1.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead-prevBytesRead != 42 && bytesRead-prevBytesRead == res.BytesRead {
+	if bytesRead-prevBytesRead != 42 && bytesRead-prevBytesRead == res.Cost {
 		t.Fatalf("expected the bytes read stat to be around 42, got %v", bytesRead-prevBytesRead)
 	}
 }

--- a/search.go
+++ b/search.go
@@ -485,12 +485,24 @@ func (ss *SearchStatus) Merge(other *SearchStatus) {
 
 // A SearchResult describes the results of executing
 // a SearchRequest.
+//
+// Status - Whether the search was executed on the underlying indexes successfully
+// or failed, and the corresponding errors.
+// Request - The SearchRequest that was executed.
+// Hits - The list of documents that matched the query and their corresponding
+// scores, score explanation, location info and so on.
+// Total - The total number of documents that matched the query.
+// Cost - indicates how expensive was the query with respect to bytes read
+// from the mmaped index files.
+// MaxScore - The maximum score seen across all document hits seen for this query.
+// Took - The time taken to execute the search.
+// Facets - The facet results for the search.
 type SearchResult struct {
 	Status   *SearchStatus                  `json:"status"`
 	Request  *SearchRequest                 `json:"request"`
 	Hits     search.DocumentMatchCollection `json:"hits"`
 	Total    uint64                         `json:"total_hits"`
-	Cost     uint64                         `json:"search_cost"`
+	Cost     uint64                         `json:"cost"`
 	MaxScore float64                        `json:"max_score"`
 	Took     time.Duration                  `json:"took"`
 	Facets   search.FacetResults            `json:"facets"`

--- a/search.go
+++ b/search.go
@@ -486,14 +486,14 @@ func (ss *SearchStatus) Merge(other *SearchStatus) {
 // A SearchResult describes the results of executing
 // a SearchRequest.
 type SearchResult struct {
-	Status    *SearchStatus                  `json:"status"`
-	Request   *SearchRequest                 `json:"request"`
-	Hits      search.DocumentMatchCollection `json:"hits"`
-	Total     uint64                         `json:"total_hits"`
-	BytesRead uint64                         `json:"bytesRead"`
-	MaxScore  float64                        `json:"max_score"`
-	Took      time.Duration                  `json:"took"`
-	Facets    search.FacetResults            `json:"facets"`
+	Status   *SearchStatus                  `json:"status"`
+	Request  *SearchRequest                 `json:"request"`
+	Hits     search.DocumentMatchCollection `json:"hits"`
+	Total    uint64                         `json:"total_hits"`
+	Cost     uint64                         `json:"search_cost"`
+	MaxScore float64                        `json:"max_score"`
+	Took     time.Duration                  `json:"took"`
+	Facets   search.FacetResults            `json:"facets"`
 }
 
 func (sr *SearchResult) Size() int {
@@ -566,7 +566,7 @@ func (sr *SearchResult) Merge(other *SearchResult) {
 	sr.Status.Merge(other.Status)
 	sr.Hits = append(sr.Hits, other.Hits...)
 	sr.Total += other.Total
-	sr.BytesRead += other.BytesRead
+	sr.Cost += other.Cost
 	if other.MaxScore > sr.MaxScore {
 		sr.MaxScore = other.MaxScore
 	}

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -200,7 +200,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 	hc.needDocIds = hc.needDocIds || loadID
 	select {
 	case <-ctx.Done():
-		search.RecordSearchCost(ctx, "abort", 0)
+		search.RecordSearchCost(ctx, search.AbortM, 0)
 		return ctx.Err()
 	default:
 		next, err = searcher.Next(searchContext)
@@ -209,7 +209,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 		if hc.total%CheckDoneEvery == 0 {
 			select {
 			case <-ctx.Done():
-				search.RecordSearchCost(ctx, "abort", 0)
+				search.RecordSearchCost(ctx, search.AbortM, 0)
 				return ctx.Err()
 			default:
 			}
@@ -235,7 +235,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 		// which must be accounted by invoking the callback.
 		statsCallbackFn.(search.SearchIOStatsCallbackFunc)(hc.bytesRead)
 
-		search.RecordSearchCost(ctx, "add", hc.bytesRead)
+		search.RecordSearchCost(ctx, search.AddM, hc.bytesRead)
 	}
 
 	// help finalize/flush the results in case

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -200,6 +200,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 	hc.needDocIds = hc.needDocIds || loadID
 	select {
 	case <-ctx.Done():
+		search.RecordSearchCost(ctx, "abort", 0)
 		return ctx.Err()
 	default:
 		next, err = searcher.Next(searchContext)
@@ -208,6 +209,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 		if hc.total%CheckDoneEvery == 0 {
 			select {
 			case <-ctx.Done():
+				search.RecordSearchCost(ctx, "abort", 0)
 				return ctx.Err()
 			default:
 			}

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -155,13 +155,6 @@ func (hc *TopNCollector) Size() int {
 	return sizeInBytes
 }
 
-func aggregateBytesRead(ctx context.Context, bytes uint64) {
-	aggCallbackFn := ctx.Value(search.SearchCostAggregatorKey)
-	if aggCallbackFn != nil {
-		aggCallbackFn.(search.SearchCostAggregatorCallbackFn)("add", "", bytes)
-	}
-}
-
 // Collect goes to the index to find the matching documents
 func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, reader index.IndexReader) error {
 	startTime := time.Now()
@@ -240,7 +233,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 		// which must be accounted by invoking the callback.
 		statsCallbackFn.(search.SearchIOStatsCallbackFunc)(hc.bytesRead)
 
-		aggregateBytesRead(ctx, hc.bytesRead)
+		search.RecordSearchCost(ctx, "add", hc.bytesRead)
 	}
 
 	// help finalize/flush the results in case

--- a/search/query/geo_boundingbox.go
+++ b/search/query/geo_boundingbox.go
@@ -63,7 +63,7 @@ func (q *GeoBoundingBoxQuery) Searcher(ctx context.Context, i index.IndexReader,
 		field = m.DefaultSearchField()
 	}
 
-	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+	ctx = context.WithValue(ctx, search.QueryTypeKey, search.Geo)
 
 	if q.BottomRight[0] < q.TopLeft[0] {
 		// cross date line, rewrite as two parts

--- a/search/query/geo_boundingbox.go
+++ b/search/query/geo_boundingbox.go
@@ -63,6 +63,8 @@ func (q *GeoBoundingBoxQuery) Searcher(ctx context.Context, i index.IndexReader,
 		field = m.DefaultSearchField()
 	}
 
+	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+
 	if q.BottomRight[0] < q.TopLeft[0] {
 		// cross date line, rewrite as two parts
 

--- a/search/query/geo_boundingpolygon.go
+++ b/search/query/geo_boundingpolygon.go
@@ -61,6 +61,8 @@ func (q *GeoBoundingPolygonQuery) Searcher(ctx context.Context, i index.IndexRea
 		field = m.DefaultSearchField()
 	}
 
+	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+
 	return searcher.NewGeoBoundedPolygonSearcher(ctx, i, q.Points, field, q.BoostVal.Value(), options)
 }
 

--- a/search/query/geo_boundingpolygon.go
+++ b/search/query/geo_boundingpolygon.go
@@ -61,7 +61,7 @@ func (q *GeoBoundingPolygonQuery) Searcher(ctx context.Context, i index.IndexRea
 		field = m.DefaultSearchField()
 	}
 
-	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+	ctx = context.WithValue(ctx, search.QueryTypeKey, search.Geo)
 
 	return searcher.NewGeoBoundedPolygonSearcher(ctx, i, q.Points, field, q.BoostVal.Value(), options)
 }

--- a/search/query/geo_distance.go
+++ b/search/query/geo_distance.go
@@ -64,7 +64,7 @@ func (q *GeoDistanceQuery) Searcher(ctx context.Context, i index.IndexReader, m 
 		field = m.DefaultSearchField()
 	}
 
-	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+	ctx = context.WithValue(ctx, search.QueryTypeKey, search.Geo)
 
 	dist, err := geo.ParseDistance(q.Distance)
 	if err != nil {

--- a/search/query/geo_distance.go
+++ b/search/query/geo_distance.go
@@ -64,6 +64,8 @@ func (q *GeoDistanceQuery) Searcher(ctx context.Context, i index.IndexReader, m 
 		field = m.DefaultSearchField()
 	}
 
+	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+
 	dist, err := geo.ParseDistance(q.Distance)
 	if err != nil {
 		return nil, err

--- a/search/query/geo_shape.go
+++ b/search/query/geo_shape.go
@@ -107,6 +107,8 @@ func (q *GeoShapeQuery) Searcher(ctx context.Context, i index.IndexReader,
 		field = m.DefaultSearchField()
 	}
 
+	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+
 	return searcher.NewGeoShapeSearcher(ctx, i, q.Geometry.Shape, q.Geometry.Relation, field,
 		q.BoostVal.Value(), options)
 }

--- a/search/query/geo_shape.go
+++ b/search/query/geo_shape.go
@@ -107,7 +107,7 @@ func (q *GeoShapeQuery) Searcher(ctx context.Context, i index.IndexReader,
 		field = m.DefaultSearchField()
 	}
 
-	ctx = context.WithValue(ctx, search.QueryTypeKey, "geo")
+	ctx = context.WithValue(ctx, search.QueryTypeKey, search.Geo)
 
 	return searcher.NewGeoShapeSearcher(ctx, i, q.Geometry.Shape, q.Geometry.Relation, field,
 		q.BoostVal.Value(), options)

--- a/search/query/numeric_range.go
+++ b/search/query/numeric_range.go
@@ -77,7 +77,7 @@ func (q *NumericRangeQuery) Searcher(ctx context.Context, i index.IndexReader, m
 	if q.FieldVal == "" {
 		field = m.DefaultSearchField()
 	}
-	ctx = context.WithValue(ctx, search.QueryTypeKey, "numeric")
+	ctx = context.WithValue(ctx, search.QueryTypeKey, search.Numeric)
 	return searcher.NewNumericRangeSearcher(ctx, i, q.Min, q.Max, q.InclusiveMin, q.InclusiveMax, field, q.BoostVal.Value(), options)
 }
 

--- a/search/query/numeric_range.go
+++ b/search/query/numeric_range.go
@@ -77,6 +77,7 @@ func (q *NumericRangeQuery) Searcher(ctx context.Context, i index.IndexReader, m
 	if q.FieldVal == "" {
 		field = m.DefaultSearchField()
 	}
+	ctx = context.WithValue(ctx, search.QueryTypeKey, "numeric")
 	return searcher.NewNumericRangeSearcher(ctx, i, q.Min, q.Max, q.InclusiveMin, q.InclusiveMax, field, q.BoostVal.Value(), options)
 }
 

--- a/search/search.go
+++ b/search/search.go
@@ -27,14 +27,6 @@ var reflectStaticSizeDocumentMatch int
 var reflectStaticSizeSearchContext int
 var reflectStaticSizeLocation int
 
-const SearchIOStatsCallbackKey = "_search_io_stats_callback_key"
-
-type SearchIOStatsCallbackFunc func(uint64)
-type SearchCostAggregatorCallbackFn func(string, string, uint64)
-
-const SearchCostAggregatorKey = "_search_cost_aggregator_key"
-const QueryTypeKey = "_query_type_key"
-
 func init() {
 	var dm DocumentMatch
 	reflectStaticSizeDocumentMatch = int(reflect.TypeOf(dm).Size())

--- a/search/search.go
+++ b/search/search.go
@@ -30,6 +30,10 @@ var reflectStaticSizeLocation int
 const SearchIOStatsCallbackKey = "_search_io_stats_callback_key"
 
 type SearchIOStatsCallbackFunc func(uint64)
+type SearchCostAggregatorCallbackFn func(string, string, uint64)
+
+const SearchCostAggregatorKey = "_search_cost_aggregator_key"
+const QueryTypeKey = "_query_type_key"
 
 func init() {
 	var dm DocumentMatch

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -59,8 +59,8 @@ func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term s
 	}
 
 	if ctx != nil {
-		reportIOStats(dictBytesRead, ctx)
-		aggregateBytesRead(ctx, dictBytesRead)
+		reportIOStats(ctx, dictBytesRead)
+		search.RecordSearchCost(ctx, "add", dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidates, field,
@@ -72,7 +72,7 @@ type fuzzyCandidates struct {
 	bytesRead  uint64
 }
 
-func reportIOStats(bytesRead uint64, ctx context.Context) {
+func reportIOStats(ctx context.Context, bytesRead uint64) {
 	// The fuzzy, regexp like queries essentially load a dictionary,
 	// which potentially incurs a cost that must be accounted by
 	// using the callback to report the value.

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -60,7 +60,7 @@ func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term s
 
 	if ctx != nil {
 		reportIOStats(ctx, dictBytesRead)
-		search.RecordSearchCost(ctx, "add", dictBytesRead)
+		search.RecordSearchCost(ctx, search.AddM, dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidates, field,

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -76,9 +76,11 @@ func reportIOStats(ctx context.Context, bytesRead uint64) {
 	// The fuzzy, regexp like queries essentially load a dictionary,
 	// which potentially incurs a cost that must be accounted by
 	// using the callback to report the value.
-	statsCallbackFn := ctx.Value(search.SearchIOStatsCallbackKey)
-	if statsCallbackFn != nil {
-		statsCallbackFn.(search.SearchIOStatsCallbackFunc)(bytesRead)
+	if ctx != nil {
+		statsCallbackFn := ctx.Value(search.SearchIOStatsCallbackKey)
+		if statsCallbackFn != nil {
+			statsCallbackFn.(search.SearchIOStatsCallbackFunc)(bytesRead)
+		}
 	}
 }
 

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -60,6 +60,7 @@ func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term s
 
 	if ctx != nil {
 		reportIOStats(dictBytesRead, ctx)
+		aggregateBytesRead(ctx, dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidates, field,

--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -225,7 +225,7 @@ func buildRectFilter(ctx context.Context, dvReader index.DocValueReader, field s
 			bytes := dvReader.BytesRead()
 			if bytes > 0 {
 				reportIOStats(ctx, bytes)
-				search.RecordSearchCost(ctx, "add", bytes)
+				search.RecordSearchCost(ctx, search.AddM, bytes)
 			}
 			for i := range lons {
 				if geo.BoundingBoxContains(lons[i], lats[i],

--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -222,6 +222,11 @@ func buildRectFilter(ctx context.Context, dvReader index.DocValueReader, field s
 			}
 		})
 		if err == nil && found {
+			bytes := dvReader.BytesRead()
+			if bytes > 0 {
+				reportIOStats(ctx, bytes)
+				search.RecordSearchCost(ctx, "add", bytes)
+			}
 			for i := range lons {
 				if geo.BoundingBoxContains(lons[i], lats[i],
 					minLon, minLat, maxLon, maxLat) {

--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -49,7 +49,7 @@ func NewGeoBoundingBoxSearcher(ctx context.Context, indexReader index.IndexReade
 				return nil, err
 			}
 
-			return NewFilteringSearcher(ctx, boxSearcher, buildRectFilter(dvReader,
+			return NewFilteringSearcher(ctx, boxSearcher, buildRectFilter(ctx, dvReader,
 				field, minLon, minLat, maxLon, maxLat)), nil
 		}
 	}
@@ -85,7 +85,7 @@ func NewGeoBoundingBoxSearcher(ctx context.Context, indexReader index.IndexReade
 		}
 		// add filter to check points near the boundary
 		onBoundarySearcher = NewFilteringSearcher(ctx, rawOnBoundarySearcher,
-			buildRectFilter(dvReader, field, minLon, minLat, maxLon, maxLat))
+			buildRectFilter(ctx, dvReader, field, minLon, minLat, maxLon, maxLat))
 		openedSearchers = append(openedSearchers, onBoundarySearcher)
 	}
 
@@ -201,7 +201,7 @@ func buildIsIndexedFunc(ctx context.Context, indexReader index.IndexReader, fiel
 	return isIndexed, closeF, err
 }
 
-func buildRectFilter(dvReader index.DocValueReader, field string,
+func buildRectFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	minLon, minLat, maxLon, maxLat float64) FilterFunc {
 	return func(d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -134,6 +134,11 @@ func buildDistFilter(ctx context.Context, dvReader index.DocValueReader, field s
 			}
 		})
 		if err == nil && found {
+			bytes := dvReader.BytesRead()
+			if bytes > 0 {
+				reportIOStats(ctx, bytes)
+				search.RecordSearchCost(ctx, "add", bytes)
+			}
 			for i := range lons {
 				dist := geo.Haversin(lons[i], lats[i], centerLon, centerLat)
 				if dist <= maxDist/1000 {

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -66,7 +66,7 @@ func NewGeoPointDistanceSearcher(ctx context.Context, indexReader index.IndexRea
 
 	// wrap it in a filtering searcher which checks the actual distance
 	return NewFilteringSearcher(ctx, rectSearcher,
-		buildDistFilter(dvReader, field, centerLon, centerLat, dist)), nil
+		buildDistFilter(ctx, dvReader, field, centerLon, centerLat, dist)), nil
 }
 
 // boxSearcher builds a searcher for the described bounding box
@@ -113,7 +113,7 @@ func boxSearcher(ctx context.Context, indexReader index.IndexReader,
 	return boxSearcher, nil
 }
 
-func buildDistFilter(dvReader index.DocValueReader, field string,
+func buildDistFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	centerLon, centerLat, maxDist float64) FilterFunc {
 	return func(d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -137,7 +137,7 @@ func buildDistFilter(ctx context.Context, dvReader index.DocValueReader, field s
 			bytes := dvReader.BytesRead()
 			if bytes > 0 {
 				reportIOStats(ctx, bytes)
-				search.RecordSearchCost(ctx, "add", bytes)
+				search.RecordSearchCost(ctx, search.AddM, bytes)
 			}
 			for i := range lons {
 				dist := geo.Haversin(lons[i], lats[i], centerLon, centerLat)

--- a/search/searcher/search_geopolygon.go
+++ b/search/searcher/search_geopolygon.go
@@ -71,7 +71,7 @@ func NewGeoBoundedPolygonSearcher(ctx context.Context, indexReader index.IndexRe
 
 	// wrap it in a filtering searcher that checks for the polygon inclusivity
 	return NewFilteringSearcher(ctx, rectSearcher,
-		buildPolygonFilter(dvReader, field, coordinates)), nil
+		buildPolygonFilter(ctx, dvReader, field, coordinates)), nil
 }
 
 const float64EqualityThreshold = 1e-6
@@ -83,7 +83,7 @@ func almostEqual(a, b float64) bool {
 // buildPolygonFilter returns true if the point lies inside the
 // polygon. It is based on the ray-casting technique as referred
 // here: https://wrf.ecse.rpi.edu/nikola/pubdetails/pnpoly.html
-func buildPolygonFilter(dvReader index.DocValueReader, field string,
+func buildPolygonFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	coordinates []geo.Point) FilterFunc {
 	return func(d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed

--- a/search/searcher/search_geopolygon.go
+++ b/search/searcher/search_geopolygon.go
@@ -107,6 +107,11 @@ func buildPolygonFilter(ctx context.Context, dvReader index.DocValueReader, fiel
 		// Note: this approach works for points which are strictly inside
 		// the polygon. ie it might fail for certain points on the polygon boundaries.
 		if err == nil && found {
+			bytes := dvReader.BytesRead()
+			if bytes > 0 {
+				reportIOStats(ctx, bytes)
+				search.RecordSearchCost(ctx, "add", bytes)
+			}
 			nVertices := len(coordinates)
 			if len(coordinates) < 3 {
 				return false

--- a/search/searcher/search_geopolygon.go
+++ b/search/searcher/search_geopolygon.go
@@ -110,7 +110,7 @@ func buildPolygonFilter(ctx context.Context, dvReader index.DocValueReader, fiel
 			bytes := dvReader.BytesRead()
 			if bytes > 0 {
 				reportIOStats(ctx, bytes)
-				search.RecordSearchCost(ctx, "add", bytes)
+				search.RecordSearchCost(ctx, search.AddM, bytes)
 			}
 			nVertices := len(coordinates)
 			if len(coordinates) < 3 {

--- a/search/searcher/search_geoshape.go
+++ b/search/searcher/search_geoshape.go
@@ -115,11 +115,11 @@ func buildRelationFilterOnShapes(ctx context.Context, dvReader index.DocValueRea
 				}
 			})
 
-		// use ctx to aggregate the bytes read
 		if err == nil && found {
 			bytes := dvReader.BytesRead()
 			if bytes > 0 {
-				aggregateBytesRead(ctx, bytes)
+				reportIOStats(ctx, bytes)
+				search.RecordSearchCost(ctx, "add", bytes)
 			}
 			return found
 		}

--- a/search/searcher/search_geoshape.go
+++ b/search/searcher/search_geoshape.go
@@ -54,7 +54,7 @@ func NewGeoShapeSearcher(ctx context.Context, indexReader index.IndexReader, sha
 	}
 
 	return NewFilteringSearcher(ctx, mSearcher,
-		buildRelationFilterOnShapes(dvReader, field, relation, shape)), nil
+		buildRelationFilterOnShapes(ctx, dvReader, field, relation, shape)), nil
 
 }
 
@@ -63,7 +63,7 @@ func NewGeoShapeSearcher(ctx context.Context, indexReader index.IndexReader, sha
 // implementation of doc values.
 var termSeparatorSplitSlice = []byte{0xff}
 
-func buildRelationFilterOnShapes(dvReader index.DocValueReader, field string,
+func buildRelationFilterOnShapes(ctx context.Context, dvReader index.DocValueReader, field string,
 	relation string, shape index.GeoJSON) FilterFunc {
 	// this is for accumulating the shape's actual complete value
 	// spread across multiple docvalue visitor callbacks.
@@ -115,7 +115,12 @@ func buildRelationFilterOnShapes(dvReader index.DocValueReader, field string,
 				}
 			})
 
+		// use ctx to aggregate the bytes read
 		if err == nil && found {
+			bytes := dvReader.BytesRead()
+			if bytes > 0 {
+				aggregateBytesRead(ctx, bytes)
+			}
 			return found
 		}
 

--- a/search/searcher/search_geoshape.go
+++ b/search/searcher/search_geoshape.go
@@ -119,7 +119,7 @@ func buildRelationFilterOnShapes(ctx context.Context, dvReader index.DocValueRea
 			bytes := dvReader.BytesRead()
 			if bytes > 0 {
 				reportIOStats(ctx, bytes)
-				search.RecordSearchCost(ctx, "add", bytes)
+				search.RecordSearchCost(ctx, search.AddM, bytes)
 			}
 			return found
 		}

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -89,7 +89,7 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 		// loaded, using the context
 		if ctx != nil {
 			reportIOStats(ctx, dictBytesRead)
-			search.RecordSearchCost(ctx, "add", dictBytesRead)
+			search.RecordSearchCost(ctx, search.AddM, dictBytesRead)
 		}
 
 		// cannot return MatchNoneSearcher because of interaction with
@@ -112,7 +112,7 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 
 	if ctx != nil {
 		reportIOStats(ctx, dictBytesRead)
-		search.RecordSearchCost(ctx, "add", dictBytesRead)
+		search.RecordSearchCost(ctx, search.AddM, dictBytesRead)
 	}
 
 	return NewMultiTermSearcherBytes(ctx, indexReader, terms, field,

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -88,8 +88,8 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 		// reporting back the IO stats with respect to the dictionary
 		// loaded, using the context
 		if ctx != nil {
-			reportIOStats(dictBytesRead, ctx)
-			aggregateBytesRead(ctx, dictBytesRead)
+			reportIOStats(ctx, dictBytesRead)
+			search.RecordSearchCost(ctx, "add", dictBytesRead)
 		}
 
 		// cannot return MatchNoneSearcher because of interaction with
@@ -111,8 +111,8 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 	}
 
 	if ctx != nil {
-		reportIOStats(dictBytesRead, ctx)
-		aggregateBytesRead(ctx, dictBytesRead)
+		reportIOStats(ctx, dictBytesRead)
+		search.RecordSearchCost(ctx, "add", dictBytesRead)
 	}
 
 	return NewMultiTermSearcherBytes(ctx, indexReader, terms, field,

--- a/search/searcher/search_numeric_range.go
+++ b/search/searcher/search_numeric_range.go
@@ -89,6 +89,7 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 		// loaded, using the context
 		if ctx != nil {
 			reportIOStats(dictBytesRead, ctx)
+			aggregateBytesRead(ctx, dictBytesRead)
 		}
 
 		// cannot return MatchNoneSearcher because of interaction with
@@ -111,6 +112,7 @@ func NewNumericRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 
 	if ctx != nil {
 		reportIOStats(dictBytesRead, ctx)
+		aggregateBytesRead(ctx, dictBytesRead)
 	}
 
 	return NewMultiTermSearcherBytes(ctx, indexReader, terms, field,

--- a/search/searcher/search_regexp.go
+++ b/search/searcher/search_regexp.go
@@ -103,7 +103,7 @@ func NewRegexpSearcher(ctx context.Context, indexReader index.IndexReader, patte
 
 	if ctx != nil {
 		reportIOStats(ctx, dictBytesRead)
-		search.RecordSearchCost(ctx, "add", dictBytesRead)
+		search.RecordSearchCost(ctx, search.AddM, dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidateTerms, field, boost,

--- a/search/searcher/search_regexp.go
+++ b/search/searcher/search_regexp.go
@@ -102,8 +102,8 @@ func NewRegexpSearcher(ctx context.Context, indexReader index.IndexReader, patte
 	}
 
 	if ctx != nil {
-		reportIOStats(dictBytesRead, ctx)
-		aggregateBytesRead(ctx, dictBytesRead)
+		reportIOStats(ctx, dictBytesRead)
+		search.RecordSearchCost(ctx, "add", dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidateTerms, field, boost,

--- a/search/searcher/search_regexp.go
+++ b/search/searcher/search_regexp.go
@@ -103,6 +103,7 @@ func NewRegexpSearcher(ctx context.Context, indexReader index.IndexReader, patte
 
 	if ctx != nil {
 		reportIOStats(dictBytesRead, ctx)
+		aggregateBytesRead(ctx, dictBytesRead)
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, candidateTerms, field, boost,

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -40,7 +40,7 @@ type TermSearcher struct {
 
 func NewTermSearcher(ctx context.Context, indexReader index.IndexReader, term string, field string, boost float64, options search.SearcherOptions) (*TermSearcher, error) {
 	if isTermQuery(ctx) {
-		ctx = context.WithValue(ctx, search.QueryTypeKey, "term")
+		ctx = context.WithValue(ctx, search.QueryTypeKey, search.Term)
 	}
 	return NewTermSearcherBytes(ctx, indexReader, []byte(term), field, boost, options)
 }

--- a/search/searcher/search_term_prefix.go
+++ b/search/searcher/search_term_prefix.go
@@ -49,8 +49,8 @@ func NewTermPrefixSearcher(ctx context.Context, indexReader index.IndexReader, p
 	}
 
 	if ctx != nil {
-		reportIOStats(fieldDict.BytesRead(), ctx)
-		aggregateBytesRead(ctx, fieldDict.BytesRead())
+		reportIOStats(ctx, fieldDict.BytesRead())
+		search.RecordSearchCost(ctx, "add", fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/searcher/search_term_prefix.go
+++ b/search/searcher/search_term_prefix.go
@@ -50,7 +50,7 @@ func NewTermPrefixSearcher(ctx context.Context, indexReader index.IndexReader, p
 
 	if ctx != nil {
 		reportIOStats(ctx, fieldDict.BytesRead())
-		search.RecordSearchCost(ctx, "add", fieldDict.BytesRead())
+		search.RecordSearchCost(ctx, search.AddM, fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/searcher/search_term_prefix.go
+++ b/search/searcher/search_term_prefix.go
@@ -50,6 +50,7 @@ func NewTermPrefixSearcher(ctx context.Context, indexReader index.IndexReader, p
 
 	if ctx != nil {
 		reportIOStats(fieldDict.BytesRead(), ctx)
+		aggregateBytesRead(ctx, fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/searcher/search_term_range.go
+++ b/search/searcher/search_term_range.go
@@ -84,8 +84,8 @@ func NewTermRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 	}
 
 	if ctx != nil {
-		reportIOStats(fieldDict.BytesRead(), ctx)
-		aggregateBytesRead(ctx, fieldDict.BytesRead())
+		reportIOStats(ctx, fieldDict.BytesRead())
+		search.RecordSearchCost(ctx, "add", fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/searcher/search_term_range.go
+++ b/search/searcher/search_term_range.go
@@ -85,7 +85,7 @@ func NewTermRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 
 	if ctx != nil {
 		reportIOStats(ctx, fieldDict.BytesRead())
-		search.RecordSearchCost(ctx, "add", fieldDict.BytesRead())
+		search.RecordSearchCost(ctx, search.AddM, fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/searcher/search_term_range.go
+++ b/search/searcher/search_term_range.go
@@ -85,6 +85,7 @@ func NewTermRangeSearcher(ctx context.Context, indexReader index.IndexReader,
 
 	if ctx != nil {
 		reportIOStats(fieldDict.BytesRead(), ctx)
+		aggregateBytesRead(ctx, fieldDict.BytesRead())
 	}
 
 	return NewMultiTermSearcher(ctx, indexReader, terms, field, boost, options, true)

--- a/search/util.go
+++ b/search/util.go
@@ -75,9 +75,11 @@ const SearchIOStatsCallbackKey = "_search_io_stats_callback_key"
 type SearchIOStatsCallbackFunc func(uint64)
 
 // The callback signature is (message, queryType, cost) which allows
-// the caller to act on a particular query type and what its the associated
-// cost of an operation. "add" indicates to increment the cost for the query
+// the caller to act on a particular query type and its associated
+// cost of operation. "add" indicates to increment the cost for the query
 // "done" indicates a finish of the accounting of the costs.
+// "abort" would indicate with respect to the fact that the search's context
+// was cancelled and the caller should act appropriately on it.
 type SearchIncrementalCostCallbackFn func(string, string, uint64)
 
 const SearchIncrementalCostKey = "_search_incremental_cost_key"

--- a/search/util.go
+++ b/search/util.go
@@ -84,15 +84,17 @@ const SearchIncrementalCostKey = "_search_incremental_cost_key"
 const QueryTypeKey = "_query_type_key"
 
 func RecordSearchCost(ctx context.Context, msg string, bytes uint64) {
-	queryType, ok := ctx.Value(QueryTypeKey).(string)
-	if !ok {
-		// for the cost of the non query type specific factors such as
-		// doc values and stored fields section.
-		queryType = ""
-	}
+	if ctx != nil {
+		queryType, ok := ctx.Value(QueryTypeKey).(string)
+		if !ok {
+			// for the cost of the non query type specific factors such as
+			// doc values and stored fields section.
+			queryType = "non-query-specific-cost"
+		}
 
-	aggCallbackFn := ctx.Value(SearchIncrementalCostKey)
-	if aggCallbackFn != nil {
-		aggCallbackFn.(SearchIncrementalCostCallbackFn)(msg, queryType, bytes)
+		aggCallbackFn := ctx.Value(SearchIncrementalCostKey)
+		if aggCallbackFn != nil {
+			aggCallbackFn.(SearchIncrementalCostCallbackFn)(msg, queryType, bytes)
+		}
 	}
 }

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -359,8 +359,8 @@ func testVersusSearches(vt *VersusTest, searchTemplates []string, idxA, idxB ble
 
 			resA.Hits = nil
 			resB.Hits = nil
-			resA.BytesRead = 0
-			resB.BytesRead = 0
+			resA.Cost = 0
+			resB.Cost = 0
 
 			if !reflect.DeepEqual(resA, resB) {
 				resAj, _ := json.Marshal(resA)


### PR DESCRIPTION
- Adds a new callback function SearchIncrementalCostCallbackFn which is used to track incremental cost updates for the query. It can also be used to track costs for different types of queries as well.

- Renames "bytesRead" to "search_cost"