### PR TITLE
MB-59421: add validation for vector field aliases

### DIFF
--- a/mapping/field.go
+++ b/mapping/field.go
@@ -79,12 +79,6 @@ type FieldMapping struct {
 	Similarity string `json:"similarity,omitempty"`
 }
 
-// Min and Max allowed dimensions for a vector field
-const (
-	MinVectorDims = 1
-	MaxVectorDims = 2048
-)
-
 // NewTextFieldMapping returns a default field mapping for text
 func NewTextFieldMapping() *FieldMapping {
 	return &FieldMapping{

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -79,6 +79,12 @@ type FieldMapping struct {
 	Similarity string `json:"similarity,omitempty"`
 }
 
+// Min and Max allowed dimensions for a vector field
+const (
+	MinVectorDims = 1
+	MaxVectorDims = 2048
+)
+
 // NewTextFieldMapping returns a default field mapping for text
 func NewTextFieldMapping() *FieldMapping {
 	return &FieldMapping{

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -174,12 +174,14 @@ func (im *IndexMappingImpl) Validate() error {
 	if err != nil {
 		return err
 	}
-	err = im.DefaultMapping.Validate(im.cache)
+
+	fieldAliasCtx := make(map[string]*FieldMapping)
+	err = im.DefaultMapping.Validate(im.cache, "", fieldAliasCtx)
 	if err != nil {
 		return err
 	}
 	for _, docMapping := range im.TypeMapping {
-		err = docMapping.Validate(im.cache)
+		err = docMapping.Validate(im.cache, "", fieldAliasCtx)
 		if err != nil {
 			return err
 		}

--- a/mapping/mapping_no_vectors.go
+++ b/mapping/mapping_no_vectors.go
@@ -17,8 +17,6 @@
 
 package mapping
 
-import "fmt"
-
 func NewVectorFieldMapping() *FieldMapping {
 	return nil
 }
@@ -31,16 +29,7 @@ func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 // -----------------------------------------------------------------------------
 // document validation functions
 
-func validateVectorField(fieldMapping *FieldMapping) error {
-	return nil
-}
-
-func validateFieldType(fieldType string) error {
-	switch fieldType {
-	case "text", "datetime", "number", "boolean", "geopoint", "geoshape", "IP":
-	default:
-		return fmt.Errorf("unknown field type: '%s'", fieldType)
-	}
-
-	return nil
+func validateFieldMapping(field *FieldMapping, parentName string,
+	fieldAliasCtx map[string]*FieldMapping) error {
+	return validateFieldType(field)
 }

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -114,6 +114,7 @@ func validateVectorFieldAlias(field *FieldMapping, parentName string,
 	field.SkipFreqNorm = true
 
 	// # If alias is present, validate the field options as per the alias
+	// note: reading from a nil map is safe
 	if fieldAlias, ok := fieldAliasCtx[field.Name]; ok {
 		if field.Dims != fieldAlias.Dims {
 			return fmt.Errorf("field: '%s', invalid alias "+
@@ -143,7 +144,9 @@ func validateVectorFieldAlias(field *FieldMapping, parentName string,
 			reflect.ValueOf(index.SupportedSimilarityMetrics).MapKeys())
 	}
 
-	fieldAliasCtx[field.Name] = field
+	if fieldAliasCtx != nil { // writing to a nil map is unsafe
+		fieldAliasCtx[field.Name] = field
+	}
 
 	return nil
 }

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -26,6 +26,12 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
+// Min and Max allowed dimensions for a vector field
+const (
+	MinVectorDims = 1
+	MaxVectorDims = 2048
+)
+
 func NewVectorFieldMapping() *FieldMapping {
 	return &FieldMapping{
 		Type:         "vector",

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -133,9 +133,10 @@ func validateVectorFieldAlias(field *FieldMapping, parentName string,
 
 	// # Validate field options
 
-	if field.Dims <= 0 || field.Dims > 2048 {
+	if field.Dims < index.MinVectorDims || field.Dims > index.MaxVectorDims {
 		return fmt.Errorf("field: '%s', invalid vector dimension: %d,"+
-			" value should be in range (%d, %d)", field.Name, field.Dims, 0, 2048)
+			" value should be in range (%d, %d)", field.Name, field.Dims,
+			index.MinVectorDims, index.MaxVectorDims)
 	}
 
 	if _, ok := index.SupportedSimilarityMetrics[field.Similarity]; !ok {

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -133,10 +133,10 @@ func validateVectorFieldAlias(field *FieldMapping, parentName string,
 
 	// # Validate field options
 
-	if field.Dims < index.MinVectorDims || field.Dims > index.MaxVectorDims {
+	if field.Dims < MinVectorDims || field.Dims > MaxVectorDims {
 		return fmt.Errorf("field: '%s', invalid vector dimension: %d,"+
 			" value should be in range (%d, %d)", field.Name, field.Dims,
-			index.MinVectorDims, index.MaxVectorDims)
+			MinVectorDims, MaxVectorDims)
 	}
 
 	if _, ok := index.SupportedSimilarityMetrics[field.Similarity]; !ok {

--- a/mapping/mapping_vectors_test.go
+++ b/mapping/mapping_vectors_test.go
@@ -1,0 +1,69 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package mapping
+
+import "testing"
+
+func TestVectorFieldAliasValidation(t *testing.T) {
+	tests := []struct {
+		// input
+		name       string // name of the test
+		mappingStr string //index mapping json string
+
+		// expected output
+		expValidity bool // validity of the mapping
+	}{
+		{
+			name: "no vector field alias",
+			mappingStr: `{
+					"default_mapping": {
+						"properties": {
+							"cityVec" {
+								"fields": [
+										{
+											"type": "vector",
+											"dims": 3
+										},
+										{
+											"name": "cityVec",
+											"type": "vector",
+											"dims": 4
+										}
+									]
+								}
+							}
+							
+					}
+				}`,
+			expValidity: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			im := NewIndexMapping()
+			err := im.UnmarshalJSON([]byte(test.mappingStr))
+			if err != nil {
+				t.Fatalf("failed to unmarshal index mapping: %v", err)
+			}
+
+			im.Validate()
+
+		})
+	}
+}


### PR DESCRIPTION
vector field Aliases (fields with same name and type as vector) must have same value for dimensions and similarity, respectively.