### PR TITLE
MB-35347: Synonym Search

### DIFF
--- a/analysis/synonym/synonym.go
+++ b/analysis/synonym/synonym.go
@@ -1,0 +1,65 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synonym
+
+import (
+	"fmt"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/registry"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+const Name = "textsynonym"
+
+type SynonymSource struct {
+	collection string
+	analyzer   string
+}
+
+func New(collection string, analyzer string) *SynonymSource {
+	return &SynonymSource{
+		collection: collection,
+		analyzer:   analyzer,
+	}
+}
+
+func (p *SynonymSource) Collection() string {
+	return p.collection
+}
+
+func (p *SynonymSource) Analyzer() string {
+	return p.analyzer
+}
+
+func (q *SynonymSource) MetadataKey() string {
+	return q.collection + string(index.SynonymKeySeparator) + q.analyzer
+}
+
+func SynonymSourceConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.SynonymSource, error) {
+	collection, ok := config["collection"].(string)
+	if !ok {
+		return nil, fmt.Errorf("must specify synonym collection")
+	}
+	analyzer, ok := config["analyzer"].(string)
+	if !ok {
+		return nil, fmt.Errorf("must specify synonym analyzer")
+	}
+	return New(collection, analyzer), nil
+}
+
+func init() {
+	registry.RegisterSynonymSource(Name, SynonymSourceConstructor)
+}

