### PR TITLE
MB-59447: support nested/chunked vectors

### DIFF
--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -37,49 +37,97 @@ func NewVectorFieldMapping() *FieldMapping {
 	}
 }
 
+// validate and process a flat vector
+func processFlatVector(vecI interface{}, dims int) ([]float32, bool) {
+	vecV := reflect.ValueOf(vecI)
+	if !vecV.IsValid() || vecV.Kind() != reflect.Slice || vecV.Len() != dims {
+		return nil, false
+	}
+
+	rv := make([]float32, dims)
+	for i := 0; i < vecV.Len(); i++ {
+		item := vecV.Index(i)
+		if !item.CanInterface() {
+			return nil, false
+		}
+		itemI := item.Interface()
+		itemFloat, ok := util.ExtractNumericValFloat32(itemI)
+		if !ok {
+			return nil, false
+		}
+		rv[i] = itemFloat
+	}
+
+	return rv, true
+}
+
+// validate and process a vector
+// max supported depth of nesting is 2 ([][]float32)
+func processVector(vecI interface{}, dims int) ([]float32, bool) {
+	vecV := reflect.ValueOf(vecI)
+	if !vecV.IsValid() || vecV.Kind() != reflect.Slice || vecV.Len() == 0 {
+		return nil, false
+	}
+
+	// Let's examine the first element (head) of the vector.
+	// If head is a slice, then vector is nested, otherwise flat.
+	headI := vecV.Index(0).Interface()
+	headV := reflect.ValueOf(headI)
+	if !headV.IsValid() {
+		return nil, false
+	}
+	if headV.Kind() != reflect.Slice { // vector is flat
+		return processFlatVector(vecI, dims)
+	}
+
+	// # process nested vector
+
+	// pre-allocate memory for the flattened vector
+	// so that we can use copy() later
+	rv := make([]float32, dims*vecV.Len())
+
+	for i := 0; i < vecV.Len(); i++ {
+		subVec := vecV.Index(i)
+		if !subVec.CanInterface() {
+			return nil, false
+		}
+		subVecI := subVec.Interface()
+		subVecV := reflect.ValueOf(subVecI)
+		if !subVecV.IsValid() {
+			return nil, false
+		}
+
+		if subVecV.Kind() != reflect.Slice {
+			return nil, false
+		}
+
+		flatVector, ok := processFlatVector(subVecI, dims)
+		if !ok {
+			return nil, false
+		}
+
+		copy(rv[i*dims:(i+1)*dims], flatVector)
+	}
+
+	return rv, true
+}
+
 func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 	pathString string, path []string, indexes []uint64, context *walkContext) {
-	propertyVal := reflect.ValueOf(propertyMightBeVector)
-	if !propertyVal.IsValid() {
+	vector, ok := processVector(propertyMightBeVector, fm.Dims)
+	// Don't add field to document if vector is invalid
+	if !ok {
 		return
 	}
 
-	// Validating the length of the vector is required here, in order to
-	// help zapx in deciding the shape of the batch of vectors to be indexed.
-	if propertyVal.Kind() == reflect.Slice && propertyVal.Len() == fm.Dims {
-		vector := make([]float32, propertyVal.Len())
-		isVectorValid := true
-		for i := 0; i < propertyVal.Len(); i++ {
-			item := propertyVal.Index(i)
-			if !item.CanInterface() {
-				isVectorValid = false
-				break
-			}
+	fieldName := getFieldName(pathString, path, fm)
+	options := fm.Options()
+	field := document.NewVectorFieldWithIndexingOptions(fieldName,
+		indexes, vector, fm.Dims, fm.Similarity, options)
+	context.doc.AddField(field)
 
-			itemFloat, ok := util.ExtractNumericValFloat32(item.Interface())
-			if !ok {
-				isVectorValid = false
-				break
-			}
-
-			vector[i] = itemFloat
-		}
-
-		// Even if one of the vector elements is not a float32, we do not index
-		// this field value and continue silently
-		if !isVectorValid {
-			return
-		}
-
-		fieldName := getFieldName(pathString, path, fm)
-		options := fm.Options()
-		field := document.NewVectorFieldWithIndexingOptions(fieldName,
-			indexes, vector, fm.Dims, fm.Similarity, options)
-		context.doc.AddField(field)
-
-		// "_all" composite field is not applicable for vector field
-		context.excludedFromAll = append(context.excludedFromAll, fieldName)
-	}
+	// "_all" composite field is not applicable for vector field
+	context.excludedFromAll = append(context.excludedFromAll, fieldName)
 }
 
 // -----------------------------------------------------------------------------

--- a/mapping/mapping_vectors_test.go
+++ b/mapping/mapping_vectors_test.go
@@ -1,0 +1,106 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package mapping
+
+import (
+	"testing"
+)
+
+type vectorTest struct {
+	vector       interface{} // input vector
+	dims         int         // expected dims of input vector
+	valid        bool        // expected validity of input vector
+	parsedVector []float32   // expected parsed vector
+}
+
+func TestProcessVector(t *testing.T) {
+	tests := []vectorTest{
+		// # Flat vectors
+
+		// ## numeric cases
+		// (all numeric elements)
+		{[]any{1, 2.2, 3}, 3, true, []float32{1, 2.2, 3}}, // len==dims
+		{[]any{1, 2.2, 3}, 2, false, nil},                 // len>dims
+		{[]any{1, 2.2, 3}, 4, false, nil},                 // len<dims
+
+		// ## imposter cases
+		// (len==dims, some elements are non-numeric)
+		{[]any{1, 2, "three"}, 3, false, nil},    // string
+		{[]any{1, nil, 3}, 3, false, nil},        // nil
+		{[]any{nil, 1}, 2, false, nil},           // nil head
+		{[]any{1, 2, struct{}{}}, 3, false, nil}, // struct
+
+		// non-slice cases
+		// (vector is of types other than slice)
+		{nil, 1, false, nil},
+		{struct{}{}, 1, false, nil},
+		{1, 1, false, nil},
+
+		// # Nested vectors
+
+		// ## numeric cases
+		// (all numeric elements)
+		{[]any{[]any{1, 2, 3}, []any{4, 5, 6}}, 3, true,
+			[]float32{1, 2, 3, 4, 5, 6}}, // len==dims
+		{[]any{[]any{1, 2, 3}}, 3, true, []float32{1, 2, 3}}, // len==dims
+		{[]any{[]any{1, 2, 3}}, 4, false, nil},               // len>dims
+		{[]any{[]any{1, 2, 3}}, 2, false, nil},               // len<dims
+
+		// ## imposter cases
+		// some inner vectors are short
+		{[]any{[]any{1, 2, 3}, []any{4, 5}}, 3, false, nil},
+		// some inner vectors are long
+		{[]any{[]any{1, 2, 3}, []any{4, 5, 6, 7}}, 3, false, nil},
+		// contains string
+		{[]any{[]any{1, 2, "three"}, []any{4, 5, 6}}, 3, false, nil},
+		// contains nil
+		{[]any{[]any{1, 2, nil}, []any{4, 5, 6}}, 3, false, nil},
+
+		// non-slice cases (inner vectors)
+		{[]any{[]any{1, 2, 3}, nil}, 3, false, nil},        // nil
+		{[]any{nil, []any{1, 2, 3}}, 3, false, nil},        // nil head
+		{[]any{[]any{1, 2, 3}, struct{}{}}, 3, false, nil}, // struct
+		{[]any{[]any{1, 2, 3}, 4}, 3, false, nil},          // int
+	}
+
+	for _, test := range tests {
+		vec, ok := processVector(test.vector, test.dims)
+		if ok != test.valid {
+			t.Errorf("validity mismatch for %v: expected %v, got %v",
+				test.vector, test.valid, ok)
+			t.Fail()
+		}
+
+		// If input vector is valid, then compare parsed vector with expected
+		if test.valid {
+			if len(vec) != len(test.parsedVector) {
+				t.Errorf("parsed vector mismatch for: %v: expected %v, got %v",
+					test.vector, test.parsedVector, vec)
+				t.Fail()
+			}
+
+			for i := 0; i < len(vec); i++ {
+				if vec[i] != test.parsedVector[i] {
+					t.Errorf("parsed vector mismatch for: %v: expected %v, got %v",
+						test.vector, test.parsedVector, vec)
+					t.Fail()
+				}
+			}
+		}
+	}
+}

--- a/mapping/mapping_vectors_test.go
+++ b/mapping/mapping_vectors_test.go
@@ -21,14 +21,23 @@ import (
 	"testing"
 )
 
+// A test case for processVector function
 type vectorTest struct {
-	vector       interface{} // input vector
-	dims         int         // expected dims of input vector
-	valid        bool        // expected validity of input vector
-	parsedVector []float32   // expected parsed vector
+	// Input
+
+	ipVec interface{} // input vector
+	dims  int         // dimensionality of input vector
+
+	// Expected Output
+
+	expValidity bool      // expected validity of the input
+	expOpVec    []float32 // expected output vector, given the input is valid
 }
 
 func TestProcessVector(t *testing.T) {
+	// Note: while creating vectors, we are using []any instead of []float32,
+	// this is done to enhance our test coverage.
+	// When we unmarshal a vector from a JSON, we get []any, not []float32.
 	tests := []vectorTest{
 		// # Flat vectors
 
@@ -79,25 +88,31 @@ func TestProcessVector(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		vec, ok := processVector(test.vector, test.dims)
-		if ok != test.valid {
-			t.Errorf("validity mismatch for %v: expected %v, got %v",
-				test.vector, test.valid, ok)
+		opVec, valid := processVector(test.ipVec, test.dims)
+
+		// check the validity of the input, as returned by processVector,
+		// against the expected validity.
+		if valid != test.expValidity {
+			t.Errorf("validity mismatch, ipVec:%v, dims:%v, expected:%v, got:%v",
+				test.ipVec, test.dims, test.expValidity, valid)
 			t.Fail()
 		}
 
-		// If input vector is valid, then compare parsed vector with expected
-		if test.valid {
-			if len(vec) != len(test.parsedVector) {
-				t.Errorf("parsed vector mismatch for: %v: expected %v, got %v",
-					test.vector, test.parsedVector, vec)
+		// If input vector is valid, check the correctness of the output vector
+		// against the expected output vector.
+		if valid {
+			if len(opVec) != len(test.expOpVec) {
+				t.Errorf("output vector mismatch, ipVec:%v, dims:%v, "+
+					"expected:%v, got:%v", test.ipVec, test.dims, test.expOpVec,
+					opVec)
 				t.Fail()
 			}
 
-			for i := 0; i < len(vec); i++ {
-				if vec[i] != test.parsedVector[i] {
-					t.Errorf("parsed vector mismatch for: %v: expected %v, got %v",
-						test.vector, test.parsedVector, vec)
+			for i := 0; i < len(opVec); i++ {
+				if opVec[i] != test.expOpVec[i] {
+					t.Errorf("output vector mismatch, ipVec:%v, dims:%v, "+
+						"expected:%v, got:%v", test.ipVec, test.dims, test.expOpVec,
+						opVec)
 					t.Fail()
 				}
 			}

--- a/util/extract.go
+++ b/util/extract.go
@@ -25,13 +25,13 @@ func ExtractNumericValFloat64(v interface{}) (float64, bool) {
 	if !val.IsValid() {
 		return 0, false
 	}
-	typ := val.Type()
-	switch typ.Kind() {
-	case reflect.Float32, reflect.Float64:
+
+	switch {
+	case val.CanFloat():
 		return val.Float(), true
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case val.CanInt():
 		return float64(val.Int()), true
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case val.CanUint():
 		return float64(val.Uint()), true
 	}
 
@@ -44,16 +44,17 @@ func ExtractNumericValFloat32(v interface{}) (float32, bool) {
 	if !val.IsValid() {
 		return 0, false
 	}
-	typ := val.Type()
-	switch typ.Kind() {
-	case reflect.Float32, reflect.Float64:
-		if val.Float() > math.MaxFloat32 {
+
+	switch {
+	case val.CanFloat():
+		floatVal := val.Float()
+		if floatVal > math.MaxFloat32 {
 			return 0, false
 		}
-		return float32(val.Float()), true
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float32(floatVal), true
+	case val.CanInt():
 		return float32(val.Int()), true
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case val.CanUint():
 		return float32(val.Uint()), true
 	}
 


### PR DESCRIPTION
Enable user to chunk vectors ([]float32) into nested_vectors ([][]float32).
This is helpful to capture more intent from text or to use multiple vector generation models for the same input.

While mapping a document, user submitted nested_vectors are flattened and submitted to bleve_index_api.Index impl (Scorch).
Scorch will then submit it to the segment plugin (Zapx).

Zapx is expected to realise that this flattened_vector have length more than Dims.
zapx should read all the subVecs out of the flattened_vector and index them individually.

We are not passing the nested_vector directly to zap. This is done to keep the API contract intact.

related changes:
    https://github.com/blevesearch/zapx/pull/185