### PR TITLE
Replacing deprecated io/ioutil functions

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ package bleve
 
 import (
 	"expvar"
-	"io/ioutil"
+	"io"
 	"log"
 	"time"
 
@@ -86,10 +86,10 @@ func init() {
 	initDisk()
 }
 
-var logger = log.New(ioutil.Discard, "bleve", log.LstdFlags)
+var logger = log.New(io.Discard, "bleve", log.LstdFlags)
 
 // SetLog sets the logger used for logging
-// by default log messages are sent to ioutil.Discard
+// by default log messages are sent to io.Discard
 func SetLog(l *log.Logger) {
 	logger = l
 }

--- a/http/util.go
+++ b/http/util.go
@@ -17,7 +17,6 @@ package http
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -42,10 +41,10 @@ func mustEncode(w io.Writer, i interface{}) {
 
 type varLookupFunc func(req *http.Request) string
 
-var logger = log.New(ioutil.Discard, "bleve.http", log.LstdFlags)
+var logger = log.New(io.Discard, "bleve.http", log.LstdFlags)
 
 // SetLog sets the logger used for logging
-// by default log messages are sent to ioutil.Discard
+// by default log messages are sent to io.Discard
 func SetLog(l *log.Logger) {
 	logger = l
 }

--- a/index_test.go
+++ b/index_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -828,7 +828,7 @@ func TestSlowSearch(t *testing.T) {
 
 	defer func() {
 		// reset logger back to normal
-		SetLog(log.New(ioutil.Discard, "bleve", log.LstdFlags))
+		SetLog(log.New(io.Discard, "bleve", log.LstdFlags))
 	}()
 	// set custom logger
 	var sdw sawDataWriter

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -15,7 +15,7 @@
 package mapping
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/blevesearch/bleve/v2/analysis"
@@ -37,10 +37,10 @@ type bleveClassifier interface {
 	BleveType() string
 }
 
-var logger = log.New(ioutil.Discard, "bleve mapping ", log.LstdFlags)
+var logger = log.New(io.Discard, "bleve mapping ", log.LstdFlags)
 
 // SetLog sets the logger used for logging
-// by default log messages are sent to ioutil.Discard
+// by default log messages are sent to io.Discard
 func SetLog(l *log.Logger) {
 	logger = l
 }

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -26,10 +26,10 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
-var logger = log.New(ioutil.Discard, "bleve mapping ", log.LstdFlags)
+var logger = log.New(io.Discard, "bleve mapping ", log.LstdFlags)
 
 // SetLog sets the logger used for logging
-// by default log messages are sent to ioutil.Discard
+// by default log messages are sent to io.Discard
 func SetLog(l *log.Logger) {
 	logger = l
 }


### PR DESCRIPTION
I think it would be better to change the io/ioutil package to the os package.
Please check the [link](https://go.dev/doc/go1.16#ioutil) and code and thank you.

Bleve search is using go 1.19 so I think it is better not to use io/ioutil package.