--- a/analysis/token/synonym/synonym.go
+++ b/analysis/token/synonym/synonym.go
@@ -1,0 +1,485 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synonym
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/registry"
+	"github.com/blevesearch/bleve/v2/search"
+	index "github.com/blevesearch/bleve_index_api"
+	"github.com/blevesearch/vellum"
+)
+
+const Name = "synonym"
+
+const SeparatingCharacter = ' '
+
+type SynonymFilter struct {
+	metadata  []*index.SynonymMetadata
+	fuzziness int
+	prefix    int
+}
+
+// fstPath is used for storing the data associated
+// with a particular path in the FST. This would be used for enabling
+// fuzzy search in the synonym filter.
+type fstPath struct {
+	// output is the sum of the outputs of all the states seen in the path
+	output uint64
+	// state is the state at the end of the path
+	state int
+	// word is the sequence of characters that were matched in the path
+	word []byte
+}
+
+func resetPath(path *fstPath) *fstPath {
+	path.output = 0
+	path.state = 0
+	path.word = path.word[:0]
+	return path
+}
+
+var pathPool = sync.Pool{
+	New: func() interface{} { return new(fstPath) },
+}
+
+// check if the input FST path ends with a word.
+// A word in the FST is defined as a sequence of characters that is either not followed by any other character
+// or is followed by a space.
+// This function is used for enabling fuzzy search in the synonym filter.
+func pathEndsWithWord(path *fstPath, fst *vellum.FST) (bool, error) {
+	spaceAccept := fst.Accept(path.state, SeparatingCharacter)
+	numEdges, err := fst.GetNumTransitionsForState(path.state)
+	if err != nil {
+		return false, err
+	}
+	// if, at the current state of the input FST path, there is a transition available for space, or
+	// if there is no transition available, the path ends with a word.
+	return spaceAccept != 1 || numEdges == 0, nil
+}
+
+// This function performs a DFS from the state present in the input FST path.
+// MatchTry is the word that must be fuzzily matched in the FST, starting from path.
+// ValidPaths is the list of valid paths that were found in the FST and if the matchTry is fuzzily matched in
+// the FST, validPaths is appended with the new path that was found.
+// Fuzziness is the maximum Levenshtein distance allowed between matchTry and the word fuzzily matched in the FST.
+//
+// Basic logic followed is as follows:
+//   - At the state in the FST where the character in the input string fails to match,
+//     we start a DFS searching for states that end a word
+//   - which are states that either do not have any outgoing transition or
+//     have a transition for a space
+//   - Since it is a FST, multiple such paths will be found, and each path's word is checked for
+//     edit distance criteria satisfaction before it is added to validPaths
+func fuzzyMatch(path *fstPath, matchTry string, validPaths []*fstPath, fst *vellum.FST, fuzziness int) ([]*fstPath, error) {
+	// stack for iterative DFS
+	pathStack := []*fstPath{path}
+	var pathIsValid bool
+	for len(pathStack) > 0 {
+		path = pathStack[len(pathStack)-1]
+		pathStack = pathStack[:len(pathStack)-1]
+		pathIsValid = false
+		// if input FST path ends with a word and if the word fuzzily matches the matchTry, append the validPaths with the input FST path.
+		endsWithWord, err := pathEndsWithWord(path, fst)
+		if err != nil {
+			return nil, err
+		}
+		if endsWithWord {
+			if search.LevenshteinDistance(string(path.word), matchTry) <= fuzziness {
+				validPaths = append(validPaths, path)
+				pathIsValid = true
+			}
+		}
+		// perform a DFS from the current state of the input FST path.
+		// even if the path ends with a word, the DFS is performed since there there may be
+		// another transition apart from a space at the state in the path.
+		//
+		// this condition is a shortcut to discard certain fst paths where it becomes known that the word
+		// will have a edit distance > fuzziness to matchTry, as path does not end with a word and
+		// path.word is already exceeding len(matchTry) by 'fuzziness' amount and any further
+		// exploration along this path will need removal of characters >'fuzziness'
+		if len(path.word)-len(matchTry) <= fuzziness {
+			transitions, err := fst.GetTransitionsForState(path.state)
+			if err != nil {
+				return nil, err
+			}
+			// for each transition from the current state of the input FST path, perform a DFS.
+			// if the transition is not a space, get a new  fstPath from the pool, and insert it
+			// into the stack with the updated parameters
+			for _, character := range transitions {
+				if character != SeparatingCharacter {
+					newState, newOutput := fst.AcceptWithVal(path.state, character)
+					newPath := pathPool.Get().(*fstPath)
+					newPath.state, newPath.output, newPath.word = newState, path.output+newOutput, append(path.word, character)
+					pathStack = append(pathStack, newPath)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+		// only discard fstPath if it was not added to validPaths
+		if !pathIsValid {
+			pathPool.Put(resetPath(path))
+		}
+	}
+	return validPaths, nil
+}
+
+// acceptSpaces is a helper function that accepts a sequence of spaces in the input FST path.
+// if the desired number of spaces is found, the state and output of the input FST path are updated
+// and the input FST path is returned.
+func acceptSpaces(numSpaces int, path *fstPath, fst *vellum.FST) *fstPath {
+	numAcceptedSpaces := 0
+	state := path.state
+	var tmp uint64
+	for numAcceptedSpaces < numSpaces {
+		state, tmp = fst.AcceptWithVal(state, SeparatingCharacter)
+		if state == 1 {
+			return nil
+		}
+		path.output += tmp
+		numAcceptedSpaces++
+	}
+	path.state = state
+	return path
+}
+
+// checkForMatch is a function that checks if a sequence of tokens starting from inputIndex in the input
+// token stream matches a phrase in the FST.
+// if a match is found, the function returns the new value to be assigned to inputIndex in the Filter, which is
+// index of the last matched token, along with the list of synonyms found for the matched phrase.
+// The position of the first word and the position of the last word in the matched phrase are also returned.
+// Greedy matching is used to find the longest sequence of input tokens that matches a phrase in the FST.
+// Two types of matches are possible for a word in the FST:
+//  1. Exact match: the word in the FST matches the word in the input token stream exactly.
+//  2. Fuzzy match: the word in the FST matches the word in the input token stream with a Levenshtein distance
+//     less than or equal to the fuzziness parameter.
+func (s *SynonymFilter) checkForMatch(input analysis.TokenStream, inputIndex int, fst *vellum.FST,
+	metadata *index.SynonymMetadata) ([]uint64, int, error) {
+
+	numTokensConsumed := 0
+	var rv []uint64
+	var validPaths []*fstPath
+	var tokenLen, matchLen, pathIndex int
+	var err error
+	// since a token can fuzzily match multiple words in the FST, a slice of valid paths is maintained.
+	// with each valid path representing a sequence of transitions in the FST that starts from the start state.
+	// for every input token, all the valid paths are checked for an exact match or a fuzzy match.
+	startPath := pathPool.Get().(*fstPath)
+	startPath.state, startPath.output, startPath.word = fst.Start(), 0, nil
+	validPaths = append(validPaths, startPath)
+	numValidPaths := len(validPaths)
+	prevPos := input[inputIndex].Position
+	for inputIndex < len(input) {
+		// check how many stop words are present between the current token and the previous token.
+		// the number of stop words is the number of times a FST path accepts the space character
+		// this code block will be executed only after the first token is exactly or fuzzily matched.
+		numStopWords := input[inputIndex].Position - prevPos - 1
+		if numStopWords > 0 {
+			pathIndex = 0
+			for _, path := range validPaths {
+				rv := acceptSpaces(numStopWords, path, fst)
+				if rv != nil {
+					validPaths[pathIndex] = rv
+					pathIndex++
+				} else {
+					pathPool.Put(resetPath(path))
+				}
+			}
+			validPaths = validPaths[:pathIndex]
+			numValidPaths = len(validPaths)
+		}
+		pathIndex = 0
+		// for each valid path, check if the current token is exactly or fuzzily matched.
+		for pathIndex < numValidPaths {
+			tokenLen = len(input[inputIndex].Term)
+			matchLen = 0
+			path := validPaths[pathIndex]
+			for _, character := range input[inputIndex].Term {
+				newState, output := fst.AcceptWithVal(path.state, character)
+				if newState == 1 {
+					// if the current token is not exactly matched, check if it is fuzzily matched, if
+					// fuzziness is not 0 and if the match length is greater than or equal to the prefix length.
+					// if the current token is fuzzily matched, append the validPaths with the
+					// set of new paths that are found.
+					if s.fuzziness != 0 && matchLen >= s.prefix {
+						validPaths, err = fuzzyMatch(path, string(input[inputIndex].Term),
+							validPaths, fst, s.fuzziness)
+						if err != nil {
+							return nil, 0, err
+						}
+					}
+					break
+				} else {
+					matchLen++
+					path.state = newState
+					path.output += output
+					path.word = append(path.word, character)
+				}
+			}
+			// if the current token is exactly matched, check if the path ends with a word.
+			// this is done so that the path is not considered as a valid path if the current token
+			// is a prefix of a word in the FST.
+			if matchLen == tokenLen {
+				endsWithWord, err := pathEndsWithWord(path, fst)
+				if err != nil {
+					return nil, 0, err
+				}
+				if endsWithWord {
+					validPaths = append(validPaths, path)
+				} else {
+					// since the path does not end with a word try to auto-complete the token
+					// by calling the fuzzyMatch function.
+					// example - if the token is "foo" and the FST contains "foobar", "foobaz" and "foobuzz",
+					// the token "foo" will be auto-completed to "foobar", "foobaz" and "foobuzz".
+					// provided fuzziness is set to 3.
+					if s.fuzziness != 0 && matchLen >= s.prefix {
+						validPaths, err = fuzzyMatch(path, string(input[inputIndex].Term),
+							validPaths, fst, s.fuzziness)
+						if err != nil {
+							return nil, 0, err
+						}
+					}
+				}
+			}
+			pathIndex++
+		}
+		// filter out the valid paths from the previous iteration.
+		validPaths = validPaths[numValidPaths:]
+		prevPos = input[inputIndex].Position
+		numTokensConsumed++
+		inputIndex++
+		var seenSynonyms []uint64
+		matchFound := false
+		pathIndex = 0
+		// for each valid path, if the state is a matching state, append the seenSynonyms with the synonyms
+		// by using the output of the path as the key to the hashToSynonyms map.
+		// filter out all paths that do not have a transition for space from the current state and since each
+		// valid path ends with a word in the FST, the "dead-ends", or the paths that do not have any transition
+		// from the current state are filtered out.
+		for _, path := range validPaths {
+			isMatch, finalOutput := fst.IsMatchWithVal(path.state)
+			hashedLHS := path.output + finalOutput
+			if isMatch && !metadata.HashToPhrase[hashedLHS].IsInvalid {
+				for _, RHS := range metadata.HashToSynonyms[hashedLHS] {
+					if !RHS.IsInvalid {
+						seenSynonyms = append(seenSynonyms, RHS.Hash)
+					}
+				}
+				seenSynonyms = append(seenSynonyms, hashedLHS)
+				matchFound = true
+			}
+			pathAfterSpace := acceptSpaces(1, path, fst)
+			if pathAfterSpace != nil {
+				validPaths[pathIndex] = pathAfterSpace
+				validPaths[pathIndex].word = nil
+				pathIndex++
+			} else {
+				pathPool.Put(resetPath(path))
+			}
+		}
+		validPaths = validPaths[:pathIndex]
+		// if a match is found, update rv with the newInputIndex, matchedSynonyms
+		if matchFound {
+			rv = seenSynonyms
+		}
+		numValidPaths = len(validPaths)
+		if numValidPaths == 0 {
+			return rv, numTokensConsumed, nil
+		}
+	}
+	return rv, numTokensConsumed, nil
+}
+
+type asyncResult struct {
+	err               error
+	output            []string
+	numTokensConsumed int
+}
+
+func (s *SynonymFilter) parallelFilter(input analysis.TokenStream, metadata *index.SynonymMetadata,
+	inputIdx int, fst *vellum.FST) *asyncResult {
+	rv, numTokensConsumed, err := s.checkForMatch(input, inputIdx, fst, metadata)
+	output := make([]string, len(rv))
+	for i, hash := range rv {
+		output[i] = metadata.HashToPhrase[hash].Phrase
+	}
+	return &asyncResult{
+		output:            output,
+		numTokensConsumed: numTokensConsumed,
+		err:               err,
+	}
+}
+
+func (s *SynonymFilter) Filter(input analysis.TokenStream) analysis.TokenStream {
+	// Load FST data for each metadata
+	allFst, err := loadFSTData(s.metadata)
+	if err != nil {
+		fmt.Printf("error in synonym filter: %v\n", err)
+		return input
+	}
+	var rv analysis.TokenStream
+	idx := 0
+	for idx < len(input) {
+		asyncResults, maxTokensConsumed := s.runParallelFilters(input, allFst, idx)
+		synonyms := s.getSynonymsWithMaxTokensConsumed(asyncResults, maxTokensConsumed)
+		rv = appendSynonymsToResult(rv, input, idx, maxTokensConsumed, synonyms)
+		idx += maxTokensConsumed
+	}
+	return rv
+}
+
+func loadFSTData(metadataList []*index.SynonymMetadata) ([]*vellum.FST, error) {
+	allFst := make([]*vellum.FST, len(metadataList))
+	for i, metadata := range metadataList {
+		fst, err := vellum.Load(metadata.SynonymFST)
+		if err != nil {
+			return nil, err
+		}
+		allFst[i] = fst
+	}
+	return allFst, nil
+}
+
+func (s *SynonymFilter) runParallelFilters(input analysis.TokenStream, allFst []*vellum.FST, idx int) ([]*asyncResult, int) {
+	asyncResults := make([]*asyncResult, len(s.metadata))
+	var maxTokensConsumed int
+	var waitGroup sync.WaitGroup
+	for i, metadata := range s.metadata {
+		waitGroup.Add(1)
+		go func(i int, metadata *index.SynonymMetadata) {
+			asyncResults[i] = s.parallelFilter(input, metadata, idx, allFst[i])
+			waitGroup.Done()
+		}(i, metadata)
+	}
+	waitGroup.Wait()
+	for _, asr := range asyncResults {
+		if asr.err != nil {
+			fmt.Printf("error in synonym filter: %v\n", asr.err)
+			return asyncResults, maxTokensConsumed
+		}
+		if asr.numTokensConsumed > maxTokensConsumed {
+			maxTokensConsumed = asr.numTokensConsumed
+		}
+	}
+	return asyncResults, maxTokensConsumed
+}
+
+func (s *SynonymFilter) getSynonymsWithMaxTokensConsumed(asyncResults []*asyncResult, maxTokensConsumed int) []string {
+	var synonyms []string
+	for _, asr := range asyncResults {
+		if asr.numTokensConsumed == maxTokensConsumed {
+			synonyms = append(synonyms, asr.output...)
+		}
+	}
+	return synonyms
+}
+
+func convertConsumedTokensToPhrase(consumedTokens analysis.TokenStream) *analysis.Token {
+	firstPos := consumedTokens[0].Position
+	lastPos := consumedTokens[len(consumedTokens)-1].Position
+	phrase := make([]string, lastPos-firstPos+1)
+	for _, token := range consumedTokens {
+		phrase[token.Position-firstPos] = string(token.Term)
+	}
+	return &analysis.Token{
+		Term:     []byte(strings.Join(phrase, " ")),
+		Position: consumedTokens[0].Position,
+		Start:    consumedTokens[0].Start,
+		End:      consumedTokens[len(consumedTokens)-1].End,
+		Type:     analysis.Synonym,
+	}
+}
+
+func appendSynonymsToResult(rv analysis.TokenStream, input analysis.TokenStream, idx, maxTokensConsumed int, synonyms []string) analysis.TokenStream {
+	if maxTokensConsumed == 1 {
+		rv = append(rv, input[idx])
+	} else {
+		// convert the consumed tokens to a phrase to be matched by the phrase searcher
+		rv = append(rv, convertConsumedTokensToPhrase(input[idx:idx+maxTokensConsumed]))
+	}
+	for _, i := range synonyms {
+		rv = append(rv, &analysis.Token{
+			Term:     []byte(i),
+			Position: input[idx].Position,
+			Start:    input[idx].Start,
+			End:      input[idx+maxTokensConsumed-1].End,
+			Type:     analysis.Synonym,
+		})
+	}
+	return rv
+}
+
+func SynonymFilterConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.TokenFilter, error) {
+	return &SynonymFilter{}, nil
+}
+
+func NewSynonymTokenFilter(metadata []*index.SynonymMetadata, fuzziness int, prefix int) *SynonymFilter {
+	return &SynonymFilter{
+		metadata:  metadata,
+		fuzziness: fuzziness,
+		prefix:    prefix,
+	}
+}
+
+func AddSynonymFilter(ctx context.Context, analyzer analysis.Analyzer, i index.IndexReader,
+	key, synonymSourceName string, fuzziness, prefix int) (analysis.Analyzer, error) {
+
+	synMD, err := getSynonymMetadata(ctx, synonymSourceName, key, i)
+	if err != nil {
+		return nil, err
+	}
+
+	synonymTokenFilter := NewSynonymTokenFilter(synMD, fuzziness, prefix)
+	return &analysis.ExtendedAnalyzer{
+		BaseAnalyzer:      analyzer,
+		ExtraTokenFilters: []analysis.TokenFilter{synonymTokenFilter},
+	}, nil
+}
+
+func getSynonymMetadata(ctx context.Context, synonymSourceName, key string, i index.IndexReader) ([]*index.SynonymMetadata, error) {
+	if searchSynMD := ctx.Value(search.ScatterSynonymMetadataKey); searchSynMD != nil {
+		// all required synonym data is already available in the context
+		// so we can just use it
+		var synSources []byte
+		var ok bool
+		if synSources, ok = searchSynMD.([]byte); !ok {
+			return nil, fmt.Errorf("invalid synonym metadata: data in context must be []byte")
+		}
+
+		var extData map[string][]*index.SynonymMetadata
+		if err := json.Unmarshal(synSources, &extData); err != nil {
+			return nil, fmt.Errorf("error unmarshalling synonym metadata: %v", err)
+		}
+
+		if rv, ok := extData[synonymSourceName]; ok {
+			return rv, nil
+		}
+
+		return nil, fmt.Errorf("no synonym metadata found for synonym source: %s", synonymSourceName)
+	}
+	return i.SynonymMetadata(key)
+}
+
+func init() {
+	registry.RegisterTokenFilter(Name, SynonymFilterConstructor)
+}

--- a/cmd/bleve/cmd/registry.go
+++ b/cmd/bleve/cmd/registry.go
@@ -54,6 +54,9 @@ var registryCmd = &cobra.Command{
 		types, instances = registry.DateTimeParserTypesAndInstances()
 		printType("Date Time Parser", types, instances)
 
+		types, instances = registry.SynonymSourceTypesAndInstances()
+		printType("Synonym Source", types, instances)
+
 		types, instances = registry.KVStoreTypesAndInstances()
 		printType("KV Store", types, instances)
 

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,9 @@ import (
 	_ "github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/nanoseconds"
 	_ "github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/seconds"
 
+	// synonym sources
+	_ "github.com/blevesearch/bleve/v2/analysis/synonym"
+
 	// languages
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/ar"
 	_ "github.com/blevesearch/bleve/v2/analysis/lang/bg"

--- a/document/field_synonym.go
+++ b/document/field_synonym.go
@@ -1,0 +1,147 @@
+//  Copyright (c) 2022 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package document
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+
+	"github.com/blevesearch/bleve/v2/size"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+var reflectStaticSizeSynonymField int
+
+func init() {
+	var f SynonymField
+	reflectStaticSizeSynonymField = int(reflect.TypeOf(f).Size())
+}
+
+type SynonymField struct {
+	name              string
+	synDef            *index.SynonymDefinition
+	analyzedSynDef    *index.SynonymDefinition
+	analyzer          analysis.Analyzer
+	options           index.FieldIndexingOptions
+	numPlainTextBytes uint64
+	length            int
+	value             []byte
+}
+
+func (n *SynonymField) Size() int {
+	return reflectStaticSizeSynonymField + size.SizeOfPtr +
+		len(n.name)
+}
+
+func (n *SynonymField) Name() string {
+	return n.name
+}
+
+func (n *SynonymField) NumPlainTextBytes() uint64 {
+	return n.numPlainTextBytes
+}
+
+func (n *SynonymField) ArrayPositions() []uint64 {
+	return nil
+}
+
+func (n *SynonymField) Options() index.FieldIndexingOptions {
+	return n.options
+}
+
+func (n *SynonymField) Value() []byte {
+	return n.value
+}
+
+func (n *SynonymField) EncodedFieldType() byte {
+	return 'y'
+}
+
+func (n *SynonymField) AnalyzedLength() int {
+	return n.length
+}
+
+func (n *SynonymField) AnalyzedTokenFrequencies() index.TokenFrequencies {
+	return nil
+}
+
+// This function is used to convert the token stream to a phrase by using the
+// position attribute of the tokens for example if the token stream is
+// "hello world" and the position of hello is 2 and world is 4 then the phrase
+// will be ["hello","","world"]
+// This would essentially maintain the number of stop words between two
+// normal words and maintain the order of the words while also stripping
+// stop words at the end and start of the phrase.
+func tokenStreamToPhrase(tokens analysis.TokenStream) []string {
+	firstPosition := int(^uint(0) >> 1)
+	lastPosition := 0
+	for _, token := range tokens {
+		if token.Position < firstPosition {
+			firstPosition = token.Position
+		}
+		if token.Position > lastPosition {
+			lastPosition = token.Position
+		}
+	}
+	phraseLen := lastPosition - firstPosition + 1
+	rv := make([]string, phraseLen)
+	if phraseLen > 0 {
+		for _, token := range tokens {
+			pos := token.Position - firstPosition
+			rv[pos] = string(token.Term)
+		}
+	}
+	return rv
+}
+
+// applies an analyzer to each string in a slice and returns the result slice.
+// if the analyzer is nil, the original slice is returned.
+func analyzeSlice(analyzer analysis.Analyzer, slice []string) []string {
+	if analyzer == nil {
+		return slice
+	}
+	loc := 0
+	rv := make([]string, len(slice))
+	for _, val := range slice {
+		analyzedPhrase := tokenStreamToPhrase(analyzer.Analyze([]byte(val)))
+		result := strings.Join(analyzedPhrase, " ")
+		rv[loc] = result
+		loc++
+	}
+	return rv
+}
+
+func (n *SynonymField) Analyze() {
+	n.analyzedSynDef = &index.SynonymDefinition{
+		MappingType: n.synDef.MappingType,
+		Input:       analyzeSlice(n.analyzer, n.synDef.Input),
+		Synonyms:    analyzeSlice(n.analyzer, n.synDef.Synonyms),
+	}
+}
+
+func (n *SynonymField) AnalyzedSynonymDefinition() *index.SynonymDefinition {
+	return n.analyzedSynDef
+}
+
+func NewSynonymField(metadataKey string, synDef *index.SynonymDefinition, analyzer analysis.Analyzer, collection string) *SynonymField {
+	return &SynonymField{
+		name:     metadataKey,
+		synDef:   synDef,
+		analyzer: analyzer,
+		options:  index.IndexField,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -41,3 +41,11 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 )
+
+replace github.com/blevesearch/vellum => ../vellum
+
+replace github.com/blevesearch/zapx/v15 => ../zap
+
+replace github.com/blevesearch/bleve_index_api => ../bleve_index_api
+
+replace github.com/blevesearch/scorch_segment_api/v2 => ../scorch_segment_api

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/RoaringBitmap/roaring v1.2.3 h1:yqreLINqIrX22ErkKI0vY47/ivtJr6n+kMhVO
 github.com/RoaringBitmap/roaring v1.2.3/go.mod h1:plvDsJQpxOC5bw8LRteu/MLWHsHez/3y6cubLI4/1yE=
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/blevesearch/bleve_index_api v1.0.6 h1:gyUUxdsrvmW3jVhhYdCVL6h9dCjNT/geNU7PxGn37p8=
-github.com/blevesearch/bleve_index_api v1.0.6/go.mod h1:YXMDwaXFFXwncRS8UobWs7nvo0DmusriM1nztTlj1ms=
 github.com/blevesearch/geo v0.1.18 h1:Np8jycHTZ5scFe7VEPLrDoHnnb9C4j636ue/CGrhtDw=
 github.com/blevesearch/geo v0.1.18/go.mod h1:uRMGWG0HJYfWfFJpK3zTdnnr1K+ksZTuWKhXeSokfnM=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
@@ -17,8 +15,6 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
-github.com/blevesearch/scorch_segment_api/v2 v2.1.6 h1:CdekX/Ob6YCYmeHzD72cKpwzBjvkOGegHOqhAkXp6yA=
-github.com/blevesearch/scorch_segment_api/v2 v2.1.6/go.mod h1:nQQYlp51XvoSVxcciBjtvuHPIVjlWrN1hX4qwK2cqdc=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -29,8 +25,6 @@ github.com/blevesearch/stempel v0.2.0 h1:CYzVPaScODMvgE9o+kf6D4RJ/VRomyi9uHF+PtB
 github.com/blevesearch/stempel v0.2.0/go.mod h1:wjeTHqQv+nQdbPuJ/YcvOjTInA2EIc6Ks1FoSUzSLvc=
 github.com/blevesearch/upsidedown_store_api v1.0.2 h1:U53Q6YoWEARVLd1OYNc9kvhBMGZzVrdmaozG2MfoB+A=
 github.com/blevesearch/upsidedown_store_api v1.0.2/go.mod h1:M01mh3Gpfy56Ps/UXHjEO/knbqyQ1Oamg8If49gRwrQ=
-github.com/blevesearch/vellum v1.0.10 h1:HGPJDT2bTva12hrHepVT3rOyIKFFF4t7Gf6yMxyMIPI=
-github.com/blevesearch/vellum v1.0.10/go.mod h1:ul1oT0FhSMDIExNjIxHqJoGpVrBpKCdgDQNxfqgJt7k=
 github.com/blevesearch/zapx/v11 v11.3.10 h1:hvjgj9tZ9DeIqBCxKhi70TtSZYMdcFn7gDb71Xo/fvk=
 github.com/blevesearch/zapx/v11 v11.3.10/go.mod h1:0+gW+FaE48fNxoVtMY5ugtNHHof/PxCqh7CnhYdnMzQ=
 github.com/blevesearch/zapx/v12 v12.3.10 h1:yHfj3vXLSYmmsBleJFROXuO08mS3L1qDCdDK81jDl8s=
@@ -39,8 +33,6 @@ github.com/blevesearch/zapx/v13 v13.3.10 h1:0KY9tuxg06rXxOZHg3DwPJBjniSlqEgVpxIq
 github.com/blevesearch/zapx/v13 v13.3.10/go.mod h1:w2wjSDQ/WBVeEIvP0fvMJZAzDwqwIEzVPnCPrz93yAk=
 github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz77pSwwKU=
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
-github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
-github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -361,7 +361,7 @@ func (s *Scorch) Delete(id string) error {
 	return s.Batch(b)
 }
 
-// Batch applices a batch of changes to the index atomically
+// Batch applies a batch of changes to the index atomically
 func (s *Scorch) Batch(batch *index.Batch) (err error) {
 	start := time.Now()
 

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2/document"
 	index "github.com/blevesearch/bleve_index_api"
-	"github.com/blevesearch/upsidedown_store_api"
+	store "github.com/blevesearch/upsidedown_store_api"
 )
 
 var reflectStaticSizeIndexReader int
@@ -62,6 +62,10 @@ func (i *IndexReader) FieldDictPrefix(fieldName string, termPrefix []byte) (inde
 
 func (i *IndexReader) DocIDReaderAll() (index.DocIDReader, error) {
 	return newUpsideDownCouchDocIDReader(i)
+}
+
+func (i *IndexReader) SynonymMetadata(field string) ([]*index.SynonymMetadata, error) {
+	return nil, nil
 }
 
 func (i *IndexReader) DocIDReaderOnly(ids []string) (index.DocIDReader, error) {

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -1249,6 +1249,9 @@ type stubIndex struct {
 func (i *stubIndex) Index(id string, data interface{}) error {
 	return i.err
 }
+func (i *stubIndex) IndexSynonym(collection string, id string, data []byte) error {
+	return i.err
+}
 
 func (i *stubIndex) Delete(id string) error {
 	return i.err

--- a/mapping/analysis.go
+++ b/mapping/analysis.go
@@ -21,6 +21,7 @@ type customAnalysis struct {
 	TokenFilters    map[string]map[string]interface{} `json:"token_filters,omitempty"`
 	Analyzers       map[string]map[string]interface{} `json:"analyzers,omitempty"`
 	DateTimeParsers map[string]map[string]interface{} `json:"date_time_parsers,omitempty"`
+	SynonymSources  map[string]map[string]interface{} `json:"synonym_sources,omitempty"`
 }
 
 func (c *customAnalysis) registerAll(i *IndexMappingImpl) error {
@@ -83,6 +84,12 @@ func (c *customAnalysis) registerAll(i *IndexMappingImpl) error {
 			return err
 		}
 	}
+	for name, config := range c.SynonymSources {
+		_, err := i.cache.DefineSynonymSource(name, config)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -94,6 +101,7 @@ func newCustomAnalysis() *customAnalysis {
 		TokenFilters:    make(map[string]map[string]interface{}),
 		Analyzers:       make(map[string]map[string]interface{}),
 		DateTimeParsers: make(map[string]map[string]interface{}),
+		SynonymSources:  make(map[string]map[string]interface{}),
 	}
 	return &rv
 }

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -77,6 +77,16 @@ func (dm *DocumentMapping) Validate(cache *registry.Cache) error {
 				return err
 			}
 		}
+		if field.SynonymSource != "" {
+			synSrc, err := cache.SynonymSourceNamed(field.SynonymSource)
+			if err != nil {
+				return err
+			}
+			_, err = cache.AnalyzerNamed(synSrc.Analyzer())
+			if err != nil {
+				return err
+			}
+		}
 		switch field.Type {
 		case "text", "datetime", "number", "boolean", "geopoint", "geoshape", "IP":
 		default:
@@ -93,6 +103,14 @@ func (dm *DocumentMapping) analyzerNameForPath(path string) string {
 	field := dm.fieldDescribedByPath(path)
 	if field != nil {
 		return field.Analyzer
+	}
+	return ""
+}
+
+func (dm *DocumentMapping) synonymSourceNameForPath(path string) string {
+	field := dm.fieldDescribedByPath(path)
+	if field != nil {
+		return field.SynonymSource
 	}
 	return ""
 }

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -69,6 +69,8 @@ type FieldMapping struct {
 	// the processing of freq/norm details when the default score based relevancy
 	// isn't needed.
 	SkipFreqNorm bool `json:"skip_freq_norm,omitempty"`
+
+	SynonymSource string `json:"synonym_source,omitempty"`
 }
 
 // NewTextFieldMapping returns a default field mapping for text
@@ -445,6 +447,11 @@ func (fm *FieldMapping) UnmarshalJSON(data []byte) error {
 			}
 		case "skip_freq_norm":
 			err := util.UnmarshalJSON(v, &fm.SkipFreqNorm)
+			if err != nil {
+				return err
+			}
+		case "synonym_source":
+			err := json.Unmarshal(v, &fm.SynonymSource)
 			if err != nil {
 				return err
 			}

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -55,4 +55,8 @@ type IndexMapping interface {
 
 	AnalyzerNameForPath(path string) string
 	AnalyzerNamed(name string) analysis.Analyzer
+
+	SynonymSourceNameForPath(path string) string
+	SynonymSourceNamed(name string) analysis.SynonymSource
+	AnalyzersForSynonymCollection(name string) map[string]analysis.Analyzer
 }

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -17,11 +17,12 @@ package mapping
 import (
 	"encoding/json"
 	"fmt"
-	index "github.com/blevesearch/bleve_index_api"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	index "github.com/blevesearch/bleve_index_api"
 
 	"github.com/blevesearch/bleve/v2/analysis/tokenizer/exception"
 	"github.com/blevesearch/bleve/v2/analysis/tokenizer/regexp"

--- a/registry/index_type.go
+++ b/registry/index_type.go
@@ -38,7 +38,7 @@ func IndexTypeConstructorByName(name string) IndexTypeConstructor {
 func IndexTypesAndInstances() ([]string, []string) {
 	var types []string
 	var instances []string
-	for name := range stores {
+	for name := range indexTypes {
 		types = append(types, name)
 	}
 	return types, instances

--- a/registry/synonym_source.go
+++ b/registry/synonym_source.go
@@ -1,0 +1,117 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+)
+
+func RegisterSynonymSource(name string, constructor SynonymSourceConstructor) {
+	_, exists := synonymSources[name]
+	if exists {
+		panic(fmt.Errorf("attempted to register duplicate synonym source named '%s'", name))
+	}
+	synonymSources[name] = constructor
+}
+
+type SynonymSourceConstructor func(config map[string]interface{}, cache *Cache) (analysis.SynonymSource, error)
+type SynonymSourceRegistry map[string]SynonymSourceConstructor
+
+type SynonymSourceCache struct {
+	*ConcurrentCache
+}
+
+func NewSynonymSourceCache() *SynonymSourceCache {
+	return &SynonymSourceCache{
+		NewConcurrentCache(),
+	}
+}
+
+func SynonymSourceBuild(name string, config map[string]interface{}, cache *Cache) (interface{}, error) {
+	cons, registered := synonymSources[name]
+	if !registered {
+		return nil, fmt.Errorf("no synonym source with name or type '%s' registered", name)
+	}
+	synonymSource, err := cons(config, cache)
+	if err != nil {
+		return nil, fmt.Errorf("error building synonym source: %v", err)
+	}
+	return synonymSource, nil
+}
+
+func (c *SynonymSourceCache) SynonymSourceNamed(name string, cache *Cache) (analysis.SynonymSource, error) {
+	item, err := c.ItemNamed(name, cache, SynonymSourceBuild)
+	if err != nil {
+		return nil, err
+	}
+	return item.(analysis.SynonymSource), nil
+}
+
+func (c *SynonymSourceCache) analyzersForCollection(collection string) []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	rv := make([]string, 0, len(c.data))
+	for _, synSource := range c.data {
+		if synSource.(analysis.SynonymSource).Collection() == collection {
+			rv = append(rv, synSource.(analysis.SynonymSource).Analyzer())
+		}
+	}
+	return rv
+}
+
+func (c *SynonymSourceCache) SynonymCollections() []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	collectionSet := make(map[string]struct{})
+	rv := make([]string, 0, len(c.data))
+	for _, synSource := range c.data {
+		collection := synSource.(analysis.SynonymSource).Collection()
+		if _, ok := collectionSet[collection]; !ok {
+			collectionSet[collection] = struct{}{}
+			rv = append(rv, synSource.(analysis.SynonymSource).Collection())
+		}
+	}
+	return rv
+}
+
+func (c *SynonymSourceCache) DefineSynonymSource(name string, typ string, config map[string]interface{}, cache *Cache) (analysis.SynonymSource, error) {
+	item, err := c.DefineItem(name, typ, config, cache, SynonymSourceBuild)
+	if err != nil {
+		if err == ErrAlreadyDefined {
+			return nil, fmt.Errorf("synonym source named '%s' already defined", name)
+		}
+		return nil, err
+	}
+
+	return item.(analysis.SynonymSource), nil
+}
+
+func SynonymSourceTypesAndInstances() ([]string, []string) {
+	emptyConfig := map[string]interface{}{}
+	emptyCache := NewCache()
+	var types []string
+	var instances []string
+	for name, cons := range synonymSources {
+		_, err := cons(emptyConfig, emptyCache)
+		if err == nil {
+			instances = append(instances, name)
+		} else {
+			types = append(types, name)
+		}
+	}
+	return types, instances
+}

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -102,6 +102,10 @@ func (sr *stubReader) Size() int {
 	return 0
 }
 
+func (sr *stubReader) SynonymMetadata(field string) ([]*index.SynonymMetadata, error) {
+	return nil, nil
+}
+
 func (sr *stubReader) TermFieldReader(ctx context.Context, term []byte, field string, includeFreq, includeNorm, includeTermVectors bool) (index.TermFieldReader, error) {
 	return nil, nil
 }

--- a/search/query/boolean.go
+++ b/search/query/boolean.go
@@ -198,6 +198,19 @@ func (q *BooleanQuery) Validate() error {
 	}
 	return nil
 }
+func (q *BooleanQuery) SynonymSourceName(m mapping.IndexMapping) []string {
+	rv := []string{}
+	if qm, ok := q.Must.(SynonymSearchEnabledQuery); ok {
+		rv = append(rv, qm.SynonymSourceName(m)...)
+	}
+	if qs, ok := q.Should.(SynonymSearchEnabledQuery); ok {
+		rv = append(rv, qs.SynonymSourceName(m)...)
+	}
+	if qmn, ok := q.MustNot.(SynonymSearchEnabledQuery); ok {
+		rv = append(rv, qmn.SynonymSourceName(m)...)
+	}
+	return rv
+}
 
 func (q *BooleanQuery) UnmarshalJSON(data []byte) error {
 	tmp := struct {

--- a/search/query/conjunction.go
+++ b/search/query/conjunction.go
@@ -54,6 +54,16 @@ func (q *ConjunctionQuery) AddQuery(aq ...Query) {
 	}
 }
 
+func (q *ConjunctionQuery) SynonymSourceName(m mapping.IndexMapping) []string {
+	rv := []string{}
+	for _, disjunct := range q.Conjuncts {
+		if disjunct, ok := disjunct.(SynonymSearchEnabledQuery); ok {
+			rv = append(rv, disjunct.SynonymSourceName(m)...)
+		}
+	}
+	return rv
+}
+
 func (q *ConjunctionQuery) Searcher(ctx context.Context, i index.IndexReader, m mapping.IndexMapping, options search.SearcherOptions) (search.Searcher, error) {
 	ss := make([]search.Searcher, 0, len(q.Conjuncts))
 	for _, conjunct := range q.Conjuncts {

--- a/search/query/disjunction.go
+++ b/search/query/disjunction.go
@@ -60,6 +60,16 @@ func (q *DisjunctionQuery) SetMin(m float64) {
 	q.Min = m
 }
 
+func (q *DisjunctionQuery) SynonymSourceName(m mapping.IndexMapping) []string {
+	rv := []string{}
+	for _, disjunct := range q.Disjuncts {
+		if disjunct, ok := disjunct.(SynonymSearchEnabledQuery); ok {
+			rv = append(rv, disjunct.SynonymSourceName(m)...)
+		}
+	}
+	return rv
+}
+
 func (q *DisjunctionQuery) Searcher(ctx context.Context, i index.IndexReader, m mapping.IndexMapping,
 	options search.SearcherOptions) (search.Searcher, error) {
 	ss := make([]search.Searcher, 0, len(q.Disjuncts))

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -58,6 +58,11 @@ type FieldableQuery interface {
 	Field() string
 }
 
+type SynonymSearchEnabledQuery interface {
+	Query
+	SynonymSourceName(mapping.IndexMapping) []string
+}
+
 // A ValidatableQuery represents a Query which can be validated
 // prior to execution.
 type ValidatableQuery interface {

--- a/search/query/query_string.go
+++ b/search/query/query_string.go
@@ -67,3 +67,13 @@ func (q *QueryStringQuery) Validate() error {
 	}
 	return nil
 }
+func (q *QueryStringQuery) SynonymSourceName(m mapping.IndexMapping) []string {
+	newQuery, err := parseQuerySyntax(q.Query)
+	if err != nil {
+		return nil
+	}
+	if newQuery, ok := newQuery.(SynonymSearchEnabledQuery); ok {
+		return newQuery.SynonymSourceName(m)
+	}
+	return nil
+}

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -73,7 +73,7 @@ func newDisjunctionHeapSearcher(ctx context.Context, indexReader index.IndexRead
 		indexReader:   indexReader,
 		searchers:     searchers,
 		numSearchers:  len(searchers),
-		scorer:        scorer.NewDisjunctionQueryScorer(options),
+		scorer:        scorer.NewDisjunctionQueryScorer(ctx, options),
 		min:           int(min),
 		matching:      make([]*search.DocumentMatch, len(searchers)),
 		matchingCurrs: make([]*SearcherCurr, len(searchers)),

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -67,7 +67,7 @@ func newDisjunctionSliceSearcher(ctx context.Context, indexReader index.IndexRea
 		searchers:    searchers,
 		numSearchers: len(searchers),
 		currs:        make([]*search.DocumentMatch, len(searchers)),
-		scorer:       scorer.NewDisjunctionQueryScorer(options),
+		scorer:       scorer.NewDisjunctionQueryScorer(ctx, options),
 		min:          int(min),
 		matching:     make([]*search.DocumentMatch, len(searchers)),
 		matchingIdxs: make([]int, len(searchers)),

--- a/search/searcher/search_synonym.go
+++ b/search/searcher/search_synonym.go
@@ -1,0 +1,171 @@
+//	Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"context"
+
+	"github.com/blevesearch/bleve/v2/analysis"
+	"github.com/blevesearch/bleve/v2/analysis/token/synonym"
+	"github.com/blevesearch/bleve/v2/search"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+// closeSearchers closes the searchers passed to it.
+// called when there is an error building the searchers.
+// It returns the first error encountered while closing the searchers.
+// If no error is encountered, it returns nil.
+func closeSearchers(err *error, searchers map[int][]search.Searcher) {
+	if *err != nil {
+		for _, sa := range searchers {
+			for _, s := range sa {
+				s.Close()
+			}
+		}
+	}
+}
+
+// splitOnSpace splits the phrase on space and returns a slice of strings.
+// This is used to split the synonym phrase into individual words.
+// For example, "a b c" is split into ["a", "b", "c"].
+// It differs from strings.Split() in that it inserts a null character
+// when two consecutive spaces are encountered.
+// For example, "a  b c" is split into ["a", "", "b", "c"].
+func tokenizeSynonym(phrase string) []string {
+	var rv []string
+	var tmp []rune
+	for _, character := range phrase {
+		if character == synonym.SeparatingCharacter {
+			rv = append(rv, string(tmp))
+			tmp = tmp[:0]
+		} else {
+			tmp = append(tmp, character)
+		}
+	}
+	rv = append(rv, string(tmp))
+	return rv
+}
+
+func tokenKey(token *analysis.Token) struct {
+	Term     string
+	Position int
+} {
+	return struct {
+		Term     string
+		Position int
+	}{string(token.Term), token.Position}
+}
+
+func SynonymScorer(ctx *search.SearchContext, constituents []*search.DocumentMatch, options search.SearcherOptions) *search.DocumentMatch {
+	var sum float64
+	var childrenExplanations []*search.Explanation
+	if options.Explain {
+		childrenExplanations = make([]*search.Explanation, len(constituents))
+	}
+
+	for i, docMatch := range constituents {
+		sum += docMatch.Score
+		if options.Explain {
+			childrenExplanations[i] = docMatch.Expl
+		}
+	}
+
+	var expl *search.Explanation
+	if options.Explain {
+		expl = &search.Explanation{Value: sum, Message: "sum of synonyms:", Children: childrenExplanations}
+	}
+
+	// reuse constituents[0] as the return value
+	rv := constituents[0]
+	rv.Score = sum
+	rv.Expl = expl
+	rv.FieldTermLocations = search.MergeFieldTermLocations(
+		rv.FieldTermLocations, constituents[1:])
+	return rv
+}
+
+func NewSynonymSearcher(ctx context.Context, indexReader index.IndexReader,
+	tokens analysis.TokenStream, field string, boost float64, fuzziness int,
+	prefix int, operator int, options search.SearcherOptions) (search.Searcher, error) {
+
+	uniqueTokens := make(map[struct {
+		Term     string
+		Position int
+	}]analysis.TokenType)
+	for _, token := range tokens {
+		key := tokenKey(token)
+		if _, exists := uniqueTokens[key]; !exists {
+			uniqueTokens[key] = token.Type
+		}
+	}
+	var err error
+	searchersAtPosition := make(map[int][]search.Searcher)
+	defer closeSearchers(&err, searchersAtPosition)
+
+	for tok, typ := range uniqueTokens {
+		var searcher search.Searcher
+		if typ == analysis.Synonym {
+			tokens := tokenizeSynonym(tok.Term)
+			if len(tokens) > 1 {
+				searcher, err = NewPhraseSearcher(ctx, indexReader, tokens, fuzziness, field, boost, options)
+				if err != nil {
+					return nil, err
+				}
+				searchersAtPosition[tok.Position] = append(searchersAtPosition[tok.Position], searcher)
+				continue
+			}
+		}
+		if fuzziness > 0 {
+			searcher, err = NewFuzzySearcher(ctx, indexReader, tok.Term, prefix, fuzziness, field, boost, options)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			searcher, err = NewTermSearcher(ctx, indexReader, tok.Term, field, boost, options)
+			if err != nil {
+				return nil, err
+			}
+		}
+		searchersAtPosition[tok.Position] = append(searchersAtPosition[tok.Position], searcher)
+	}
+
+	searchers := make([]search.Searcher, len(searchersAtPosition))
+	idx := 0
+	overridedScorerCtx := context.WithValue(ctx, search.SynonymScorerKey, search.SynonymScorerCallbackFn(SynonymScorer))
+	for _, searcher := range searchersAtPosition {
+		var s search.Searcher
+		if len(searcher) == 1 {
+			s = searcher[0]
+		} else if len(searcher) > 1 {
+			s, err = NewDisjunctionSearcher(overridedScorerCtx, indexReader, searcher, 1, options)
+			if err != nil {
+				return nil, err
+			}
+		}
+		searchers[idx] = s
+		idx += 1
+	}
+	var rv search.Searcher
+	switch operator {
+	case 0:
+		rv, err = NewDisjunctionSearcher(ctx, indexReader, searchers, 1, options)
+	case 1:
+		rv, err = NewConjunctionSearcher(ctx, indexReader, searchers, options)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rv, nil
+}

--- a/search/util.go
+++ b/search/util.go
@@ -106,6 +106,12 @@ const (
 const SearchIncrementalCostKey = "_search_incremental_cost_key"
 const QueryTypeKey = "_query_type_key"
 const FuzzyMatchPhraseKey = "_fuzzy_match_phrase_key"
+const SynonymScorerKey = "_synonym_scorer_key"
+
+type SynonymScorerCallbackFn func(*SearchContext, []*DocumentMatch, SearcherOptions) *DocumentMatch
+
+const ScatterSynonymMetadataKey = "_scatter_synonym_metadata_key"
+const GatherSynonymMetadataKey = "_gather_synonym_metadata_key"
 
 func RecordSearchCost(ctx context.Context,
 	msg SearchIncrementalCostCallbackMsg, bytes uint64) {


### PR DESCRIPTION
# Jira

[MB-35347](https://issues.couchbase.com/browse/MB-35347)

## Description

- Introduces the ability to index specialized "Synonym Documents" that function as a thesaurus within bleve. When a word is queried using the Match Query, this thesaurus is consulted to find synonyms for the queried word.
- This feature supports acronyms and multi-word synonyms when the indexed field has IncludeTermVectors set to true.
- All customizations for the Match Query are fully supported, including options like Fuzziness and the Operator. This means you can perform fuzzy matching on a word and find its synonyms within the index.
- You have the flexibility to define synonym sources using the AddSynonymSource API. Furthermore, you can associate any TextFieldMapping with a synonym source to use it during queries. Additionally, you can set a custom analyzer for the synonym documents, allowing you to use a single source of synonym documents with multiple analyzers attached to it, making it usable across various FieldMappings. 

# Issues
- Addresses issue: https://github.com/blevesearch/bleve/issues/1945