### PR TITLE
Avoid double counting when sorting by field for faceted query

### DIFF
--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -371,7 +371,20 @@ func (hc *TopNCollector) visitFieldTerms(reader index.IndexReader, d *search.Doc
 // SetFacetsBuilder registers a facet builder for this collector
 func (hc *TopNCollector) SetFacetsBuilder(facetsBuilder *search.FacetsBuilder) {
 	hc.facetsBuilder = facetsBuilder
-	hc.neededFields = append(hc.neededFields, hc.facetsBuilder.RequiredFields()...)
+	fieldsRequiredForFaceting := facetsBuilder.RequiredFields()
+	// for each of these fields, append only if not already there in hc.neededFields.
+	for _, field := range fieldsRequiredForFaceting {
+		found := false
+		for _, neededField := range hc.neededFields {
+			if field == neededField {
+				found = true
+				break
+			}
+		}
+		if !found {
+			hc.neededFields = append(hc.neededFields, field)
+		}
+	}
 }
 
 // finalizeResults starts with the heap containing the final top size+skip


### PR DESCRIPTION
When a query sorts by the same field as the facets, the number of search results per facet doubles. This is because there is double counting of the documents by the collector on that field for both sorting and faceting.

This PR deduplicates the fields in the collector to avoid this.