### PR TITLE
Knn collector

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -460,6 +460,8 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		coll = collector.NewTopNCollector(req.Size, req.From, req.Sort)
 	}
 
+	setStoreForKNN(req, coll, req.Size)
+
 	// open a reader for this search
 	indexReader, err := i.i.Reader()
 	if err != nil {
@@ -657,7 +659,6 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		Took:     searchDuration,
 		Facets:   coll.FacetResults(),
 	}
-	mergeKNNResults(req, rv)
 	return rv, nil
 }
 

--- a/search/collector/heap.go
+++ b/search/collector/heap.go
@@ -35,10 +35,41 @@ func newStoreHeap(capacity int, compare collectorCompare) *collectStoreHeap {
 }
 
 func (c *collectStoreHeap) AddNotExceedingSize(doc *search.DocumentMatch,
-	size int) *search.DocumentMatch {
+	size int) []*search.DocumentMatch {
 	c.add(doc)
 	if c.Len() > size {
+		return []*search.DocumentMatch{c.removeLast()}
+	}
+	return nil
+}
+
+func (c *collectStoreHeap) Add(doc *search.DocumentMatch) {
+	c.add(doc)
+}
+
+func (c *collectStoreHeap) Remove() *search.DocumentMatch {
+	if c.Len() > 0 {
 		return c.removeLast()
+	}
+	return nil
+}
+
+func (c *collectStoreHeap) PopWhile(popCondition func(doc *search.DocumentMatch) bool) []*search.DocumentMatch {
+	var rv []*search.DocumentMatch
+	for c.Len() > 0 {
+		doc := c.peak()
+		if popCondition(doc) {
+			rv = append(rv, c.removeLast())
+		} else {
+			break
+		}
+	}
+	return rv
+}
+
+func (c *collectStoreHeap) peak() *search.DocumentMatch {
+	if c.Len() > 0 {
+		return c.heap[0]
 	}
 	return nil
 }

--- a/search/collector/knn.go
+++ b/search/collector/knn.go
@@ -1,0 +1,116 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"github.com/blevesearch/bleve/v2/search"
+)
+
+type collectStoreKNN struct {
+	internalHeaps  []collectorStore
+	sizes          []int64
+	totalScoreHeap collectorStore
+	ejectedDocs    []*search.DocumentMatch
+	scoreCorrector func(docMatch *search.DocumentMatch)
+}
+
+// size is the from+size used for the tf-idf and total score heaps.
+func newStoreKNN(totalScoreHeap collectorStore, sizes []int64, internalHeaps []collectorStore,
+	scoreCorrector func(docMatch *search.DocumentMatch)) *collectStoreKNN {
+	return &collectStoreKNN{
+		internalHeaps:  internalHeaps,
+		totalScoreHeap: totalScoreHeap,
+		sizes:          sizes,
+		ejectedDocs:    make([]*search.DocumentMatch, len(internalHeaps)),
+		scoreCorrector: scoreCorrector,
+	}
+}
+
+func (c *collectStoreKNN) AddNotExceedingSize(doc *search.DocumentMatch, size int) []*search.DocumentMatch {
+	numDocsEjected := 0
+
+	for heapIdx := 1; heapIdx < len(c.internalHeaps); heapIdx++ {
+		if doc.ScoreBreakdown[heapIdx] == 0 {
+			continue
+		}
+		ejectedDoc := c.internalHeaps[heapIdx].AddNotExceedingSize(doc, int(c.sizes[heapIdx]))
+		if ejectedDoc != nil {
+			delete(ejectedDoc[0].ScoreBreakdown, heapIdx)
+			c.ejectedDocs[numDocsEjected] = ejectedDoc[0]
+			numDocsEjected++
+		}
+	}
+	if doc.ScoreBreakdown[0] != 0 {
+		tfIdfEject := c.internalHeaps[0].AddNotExceedingSize(doc, int(c.sizes[0]))
+		if tfIdfEject != nil && len(tfIdfEject[0].ScoreBreakdown) == 1 {
+			delete(tfIdfEject[0].ScoreBreakdown, 0)
+			c.ejectedDocs[numDocsEjected] = tfIdfEject[0]
+			numDocsEjected++
+		}
+	}
+
+	for idx := 0; idx < numDocsEjected; idx++ {
+		c.scoreCorrector(c.ejectedDocs[idx])
+	}
+
+	c.totalScoreHeap.Add(doc)
+	rv := c.totalScoreHeap.PopWhile(func(doc *search.DocumentMatch) bool {
+		return doc.Score == 0
+	})
+	return rv
+}
+
+func (c *collectStoreKNN) Final(skip int, fixup collectorFixup) (search.DocumentMatchCollection, error) {
+	if c.totalScoreHeap.Len() <= skip {
+		// heap is smaller than skip, return empty
+		return make(search.DocumentMatchCollection, 0), nil
+	}
+	for i := 0; i < skip; i++ {
+		// remove lowest skip elements of the total score heap - min heap
+		c.totalScoreHeap.Remove()
+	}
+	// need to return min(size, len(c.pq)) elements now
+	size := int(c.sizes[0]) - skip
+	if size > c.totalScoreHeap.Len() {
+		size = c.totalScoreHeap.Len()
+	}
+	rv := make(search.DocumentMatchCollection, size)
+	for i := 0; i < size; i++ {
+		doc := c.totalScoreHeap.Remove()
+		err := fixup(doc)
+		if err != nil {
+			return nil, err
+		}
+		rv[i] = doc
+	}
+	return rv, nil
+}
+
+func (c *collectStoreKNN) PopWhile(popCondition func(doc *search.DocumentMatch) bool) []*search.DocumentMatch {
+	// not impl here
+	return nil
+}
+func (c *collectStoreKNN) Add(doc *search.DocumentMatch) {
+	// not impl here
+}
+func (c *collectStoreKNN) Remove() *search.DocumentMatch {
+	// not impl here
+	return nil
+}
+
+func (c *collectStoreKNN) Len() int {
+	// not impl here
+	return 0
+}

