### PR TITLE
MB-58130: Enhanced date range queries

### DIFF
--- a/analysis/datetime/flexible/flexible.go
+++ b/analysis/datetime/flexible/flexible.go
@@ -24,6 +24,39 @@ import (
 
 const Name = "flexiblego"
 
+var formatDelimiter byte = '%'
+
+var formatSpecifierToLayout = map[byte]string{
+	formatDelimiter: "%",
+	'd':             "2",
+	'D':             "02",
+	'm':             "1",
+	'M':             "01",
+	'y':             "06",
+	'Y':             "2006",
+	'b':             "Jan",
+	'B':             "January",
+	'a':             "Mon",
+	'A':             "Monday",
+	'h':             "3",
+	'H':             "03",
+	'O':             "15",
+	'i':             "4",
+	'I':             "04",
+	's':             "5",
+	'S':             "05",
+	'p':             "pm",
+	'P':             "PM",
+	'z':             "-0700",
+	'Z':             "-070000",
+	'x':             "-07",
+	'v':             "-07:00",
+	'V':             "-07:00:00",
+	'N':             ".000000000",
+	'F':             ".000000",
+	'U':             ".000",
+}
+
 type DateTimeParser struct {
 	layouts []string
 }
@@ -38,10 +71,37 @@ func (p *DateTimeParser) ParseDateTime(input string) (time.Time, error) {
 	for _, layout := range p.layouts {
 		rv, err := time.Parse(layout, input)
 		if err == nil {
+			if rv.Year() == 0 && !rv.IsZero() {
+				// year is zero, so this time.Time has unspecified date
+				// but is Not Zero so must have time only
+				rv = rv.AddDate(1700, 0, 0)
+			}
 			return rv, nil
 		}
 	}
 	return time.Time{}, analysis.ErrInvalidDateTime
+}
+
+func parseFormatString(formatString string) (string, error) {
+	dateTimeLayout := ""
+	for idx := 0; idx < len(formatString); {
+		if formatString[idx] == formatDelimiter {
+			if idx+1 < len(formatString) {
+				if layout, ok := formatSpecifierToLayout[formatString[idx+1]]; ok {
+					dateTimeLayout += layout
+					idx += 2
+				} else {
+					return "", fmt.Errorf("invalid format string, unknown format specifier: " + string(formatString[idx+1]))
+				}
+			} else {
+				return "", fmt.Errorf("invalid format string, expected character after " + string(formatDelimiter))
+			}
+		} else {
+			dateTimeLayout += string(formatString[idx])
+			idx++
+		}
+	}
+	return dateTimeLayout, nil
 }
 
 func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.DateTimeParser, error) {
@@ -53,6 +113,10 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 	for _, layout := range layouts {
 		layoutStr, ok := layout.(string)
 		if ok {
+			layoutStr, err := parseFormatString(layoutStr)
+			if err != nil {
+				return nil, err
+			}
 			layoutStrs = append(layoutStrs, layoutStr)
 		}
 	}

--- a/analysis/datetime/flexible/flexible_test.go
+++ b/analysis/datetime/flexible/flexible_test.go
@@ -51,6 +51,11 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			input:         "2000-03-31 01:33:51 -0800",
+			expectedTime:  time.Date(2000, 3, 31, 01, 33, 51, 0, testLocation),
+			expectedError: nil,
+		},
+		{
 			input:         "2014-08-03T15:59:30.999999999-08:00",
 			expectedTime:  time.Date(2014, 8, 3, 15, 59, 30, 999999999, testLocation),
 			expectedError: nil,
@@ -64,6 +69,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 
 	rfc3339NoTimezone := "2006-01-02T15:04:05"
 	rfc3339NoTimezoneNoT := "2006-01-02 15:04:05"
+	rfc3339Offest := "2006-01-02 15:04:05 -0700"
 	rfc3339NoTime := "2006-01-02"
 
 	dateOptionalTimeParser := New(
@@ -72,6 +78,7 @@ func TestFlexibleDateTimeParser(t *testing.T) {
 			time.RFC3339,
 			rfc3339NoTimezone,
 			rfc3339NoTimezoneNoT,
+			rfc3339Offest,
 			rfc3339NoTime,
 		})
 

--- a/analysis/datetime/optional/optional.go
+++ b/analysis/datetime/optional/optional.go
@@ -26,6 +26,7 @@ const Name = "dateTimeOptional"
 
 const rfc3339NoTimezone = "2006-01-02T15:04:05"
 const rfc3339NoTimezoneNoT = "2006-01-02 15:04:05"
+const rfc3339Offest = "2006-01-02 15:04:05 -0700"
 const rfc3339NoTime = "2006-01-02"
 
 var layouts = []string{
@@ -33,6 +34,7 @@ var layouts = []string{
 	time.RFC3339,
 	rfc3339NoTimezone,
 	rfc3339NoTimezoneNoT,
+	rfc3339Offest,
 	rfc3339NoTime,
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -401,7 +401,7 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	prevBytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if prevBytesRead != 32349 && res.Cost == prevBytesRead {
+	if prevBytesRead != 36066 && res.Cost == prevBytesRead {
 		t.Fatalf("expected bytes read for query string 32349, got %v",
 			prevBytesRead)
 	}

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -39,11 +39,12 @@ import (
 // are used.  To disable this automatic handling, set
 // Dynamic to false.
 type DocumentMapping struct {
-	Enabled         bool                        `json:"enabled"`
-	Dynamic         bool                        `json:"dynamic"`
-	Properties      map[string]*DocumentMapping `json:"properties,omitempty"`
-	Fields          []*FieldMapping             `json:"fields,omitempty"`
-	DefaultAnalyzer string                      `json:"default_analyzer,omitempty"`
+	Enabled               bool                        `json:"enabled"`
+	Dynamic               bool                        `json:"dynamic"`
+	Properties            map[string]*DocumentMapping `json:"properties,omitempty"`
+	Fields                []*FieldMapping             `json:"fields,omitempty"`
+	DefaultAnalyzer       string                      `json:"default_analyzer,omitempty"`
+	DefaultDateTimeParser string                      `json:"default_date_time_parser,omitempty"`
 
 	// StructTagKey overrides "json" when looking for field names in struct tags
 	StructTagKey string `json:"struct_tag_key,omitempty"`
@@ -92,6 +93,14 @@ func (dm *DocumentMapping) analyzerNameForPath(path string) string {
 	field := dm.fieldDescribedByPath(path)
 	if field != nil {
 		return field.Analyzer
+	}
+	return ""
+}
+
+func (dm *DocumentMapping) dateTimeParserForPath(path string) string {
+	field := dm.fieldDescribedByPath(path)
+	if field != nil {
+		return field.DateFormat
 	}
 	return ""
 }
@@ -266,6 +275,11 @@ func (dm *DocumentMapping) UnmarshalJSON(data []byte) error {
 			if err != nil {
 				return err
 			}
+		case "default_datetime_parser":
+			err := json.Unmarshal(v, &dm.DefaultDateTimeParser)
+			if err != nil {
+				return err
+			}
 		case "properties":
 			err := json.Unmarshal(v, &dm.Properties)
 			if err != nil {
@@ -304,6 +318,22 @@ func (dm *DocumentMapping) defaultAnalyzerName(path []string) string {
 		}
 		if current.DefaultAnalyzer != "" {
 			rv = current.DefaultAnalyzer
+		}
+	}
+	return rv
+}
+
+func (dm *DocumentMapping) defaultDateTimeParser(path []string) string {
+	current := dm
+	rv := current.DefaultDateTimeParser
+	for _, pathElement := range path {
+		var ok bool
+		current, ok = current.Properties[pathElement]
+		if !ok {
+			break
+		}
+		if current.DefaultDateTimeParser != "" {
+			rv = current.DefaultDateTimeParser
 		}
 	}
 	return rv

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -17,6 +17,7 @@ package mapping
 import (
 	"encoding/json"
 	"fmt"
+
 	index "github.com/blevesearch/bleve_index_api"
 
 	"github.com/blevesearch/bleve/v2/analysis"
@@ -417,17 +418,40 @@ func (im *IndexMappingImpl) DateTimeParserNamed(name string) analysis.DateTimePa
 	return dateTimeParser
 }
 
-func (im *IndexMappingImpl) datetimeParserNameForPath(path string) string {
-
+func (im *IndexMappingImpl) DatetimeParserNameForPath(path string) string {
 	// first we look for explicit mapping on the field
 	for _, docMapping := range im.TypeMapping {
-		pathMapping, _ := docMapping.documentMappingForPath(path)
-		if pathMapping != nil {
-			if len(pathMapping.Fields) > 0 {
-				if pathMapping.Fields[0].Analyzer != "" {
-					return pathMapping.Fields[0].Analyzer
-				}
+		dateTimeParser := docMapping.dateTimeParserForPath(path)
+		if dateTimeParser != "" {
+			return dateTimeParser
+		}
+	}
+
+	// now try the default mapping
+	pathMapping, _ := im.DefaultMapping.documentMappingForPath(path)
+	if pathMapping != nil {
+		if len(pathMapping.Fields) > 0 {
+			if pathMapping.Fields[0].DateFormat != "" {
+				return pathMapping.Fields[0].DateFormat
 			}
+		}
+	}
+
+	// next we will try default date-time parsers for the path
+	pathDecoded := decodePath(path)
+	for _, docMapping := range im.TypeMapping {
+		if docMapping.Enabled {
+			rv := docMapping.defaultDateTimeParser(pathDecoded)
+			if rv != "" {
+				return rv
+			}
+		}
+	}
+	// now the default date-time parser for the default mapping
+	if im.DefaultMapping.Enabled {
+		rv := im.DefaultMapping.defaultDateTimeParser(pathDecoded)
+		if rv != "" {
+			return rv
 		}
 	}
 

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -49,6 +49,7 @@ type IndexMapping interface {
 	MapDocument(doc *document.Document, data interface{}) error
 	Validate() error
 
+	DatetimeParserNameForPath(path string) string
 	DateTimeParserNamed(name string) analysis.DateTimeParser
 
 	DefaultSearchField() string

--- a/search/query/date_range.go
+++ b/search/query/date_range.go
@@ -46,8 +46,8 @@ var MinRFC3339NanoCompatibleTime time.Time
 var MaxRFC3339NanoCompatibleTime time.Time
 
 func init() {
-	MinRFC3339NanoCompatibleTime, _ = time.Parse(time.RFC3339Nano, "1677-12-01T00:00:00.999999999Z")
-	MaxRFC3339NanoCompatibleTime, _ = time.Parse(time.RFC3339Nano, "2262-04-11T11:59:59.999999999Z")
+	MinRFC3339NanoCompatibleTime, _ = time.Parse(time.RFC3339Nano, "1677-12-01T00:00:00.000000000Z")
+	MaxRFC3339NanoCompatibleTime, _ = time.Parse(time.RFC3339Nano, "2262-04-11T11:59:59.000000000Z")
 }
 
 func queryTimeFromString(t string) (time.Time, error) {

--- a/search/query/date_range_test.go
+++ b/search/query/date_range_test.go
@@ -119,8 +119,8 @@ func TestValidateDatetimeRanges(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		startTime, _ := time.Parse(time.RFC3339, test.start)
-		endTime, _ := time.Parse(time.RFC3339, test.end)
+		startTime, _ := time.Parse(time.RFC3339Nano, test.start)
+		endTime, _ := time.Parse(time.RFC3339Nano, test.end)
 
 		dateRangeQuery := NewDateRangeQuery(startTime, endTime)
 		if (dateRangeQuery.Validate() == nil) != test.expect {

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -186,7 +186,7 @@ func ParseQuery(input []byte) (Query, error) {
 	_, hasEnd := tmp["end"]
 	if hasStart || hasEnd {
 		var rv DateRangeQuery
-		err := json.Unmarshal(input, &rv)
+		err := DateRangeUnmarshal(input, &rv)
 		if err != nil {
 			return nil, err
 		}

--- a/search/query/query_test.go
+++ b/search/query/query_test.go
@@ -174,14 +174,6 @@ func TestParseQuery(t *testing.T) {
 			}(),
 		},
 		{
-			input: []byte(`{"start":"` + startDateStr + `","end":"` + endDateStr + `","field":"desc"}`),
-			output: func() Query {
-				q := NewDateRangeQuery(startDate, endDate)
-				q.SetField("desc")
-				return q
-			}(),
-		},
-		{
 			input: []byte(`{"prefix":"budwei","field":"desc"}`),
 			output: func() Query {
 				q := NewPrefixQuery("budwei")


### PR DESCRIPTION
## Jira

1. [MB-57972](https://issues.couchbase.com/browse/MB-57972)
2. [MB-58034](https://issues.couchbase.com/browse/MB-58034)
3. [MB-57973](https://issues.couchbase.com/browse/MB-57973)
4. [MB-58033](https://issues.couchbase.com/browse/MB-58033)

## Description

- [ ] MB-57972

Currently in Couchbase sample datasets:
1. gamesim-sample: No date fields are there
2. travel-sample: A reviews.date field is there with the layout YYYY:MM:DD HH:MM:SS Offset
3. beer-sample: A date field is there with layout YYYY:MM:DD HH:MM:SS
 
A default mapping (uncustomized) will use dateTimeOptional which has layouts to parse beer-sample but not travel-sample, because of this the user needs to set a custom date time parser to do a date-range query on travel sample. To avoid this and enchance UX, add YYYY:MM:DD HH:MM:SS Offset layout to dateTimeOptional

- [ ] MB-58034

The ParseQuery function, that un-marshalls a query struct (given as a byte slice) given from Couchbase Server uses the default UnMarshallJSON for BleveQueryTime, which basically enforces the usage of RFC3339 date time parse format, which essentially negates any custom date time parser that the user sets in the index mapping, either for the queried field or in the default mappings etc. The idea this PR puts is the following:

1. A User Path, where a bleve-only user sets the index mapping etc, this path remains wholly unchanged, since the API requires the bleve-only user to give a valid time.Time object to create a DateRange query to begin with, so no issues in parse and all. The bleve only user should be able to perform the json Marshal Unmarshall cycle without any difference in usage. This is because this issue is not observed for bleve-only users.
2. A ParseQuery path, which is followed in the Couchbase area, where cbft repo calls the ParseQuery() API, to unmarshall the []byte given in the "query" part of the cbft.SearchRequest. This shoul NOT call the same UnmarshallJSON called in user path, since default RFC3339 will be applied. Instead we call a custom JSON unmarshaller, which saves the raw start and end strings without parsing, and during the searcher phase we see the index mapping, get the custom field - specific date time parser and THEN convert the raw strings to time.Time objects, after which the workflow remains the same.

Hence this achieves - no change to bleve only users but improvement for couchbase

- [ ] MB-57973

Currently user does not receive any feedback if the custom date time parser input by him is valid or not. These custom parsers must only contain magic numbers/ constants specified in https://pkg.go.dev/time#pkg-constants else it is not valid even though no error is returned buy the time package. The input validation here ensures only valid magic numbers are used.

- [ ] MB-58033

New format for custom date time parsers
