### PR TITLE
Upgrade zapx@v16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.0-20231110151736-c56571088d10
+	github.com/blevesearch/zapx/v16 v16.0.0-20231121170046-dd26ea1bbf91
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/blevesearch/go-faiss v1.0.3-0.20231110151003-0ea762e5c06d // indirect
+	github.com/blevesearch/go-faiss v1.0.3 // indirect
 	github.com/blevesearch/mmap-go v1.0.4 // indirect
 	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/blevesearch/bleve_index_api v1.1.3 h1:aNyMEiWFviY/1zYm7JCr2lZRIiYX0TM
 github.com/blevesearch/bleve_index_api v1.1.3/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/geo v0.1.18 h1:Np8jycHTZ5scFe7VEPLrDoHnnb9C4j636ue/CGrhtDw=
 github.com/blevesearch/geo v0.1.18/go.mod h1:uRMGWG0HJYfWfFJpK3zTdnnr1K+ksZTuWKhXeSokfnM=
-github.com/blevesearch/go-faiss v1.0.3-0.20231110151003-0ea762e5c06d h1:qIVY0mozIvyrOJso6EnuWnXMDjOy9DqCC+TOEdthdNg=
-github.com/blevesearch/go-faiss v1.0.3-0.20231110151003-0ea762e5c06d/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
+github.com/blevesearch/go-faiss v1.0.3 h1:NZfqZif0+OfcPVM1IDI9gjc3P3jsETR+EN54L+OlfWQ=
+github.com/blevesearch/go-faiss v1.0.3/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.0-20231110151736-c56571088d10 h1:+QxeHgc8Tt5AZUZmivIJ7zUHtZ882IaIwiHZ2ycc4ss=
-github.com/blevesearch/zapx/v16 v16.0.0-20231110151736-c56571088d10/go.mod h1:ZlLFTYYHQrXB8KsgVOoQ1arnT8GKHMlOVDzMi5i57iU=
+github.com/blevesearch/zapx/v16 v16.0.0-20231121170046-dd26ea1bbf91 h1:FPbRalI5eNPVYlV6tv3Nle2KsVPrJAYSn00+nONz0i0=
+github.com/blevesearch/zapx/v16 v16.0.0-20231121170046-dd26ea1bbf91/go.mod h1:1wZRO5mWgYFa9LDNomxqbcyJ1JU827X/V7fCIdssSIg=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
Includes:
* dd26ea1 Thejas-bhat | command line tool support for vector search (#175)
* d292ef9 Thejas-bhat | replacing the flat index with the IVF family index. (#180)
* f5e149a Thejas-bhat | bug fix: accounting the vecIDs approriately while merging (#179)
* 0296d71 Thejas-bhat | optimization: avoiding storing of bitmaps when vector is in a single document (#181)
* 6b9b047 Abhi Dangeti | MB-59692: Respect choice of similarity metric, bleve_index_api@v1.1.3 (#182)
* e1fe4fb Abhi Dangeti | MB-59569: Upgrade to blevesearch/go-faiss@v1.0.3 (#183)