--- a/search/collector/slice.go
+++ b/search/collector/slice.go
@@ -14,7 +14,9 @@
 
 package collector
 
-import "github.com/blevesearch/bleve/v2/search"
+import (
+	"github.com/blevesearch/bleve/v2/search"
+)
 
 type collectStoreSlice struct {
 	slice   search.DocumentMatchCollection
@@ -29,11 +31,46 @@ func newStoreSlice(capacity int, compare collectorCompare) *collectStoreSlice {
 	return rv
 }
 
+func (c *collectStoreSlice) Add(doc *search.DocumentMatch) {
+	c.add(doc)
+}
+
+func (c *collectStoreSlice) Remove() *search.DocumentMatch {
+	if c.len() > 0 {
+		return c.removeLast()
+	}
+	return nil
+}
+
+func (c *collectStoreSlice) Len() int {
+	return c.len()
+}
+
+func (c *collectStoreSlice) PopWhile(popCondition func(doc *search.DocumentMatch) bool) []*search.DocumentMatch {
+	var rv []*search.DocumentMatch
+	for c.len() > 0 {
+		doc := c.peak()
+		if popCondition(doc) {
+			rv = append(rv, c.removeLast())
+		} else {
+			break
+		}
+	}
+	return rv
+}
+
+func (c *collectStoreSlice) peak() *search.DocumentMatch {
+	if c.len() > 0 {
+		return c.slice[c.len()-1]
+	}
+	return nil
+}
+
 func (c *collectStoreSlice) AddNotExceedingSize(doc *search.DocumentMatch,
-	size int) *search.DocumentMatch {
+	size int) []*search.DocumentMatch {
 	c.add(doc)
 	if c.len() > size {
-		return c.removeLast()
+		return []*search.DocumentMatch{c.removeLast()}
 	}
 	return nil
 }

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -977,17 +977,32 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 		{
 			numSegments: 6,
 			queryIndex:  0,
-			mapping:     indexMappingDotProduct,
+			mapping:     indexMappingL2Norm,
 		},
 		{
 			numSegments: 7,
 			queryIndex:  1,
-			mapping:     indexMappingDotProduct,
+			mapping:     indexMappingL2Norm,
 		},
 		{
 			numSegments: 8,
 			queryIndex:  2,
-			mapping:     indexMappingDotProduct,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 12,
+			queryIndex:  3,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 11,
+			queryIndex:  4,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 22,
+			queryIndex:  5,
+			mapping:     indexMappingL2Norm,
 		},
 	}
 	for testCaseNum, testCase := range testCases {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -976,6 +976,21 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 		},
 		{
 			numSegments: 6,
+			queryIndex:  3,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 7,
+			queryIndex:  4,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 8,
+			queryIndex:  5,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 6,
 			queryIndex:  0,
 			mapping:     indexMappingL2Norm,
 		},
@@ -1003,6 +1018,21 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			numSegments: 22,
 			queryIndex:  5,
 			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 6,
+			queryIndex:  3,
+			mapping:     indexMappingDotProduct,
+		},
+		{
+			numSegments: 7,
+			queryIndex:  4,
+			mapping:     indexMappingDotProduct,
+		},
+		{
+			numSegments: 8,
+			queryIndex:  5,
+			mapping:     indexMappingDotProduct,
 		},
 	}
 	for testCaseNum, testCase := range testCases {

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/search/collector"
 	"github.com/blevesearch/bleve/v2/search/query"
 )
 
@@ -150,6 +151,10 @@ func queryWithKNN(req *SearchRequest) (query.Query, error) {
 
 func validateKNN(req *SearchRequest) error {
 	return nil
+}
+
+func setStoreForKNN(req *SearchRequest, coll *collector.TopNCollector, size int) {
+	return
 }
 
 func mergeKNNResults(req *SearchRequest, sr *SearchResult) {


### PR DESCRIPTION
Uses a 2 + M fixed size heap approach to optimally solve the multi-segment knn results merging problem. 
The naive approach of just keeping a min-heap of size N = (size+from) which is based on the total score was flawed because the heap elements(total score) were subject to constant change, therefore we might eject out a value from the top N prematurely as that total score might end up to be zero later on when some other segment is read. The other approach was to keep a heap of size X where X is the number of search results, which i promptly discarded as the space complexity contract will be broken

The current solution - 
Time complexity = O(Nlog(max(size+from, maxK))
Space Complexity = O(max(maxK, size+from)) 
All collectors have the similar time and space complexities, i have increased it by a little bit - max of all k values.

Please let me know if there is any error in the logic
