### PR TITLE
Fix panic

### DIFF
--- a/search/query/knn.go
+++ b/search/query/knn.go
@@ -19,6 +19,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
@@ -65,6 +66,9 @@ func (q *KNNQuery) Searcher(ctx context.Context, i index.IndexReader,
 	similarityMetric := fieldMapping.Similarity
 	if similarityMetric == "" {
 		similarityMetric = util.DefaultSimilarityMetric
+	}
+	if q.K <= 0 {
+		return nil, fmt.Errorf("k must be greater than 0")
 	}
 
 	return searcher.NewKNNSearcher(ctx, i, m, options, q.VectorField,

--- a/search/query/knn.go
+++ b/search/query/knn.go
@@ -67,10 +67,9 @@ func (q *KNNQuery) Searcher(ctx context.Context, i index.IndexReader,
 	if similarityMetric == "" {
 		similarityMetric = util.DefaultSimilarityMetric
 	}
-	if q.K <= 0 {
-		return nil, fmt.Errorf("k must be greater than 0")
+	if q.K <= 0 || len(q.Vector) == 0 {
+		return nil, fmt.Errorf("k must be greater than 0 and vector must be non-empty")
 	}
-
 	return searcher.NewKNNSearcher(ctx, i, m, options, q.VectorField,
 		q.Vector, q.K, q.BoostVal.Value(), similarityMetric)
 }


### PR DESCRIPTION
need this check because i accidentally used the API without giving a k value it panicked because in

index.go in go-faiss you have


	func (idx *faissIndex) Search(x []float32, k int64) (
		distances []float32, labels []int64, err error,
		) {
	n := len(x) / idx.D()
	distances = make([]float32, int64(n)*k)
	labels = make([]int64, int64(n)*k)
	if c := C.faiss_Index_search(
		idx.idx,
		C.idx_t(n),
		(*C.float)(&x[0]),
		C.idx_t(k),
		(*C.float)(&distances[0]),
		(*C.idx_t)(&labels[0]),

so if either k is 0 or query vector is nil/empty we get a panic because distances[0] is invalid operation

