### PR TITLE
search/searcher: fix dropped test errors

### DIFF
--- a/search/searcher/search_boolean_test.go
+++ b/search/searcher/search_boolean_test.go
@@ -205,6 +205,9 @@ func TestBooleanSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 	conjunctionSearcher7, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher7, booleanSearcher7}, explainTrue)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// test 7
 	beerTermSearcher8, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -378,7 +378,7 @@ func testScorchCompositeSearchOptimizationsHelper(
 
 		next, err := cs.Next(ctx)
 		i := 0
-		for err == nil && next != nil {
+		for next != nil {
 			docID, err := indexReader.ExternalID(next.IndexInternalID)
 			if err != nil {
 				t.Fatal(err)
@@ -391,8 +391,10 @@ func testScorchCompositeSearchOptimizationsHelper(
 					t.Errorf("missing %s", string(docID))
 				}
 			}
-
 			next, err = cs.Next(ctx)
+			if err != nil {
+				t.Fatalf("error iterating searcher: %v", err)
+			}
 			i++
 		}
 

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -244,7 +244,7 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 	}
 	next, err := searcher.Next(ctx)
 	i := 0
-	for err == nil && next != nil {
+	for next != nil {
 		extId, err := scorchReader.ExternalID(next.IndexInternalID)
 		if err != nil {
 			t.Fatal(err)
@@ -252,10 +252,10 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 		got = append(got, extId)
 		ctx.DocumentMatchPool.Put(next)
 		next, err = searcher.Next(ctx)
+		if err != nil {
+			t.Fatalf("error iterating searcher: %v", err)
+		}
 		i++
-	}
-	if err != nil {
-		t.Fatalf("error iterating searcher: %v", err)
 	}
 	err = searcher.Close()
 	if err != nil {


### PR DESCRIPTION
This fixes three dropped `err` variables in the tests for `search/searcher`.

The missing `err` in `TestBooleanSearch()` was simply omitted. The mishandled `err` variables in `testScorchCompositeSearchOptimizationsHelper()` and `TestTermRangeSearchTooManyTerms()` were being redefined with a `:-=` inside a for loop, so both were lost before the `if err != nil` test outside the loop.