### PR TITLE
MB-57972: Add new layout to dateTimeOptional

### DIFF
--- a/analysis/datetime/flexible/flexible_test.go
+++ b/analysis/datetime/flexible/flexible_test.go
@@ -69,7 +69,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 
 	rfc3339NoTimezone := "2006-01-02T15:04:05"
 	rfc3339NoTimezoneNoT := "2006-01-02 15:04:05"
-	rfc3339Offest := "2006-01-02 15:04:05 -0700"
+	rfc3339Offset := "2006-01-02 15:04:05 -0700"
 	rfc3339NoTime := "2006-01-02"
 
 	dateOptionalTimeParser := New(
@@ -78,7 +78,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 			time.RFC3339,
 			rfc3339NoTimezone,
 			rfc3339NoTimezoneNoT,
-			rfc3339Offest,
+			rfc3339Offset,
 			rfc3339NoTime,
 		})
 

--- a/analysis/datetime/flexible/flexible_test.go
+++ b/analysis/datetime/flexible/flexible_test.go
@@ -51,6 +51,11 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			input:         "2000-03-31 01:33:51 -0800",
+			expectedTime:  time.Date(2000, 3, 31, 01, 33, 51, 0, testLocation),
+			expectedError: nil,
+		},
+		{
 			input:         "2014-08-03T15:59:30.999999999-08:00",
 			expectedTime:  time.Date(2014, 8, 3, 15, 59, 30, 999999999, testLocation),
 			expectedError: nil,
@@ -64,6 +69,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 
 	rfc3339NoTimezone := "2006-01-02T15:04:05"
 	rfc3339NoTimezoneNoT := "2006-01-02 15:04:05"
+	rfc3339Offest := "2006-01-02 15:04:05 -0700"
 	rfc3339NoTime := "2006-01-02"
 
 	dateOptionalTimeParser := New(
@@ -72,6 +78,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 			time.RFC3339,
 			rfc3339NoTimezone,
 			rfc3339NoTimezoneNoT,
+			rfc3339Offest,
 			rfc3339NoTime,
 		})
 

--- a/analysis/datetime/optional/optional.go
+++ b/analysis/datetime/optional/optional.go
@@ -26,6 +26,7 @@ const Name = "dateTimeOptional"
 
 const rfc3339NoTimezone = "2006-01-02T15:04:05"
 const rfc3339NoTimezoneNoT = "2006-01-02 15:04:05"
+const rfc3339Offest = "2006-01-02 15:04:05 -0700"
 const rfc3339NoTime = "2006-01-02"
 
 var layouts = []string{
@@ -33,6 +34,7 @@ var layouts = []string{
 	time.RFC3339,
 	rfc3339NoTimezone,
 	rfc3339NoTimezoneNoT,
+	rfc3339Offest,
 	rfc3339NoTime,
 }
 

--- a/analysis/datetime/optional/optional.go
+++ b/analysis/datetime/optional/optional.go
@@ -26,7 +26,7 @@ const Name = "dateTimeOptional"
 
 const rfc3339NoTimezone = "2006-01-02T15:04:05"
 const rfc3339NoTimezoneNoT = "2006-01-02 15:04:05"
-const rfc3339Offest = "2006-01-02 15:04:05 -0700"
+const rfc3339Offset = "2006-01-02 15:04:05 -0700"
 const rfc3339NoTime = "2006-01-02"
 
 var layouts = []string{
@@ -34,7 +34,7 @@ var layouts = []string{
 	time.RFC3339,
 	rfc3339NoTimezone,
 	rfc3339NoTimezoneNoT,
-	rfc3339Offest,
+	rfc3339Offset,
 	rfc3339NoTime,
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -401,7 +401,7 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	prevBytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if prevBytesRead != 32349 && res.Cost == prevBytesRead {
+	if prevBytesRead != 36066 && res.Cost == prevBytesRead {
 		t.Fatalf("expected bytes read for query string 32349, got %v",
 			prevBytesRead)
 	}


### PR DESCRIPTION
## Jira

[MB-57972](https://issues.couchbase.com/browse/MB-57972)

## Description
Currently in Couchbase sample datasets:
1. gamesim-sample: No date fields are there
2. travel-sample: A reviews.date field is there with the layout YYYY:MM:DD HH:MM:SS Offset
3. beer-sample: A date field is there with layout YYYY:MM:DD HH:MM:SS
 
A default mapping (uncustomized) will use dateTimeOptional which has layouts to parse beer-sample but not travel-sample, because of this the user needs to set a custom date time parser to do a date-range query on travel sample. To avoid this and enchance UX, add YYYY:MM:DD HH:MM:SS Offset layout to dateTimeOptional