### PR TITLE
index/upsidedown: fix dropped error

### DIFF
--- a/index/upsidedown/row.go
+++ b/index/upsidedown/row.go
@@ -880,6 +880,9 @@ func NewStoredRowK(key []byte) (*StoredRow, error) {
 	}
 
 	rv.doc, err = buf.ReadBytes(ByteSeparator)
+	if err != nil {
+		return nil, err
+	}
 	if len(rv.doc) < 2 { // 1 for min doc id length, 1 for separator
 		err = fmt.Errorf("invalid doc length 0")
 		return nil, err


### PR DESCRIPTION
This fixes a dropped `err` variable in `index/upsidedown`.