### PR TITLE
MB-59766: Fix total calculation

### DIFF
--- a/search_knn.go
+++ b/search_knn.go
@@ -278,6 +278,7 @@ func mergeKNN(req *SearchRequest, sr *SearchResult) {
 	}
 	nonZeroScoreHits := make([]*search.DocumentMatch, 0, len(sr.Hits))
 	maxScore := 0.0
+	var numHitsDropped uint64
 	for _, hit := range sr.Hits {
 		newScore := recomputeTotalScore(operator, hit)
 		if newScore > 0 {
@@ -286,11 +287,13 @@ func mergeKNN(req *SearchRequest, sr *SearchResult) {
 				maxScore = newScore
 			}
 			nonZeroScoreHits = append(nonZeroScoreHits, hit)
+		} else {
+			numHitsDropped++
 		}
 	}
 	sr.Hits = nonZeroScoreHits
 	sr.MaxScore = maxScore
-	sr.Total = uint64(len(nonZeroScoreHits))
+	sr.Total -= numHitsDropped
 }
 
 func recomputeTotalScore(operator int, hit *search.DocumentMatch) float64 {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -358,8 +358,8 @@ func runKNNTest(t *testing.T, randomizeDocuments bool) {
 			numIndexPartitions: 1,
 			expectedResults: map[string]testResult{
 				"doc7": {
-					score:          math.MaxFloat64,
-					scoreBreakdown: []float64{0, 0, math.MaxFloat64 / 3.0},
+					score:          math.MaxFloat64 / 3.0,
+					scoreBreakdown: []float64{0, 0, math.MaxFloat64},
 				},
 				"doc29": {
 					score:          0.6774608026082964,
@@ -405,8 +405,8 @@ func runKNNTest(t *testing.T, randomizeDocuments bool) {
 			numIndexPartitions: 4,
 			expectedResults: map[string]testResult{
 				"doc7": {
-					score:          math.MaxFloat64,
-					scoreBreakdown: []float64{0, 0, math.MaxFloat64 / 3.0},
+					score:          math.MaxFloat64 / 3.0,
+					scoreBreakdown: []float64{0, 0, math.MaxFloat64},
 				},
 				"doc29": {
 					score:          0.567426591648309,
@@ -712,8 +712,8 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			queryIndex:  2,
 			expectedResults: map[string]testResult{
 				"doc7": {
-					score:          2357.022603955158,
-					scoreBreakdown: []float64{0, 0, 7071.067811865475},
+					score:          math.MaxFloat64 / 3.0,
+					scoreBreakdown: []float64{0, 0, math.MaxFloat64},
 				},
 				"doc29": {
 					score:          0.6774608026082964,
@@ -758,8 +758,8 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			queryIndex:  2,
 			expectedResults: map[string]testResult{
 				"doc7": {
-					score:          2357.022603955158,
-					scoreBreakdown: []float64{0, 0, 7071.067811865475},
+					score:          math.MaxFloat64 / 3.0,
+					scoreBreakdown: []float64{0, 0, math.MaxFloat64},
 				},
 				"doc29": {
 					score:          0.6774608026082964,


### PR DESCRIPTION
total must reflect total doc hits in full index and not just the number of hits returned as part of search result