### PR TITLE
MB-59102: Merging kNN hits from a distributed index with exact search hits

### DIFF
--- a/error.go
+++ b/error.go
@@ -26,6 +26,7 @@ const (
 	ErrorUnknownIndexType
 	ErrorEmptyID
 	ErrorIndexReadInconsistency
+	ErrorPreSearchFailed
 )
 
 // Error represents a more strongly typed bleve error for detecting
@@ -47,4 +48,5 @@ var errorMessages = map[Error]string{
 	ErrorUnknownIndexType:       "unknown index type",
 	ErrorEmptyID:                "document ID cannot be empty",
 	ErrorIndexReadInconsistency: "index read inconsistency detected",
+	ErrorPreSearchFailed:        "index pre-search failed",
 }

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -162,9 +162,11 @@ func (i *indexAliasImpl) SearchInContext(ctx context.Context, req *SearchRequest
 		return nil, ErrorAliasEmpty
 	}
 	if _, ok := ctx.Value(search.PreSearchKey).(bool); ok {
-		// this alias is an index in a larger alias
-		// we need to do a presearch search and NOT
-		// a real search
+		// since presearchKey is set, it means that the request
+		// is being executed as part of a presearch, which
+		// indicates that this index alias is set as an Index
+		// in another alias, so we need to do a presearch search
+		// and NOT a real search
 		return PreSearchDataSearch(ctx, req, i.indexes...)
 	}
 

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -594,7 +594,7 @@ func TestMultiSearchNoError(t *testing.T) {
 		MaxScore: 2.0,
 	}
 
-	results, err := MultiSearch(context.Background(), sr, ei1, ei2)
+	results, err := MultiSearch(context.Background(), sr, nil, ei1, ei2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -625,7 +625,7 @@ func TestMultiSearchSomeError(t *testing.T) {
 	}}
 	ei2 := &stubIndex{name: "ei2", err: fmt.Errorf("deliberate error")}
 	sr := NewSearchRequest(NewTermQuery("test"))
-	res, err := MultiSearch(context.Background(), sr, ei1, ei2)
+	res, err := MultiSearch(context.Background(), sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -652,7 +652,7 @@ func TestMultiSearchAllError(t *testing.T) {
 	ei1 := &stubIndex{name: "ei1", err: fmt.Errorf("deliberate error")}
 	ei2 := &stubIndex{name: "ei2", err: fmt.Errorf("deliberate error")}
 	sr := NewSearchRequest(NewTermQuery("test"))
-	res, err := MultiSearch(context.Background(), sr, ei1, ei2)
+	res, err := MultiSearch(context.Background(), sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -708,7 +708,7 @@ func TestMultiSearchSecondPage(t *testing.T) {
 		checkRequest: checkRequest,
 	}
 	sr := NewSearchRequestOptions(NewTermQuery("test"), 10, 10, false)
-	_, err := MultiSearch(context.Background(), sr, ei1, ei2)
+	_, err := MultiSearch(context.Background(), sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -786,7 +786,7 @@ func TestMultiSearchTimeout(t *testing.T) {
 	defer cancel()
 	query := NewTermQuery("test")
 	sr := NewSearchRequest(query)
-	res, err := MultiSearch(ctx, sr, ei1, ei2)
+	res, err := MultiSearch(ctx, sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -806,7 +806,7 @@ func TestMultiSearchTimeout(t *testing.T) {
 	// now run a search again with an absurdly low timeout (should timeout)
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Microsecond)
 	defer cancel()
-	res, err = MultiSearch(ctx, sr, ei1, ei2)
+	res, err = MultiSearch(ctx, sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -833,7 +833,7 @@ func TestMultiSearchTimeout(t *testing.T) {
 	// now run a search again with a normal timeout, but cancel it first
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	cancel()
-	res, err = MultiSearch(ctx, sr, ei1, ei2)
+	res, err = MultiSearch(ctx, sr, nil, ei1, ei2)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -968,7 +968,7 @@ func TestMultiSearchTimeoutPartial(t *testing.T) {
 		MaxScore: 2.0,
 	}
 
-	res, err := MultiSearch(ctx, sr, ei1, ei2, ei3)
+	res, err := MultiSearch(ctx, sr, nil, ei1, ei2, ei3)
 	if err != nil {
 		t.Fatalf("expected no err, got %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestMultiSearchCustomSort(t *testing.T) {
 		MaxScore: 3.0,
 	}
 
-	results, err := MultiSearch(context.Background(), sr, ei1, ei2)
+	results, err := MultiSearch(context.Background(), sr, nil, ei1, ei2)
 	if err != nil {
 		t.Error(err)
 	}

--- a/index_impl.go
+++ b/index_impl.go
@@ -501,14 +501,14 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	var knnHits []*search.DocumentMatch
 	var ok bool
 	var skipKnnCollector bool
-	if req.Metadata != nil {
-		for k, v := range req.Metadata {
+	if req.PreSearchData != nil {
+		for k, v := range req.PreSearchData {
 			switch k {
-			case search.KnnMetadataKey:
+			case search.KnnPreSearchDataKey:
 				if v != nil {
 					knnHits, ok = v.([]*search.DocumentMatch)
 					if !ok {
-						return nil, fmt.Errorf("knn metadata must be of type []*search.DocumentMatch")
+						return nil, fmt.Errorf("knn preSearchData must be of type []*search.DocumentMatch")
 					}
 				}
 				skipKnnCollector = true

--- a/index_impl.go
+++ b/index_impl.go
@@ -433,6 +433,25 @@ func memNeededForSearch(req *SearchRequest,
 	return uint64(estimate)
 }
 
+func (i *indexImpl) preSearch(ctx context.Context, req *SearchRequest, reader index.IndexReader) (*SearchResult, error) {
+	var knnHits []*search.DocumentMatch
+	var err error
+	if requestHasKNN(req) {
+		knnHits, err = i.runKnnCollector(ctx, req, reader, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SearchResult{
+		Status: &SearchStatus{
+			Total:      1,
+			Successful: 1,
+		},
+		Hits: knnHits,
+	}, nil
+}
+
 // SearchInContext executes a search request operation within the provided
 // Context. Returns a SearchResult object or an error.
 func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr *SearchResult, err error) {
@@ -443,6 +462,25 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 
 	if !i.open {
 		return nil, ErrorIndexClosed
+	}
+
+	// open a reader for this search
+	indexReader, err := i.i.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("error opening index reader %v", err)
+	}
+	defer func() {
+		if cerr := indexReader.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+
+	if _, ok := ctx.Value(search.PreSearchKey).(bool); ok {
+		preSearchResult, err := i.preSearch(ctx, req, indexReader)
+		if err != nil {
+			return nil, err
+		}
+		return preSearchResult, nil
 	}
 
 	var reverseQueryExecution bool
@@ -460,16 +498,31 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		coll = collector.NewTopNCollector(req.Size, req.From, req.Sort)
 	}
 
-	// open a reader for this search
-	indexReader, err := i.i.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("error opening index reader %v", err)
-	}
-	defer func() {
-		if cerr := indexReader.Close(); err == nil && cerr != nil {
-			err = cerr
+	var knnHits []*search.DocumentMatch
+	var ok bool
+	var skipKnnCollector bool
+	if req.Metadata != nil {
+		for k, v := range req.Metadata {
+			switch k {
+			case search.KnnMetadataKey:
+				if v != nil {
+					knnHits, ok = v.([]*search.DocumentMatch)
+					if !ok {
+						return nil, fmt.Errorf("knn metadata must be of type []*search.DocumentMatch")
+					}
+				}
+				skipKnnCollector = true
+			}
 		}
-	}()
+	}
+	if !skipKnnCollector && requestHasKNN(req) {
+		knnHits, err = i.runKnnCollector(ctx, req, indexReader, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	setKnnHitsInCollector(knnHits, req, coll)
 
 	// This callback and variable handles the tracking of bytes read
 	//  1. as part of creation of tfr and its Next() calls which is
@@ -496,14 +549,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	ctx = context.WithValue(ctx, search.GeoBufferPoolCallbackKey,
 		search.GeoBufferPoolCallbackFunc(getBufferPool))
 
-	// Using a query to get results from KNN queries
-	// and the original query based on the KNN operator.
-	searchQuery, err := queryWithKNN(req)
-	if err != nil {
-		return nil, err
-	}
-
-	searcher, err := searchQuery.Searcher(ctx, indexReader, i.m, search.SearcherOptions{
+	searcher, err := req.Query.Searcher(ctx, indexReader, i.m, search.SearcherOptions{
 		Explain:            req.Explain,
 		IncludeTermVectors: req.IncludeLocations || req.Highlight != nil,
 		Score:              req.Score,
@@ -657,7 +703,6 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		Took:     searchDuration,
 		Facets:   coll.FacetResults(),
 	}
-	mergeKNNResults(req, rv)
 	return rv, nil
 }
 

--- a/search/collector.go
+++ b/search/collector.go
@@ -44,9 +44,15 @@ type MakeDocumentMatchHandlerKeyType string
 var MakeDocumentMatchHandlerKey = MakeDocumentMatchHandlerKeyType(
 	"MakeDocumentMatchHandlerKey")
 
+var MakeKNNDocumentMatchHandlerKey = MakeDocumentMatchHandlerKeyType(
+	"MakeKNNDocumentMatchHandlerKey")
+
 // MakeDocumentMatchHandler is an optional DocumentMatchHandler
 // builder function which the applications can pass to bleve.
 // These builder methods gives a DocumentMatchHandler function
 // to bleve, which it will invoke on every document matches.
 type MakeDocumentMatchHandler func(ctx *SearchContext) (
 	callback DocumentMatchHandler, loadID bool, err error)
+
+type MakeKNNDocumentMatchHandler func(ctx *SearchContext) (
+	callback DocumentMatchHandler, err error)

--- a/search/collector/knn.go
+++ b/search/collector/knn.go
@@ -1,0 +1,257 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"time"
+
+	"github.com/blevesearch/bleve/v2/search"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+type collectStoreKNN struct {
+	internalHeaps []collectorStore
+	kValues       []int64
+	allHits       map[*search.DocumentMatch]struct{}
+	ejectedDocs   map[*search.DocumentMatch]struct{}
+}
+
+func newStoreKNN(internalHeaps []collectorStore, kValues []int64) *collectStoreKNN {
+	return &collectStoreKNN{
+		internalHeaps: internalHeaps,
+		kValues:       kValues,
+		ejectedDocs:   make(map[*search.DocumentMatch]struct{}),
+		allHits:       make(map[*search.DocumentMatch]struct{}),
+	}
+}
+
+// Adds a document to the collector store and returns the documents that were ejected
+// from the store. The documents that were ejected from the store are the ones that
+// were not in the top K documents for any of the heaps.
+// These document are put back into the pool document match pool in the KNN Collector.
+func (c *collectStoreKNN) AddDocument(doc *search.DocumentMatch) []*search.DocumentMatch {
+	for heapIdx := 0; heapIdx < len(c.internalHeaps); heapIdx++ {
+		if _, ok := doc.ScoreBreakdown[heapIdx]; !ok {
+			continue
+		}
+		ejectedDoc := c.internalHeaps[heapIdx].AddNotExceedingSize(doc, int(c.kValues[heapIdx]))
+		if ejectedDoc != nil {
+			delete(ejectedDoc.ScoreBreakdown, heapIdx)
+			c.ejectedDocs[ejectedDoc] = struct{}{}
+		}
+	}
+	var rv []*search.DocumentMatch
+	for doc := range c.ejectedDocs {
+		if len(doc.ScoreBreakdown) == 0 {
+			rv = append(rv, doc)
+			delete(c.allHits, doc)
+		}
+		// clear out the ejectedDocs map to reuse it in the next AddDocument call
+		delete(c.ejectedDocs, doc)
+	}
+	if len(doc.ScoreBreakdown) > 0 {
+		c.allHits[doc] = struct{}{}
+	}
+	return rv
+}
+
+func (c *collectStoreKNN) AllHits() map[*search.DocumentMatch]struct{} {
+	return c.allHits
+}
+
+func (c *collectStoreKNN) Final(fixup collectorFixup) (search.DocumentMatchCollection, error) {
+	size := len(c.allHits)
+	if size <= 0 {
+		return make(search.DocumentMatchCollection, 0), nil
+	}
+	rv := make(search.DocumentMatchCollection, size)
+	i := 0
+	for doc := range c.allHits {
+		err := fixup(doc)
+		if err != nil {
+			return nil, err
+		}
+		rv[i] = doc
+		i++
+	}
+	return rv, nil
+}
+
+func MakeKNNDocMatchHandler(ctx *search.SearchContext) (search.DocumentMatchHandler, error) {
+	var hc *KNNCollector
+	var ok bool
+	if hc, ok = ctx.Collector.(*KNNCollector); ok {
+		return func(d *search.DocumentMatch) error {
+			if d == nil {
+				return nil
+			}
+			toRelease := hc.knnStore.AddDocument(d)
+			for _, doc := range toRelease {
+				ctx.DocumentMatchPool.Put(doc)
+			}
+			return nil
+		}, nil
+	}
+	return nil, nil
+}
+
+func GetNewKNNCollectorStore(kArray []int64) *collectStoreKNN {
+	internalHeaps := make([]collectorStore, len(kArray))
+	for knnIdx, k := range kArray {
+		// TODO - Check if the datatype of k can be made into an int instead of int64
+		idx := knnIdx
+		internalHeaps[idx] = getOptimalCollectorStore(int(k), 0, func(i, j *search.DocumentMatch) int {
+			if i.ScoreBreakdown[idx] < j.ScoreBreakdown[idx] {
+				return 1
+			}
+			return -1
+		})
+	}
+	return newStoreKNN(internalHeaps, kArray)
+}
+
+// implements Collector interface
+type KNNCollector struct {
+	knnStore *collectStoreKNN
+	size     int
+	total    uint64
+	took     time.Duration
+	results  search.DocumentMatchCollection
+	maxScore float64
+}
+
+func NewKNNCollector(kArray []int64, size int64) *KNNCollector {
+	return &KNNCollector{
+		knnStore: GetNewKNNCollectorStore(kArray),
+		size:     int(size),
+	}
+}
+
+func (hc *KNNCollector) Collect(ctx context.Context, searcher search.Searcher, reader index.IndexReader) error {
+	startTime := time.Now()
+	var err error
+	var next *search.DocumentMatch
+
+	// pre-allocate enough space in the DocumentMatchPool
+	// unless the sum of K is too large, then cap it
+	// everything should still work, just allocates DocumentMatches on demand
+	backingSize := hc.size
+	if backingSize > PreAllocSizeSkipCap {
+		backingSize = PreAllocSizeSkipCap + 1
+	}
+	searchContext := &search.SearchContext{
+		DocumentMatchPool: search.NewDocumentMatchPool(backingSize+searcher.DocumentMatchPoolSize(), 0),
+		Collector:         hc,
+		IndexReader:       reader,
+	}
+
+	dmHandlerMakerKNN := MakeKNNDocMatchHandler
+	if cv := ctx.Value(search.MakeKNNDocumentMatchHandlerKey); cv != nil {
+		dmHandlerMakerKNN = cv.(search.MakeKNNDocumentMatchHandler)
+	}
+	// use the application given builder for making the custom document match
+	// handler and perform callbacks/invocations on the newly made handler.
+	dmHandler, err := dmHandlerMakerKNN(searchContext)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		search.RecordSearchCost(ctx, search.AbortM, 0)
+		return ctx.Err()
+	default:
+		next, err = searcher.Next(searchContext)
+	}
+	for err == nil && next != nil {
+		if hc.total%CheckDoneEvery == 0 {
+			select {
+			case <-ctx.Done():
+				search.RecordSearchCost(ctx, search.AbortM, 0)
+				return ctx.Err()
+			default:
+			}
+		}
+		hc.total++
+
+		err = dmHandler(next)
+		if err != nil {
+			break
+		}
+
+		next, err = searcher.Next(searchContext)
+	}
+	if err != nil {
+		return err
+	}
+
+	// help finalize/flush the results in case
+	// of custom document match handlers.
+	err = dmHandler(nil)
+	if err != nil {
+		return err
+	}
+
+	// compute search duration
+	hc.took = time.Since(startTime)
+
+	// finalize actual results
+	err = hc.finalizeResults(reader)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (hc *KNNCollector) finalizeResults(r index.IndexReader) error {
+	var err error
+	hc.results, err = hc.knnStore.Final(func(doc *search.DocumentMatch) error {
+		if doc.ID == "" {
+			// look up the id since we need it for lookup
+			var err error
+			doc.ID, err = r.ExternalID(doc.IndexInternalID)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+func (hc *KNNCollector) Results() search.DocumentMatchCollection {
+	return hc.results
+}
+
+func (hc *KNNCollector) Total() uint64 {
+	return hc.total
+}
+
+func (hc *KNNCollector) MaxScore() float64 {
+	return hc.maxScore
+}
+
+func (hc *KNNCollector) Took() time.Duration {
+	return hc.took
+}
+
+func (hc *KNNCollector) SetFacetsBuilder(facetsBuilder *search.FacetsBuilder) {
+	// facet unsupported for vector search
+}
+
+func (hc *KNNCollector) FacetResults() search.FacetResults {
+	// facet unsupported for vector search
+	return nil
+}

--- a/search/collector/knn.go
+++ b/search/collector/knn.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build vectors
+// +build vectors
+
 package collector
 
 import (

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -257,7 +257,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 			if err != nil {
 				return err
 			}
-			err = dmHandler(next)
+			err = dmHandler(knnDoc)
 			if err != nil {
 				return err
 			}

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -416,6 +416,15 @@ func (hc *TopNCollector) visitFieldTerms(reader index.IndexReader, d *search.Doc
 	if hc.facetsBuilder != nil {
 		hc.facetsBuilder.StartDoc()
 	}
+	if d.ID != "" && d.IndexInternalID == nil {
+		// this document may have been sent over as preSearchData and
+		// we need to look up the internal id to visit the doc values for it
+		var err error
+		d.IndexInternalID, err = reader.InternalID(d.ID)
+		if err != nil {
+			return err
+		}
+	}
 
 	err := hc.dvReader.VisitDocValues(d.IndexInternalID, hc.updateFieldVisitor)
 	if hc.facetsBuilder != nil {

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -72,6 +72,10 @@ type TopNCollector struct {
 	updateFieldVisitor        index.DocValueVisitor
 	dvReader                  index.DocValueReader
 	searchAfter               *search.DocumentMatch
+
+	knnHits          map[string]*search.DocumentMatch
+	computeNewScore  func(d *search.DocumentMatch, knnHit *search.DocumentMatch) float64
+	isKnnOperatorAnd func() bool
 }
 
 // CheckDoneEvery controls how frequently we check the context deadline
@@ -110,23 +114,9 @@ func NewTopNCollectorAfter(size int, sort search.SortOrder, after []string) *Top
 func newTopNCollector(size int, skip int, sort search.SortOrder) *TopNCollector {
 	hc := &TopNCollector{size: size, skip: skip, sort: sort}
 
-	// pre-allocate space on the store to avoid reslicing
-	// unless the size + skip is too large, then cap it
-	// everything should still work, just reslices as necessary
-	backingSize := size + skip + 1
-	if size+skip > PreAllocSizeSkipCap {
-		backingSize = PreAllocSizeSkipCap + 1
-	}
-
-	if size+skip > 10 {
-		hc.store = newStoreHeap(backingSize, func(i, j *search.DocumentMatch) int {
-			return hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, i, j)
-		})
-	} else {
-		hc.store = newStoreSlice(backingSize, func(i, j *search.DocumentMatch) int {
-			return hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, i, j)
-		})
-	}
+	hc.store = getOptimalCollectorStore(size, skip, func(i, j *search.DocumentMatch) int {
+		return hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, i, j)
+	})
 
 	// these lookups traverse an interface, so do once up-front
 	if sort.RequiresDocID() {
@@ -137,6 +127,22 @@ func newTopNCollector(size int, skip int, sort search.SortOrder) *TopNCollector 
 	hc.cachedDesc = sort.CacheDescending()
 
 	return hc
+}
+
+func getOptimalCollectorStore(size, skip int, comparator collectorCompare) collectorStore {
+	// pre-allocate space on the store to avoid reslicing
+	// unless the size + skip is too large, then cap it
+	// everything should still work, just reslices as necessary
+	backingSize := size + skip + 1
+	if size+skip > PreAllocSizeSkipCap {
+		backingSize = PreAllocSizeSkipCap + 1
+	}
+
+	if size+skip > 10 {
+		return newStoreHeap(backingSize, comparator)
+	} else {
+		return newStoreSlice(backingSize, comparator)
+	}
 }
 
 func (hc *TopNCollector) Size() int {
@@ -205,6 +211,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 	default:
 		next, err = searcher.Next(searchContext)
 	}
+	var skipped bool
 	for err == nil && next != nil {
 		if hc.total%CheckDoneEvery == 0 {
 			select {
@@ -215,6 +222,15 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 			}
 		}
 
+		skipped, err = hc.adjustDocumentMatch(searchContext, reader, next)
+		if err != nil {
+			break
+		}
+		if skipped {
+			searchContext.DocumentMatchPool.Put(next)
+			next, err = searcher.Next(searchContext)
+			continue
+		}
 		err = hc.prepareDocumentMatch(searchContext, reader, next)
 		if err != nil {
 			break
@@ -226,6 +242,26 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 		}
 
 		next, err = searcher.Next(searchContext)
+	}
+	if err != nil {
+		return err
+	}
+	if hc.knnHits != nil && !hc.isKnnOperatorAnd() {
+		// if the operator is OR, then we may have some knn hits
+		// left that did not match any of the top N tf-idf hits
+		// we need to add them to the collector store to consider
+		// them as well.
+		for _, knnDoc := range hc.knnHits {
+			knnDoc.Score = hc.computeNewScore(nil, knnDoc)
+			err = hc.prepareDocumentMatch(searchContext, reader, knnDoc)
+			if err != nil {
+				return err
+			}
+			err = dmHandler(next)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	statsCallbackFn := ctx.Value(search.SearchIOStatsCallbackKey)
@@ -258,6 +294,28 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 
 var sortByScoreOpt = []string{"_score"}
 
+func (hc *TopNCollector) adjustDocumentMatch(ctx *search.SearchContext,
+	reader index.IndexReader, d *search.DocumentMatch) (skipped bool, err error) {
+
+	if hc.knnHits != nil {
+		if hc.needDocIds {
+			d.ID, err = reader.ExternalID(d.IndexInternalID)
+			if err != nil {
+				return false, err
+			}
+		}
+		if knnHit, ok := hc.knnHits[d.ID]; ok {
+			d.Score = hc.computeNewScore(d, knnHit)
+			delete(hc.knnHits, d.ID)
+		} else if hc.isKnnOperatorAnd() {
+			// if the operator is AND, then we need to skip this hit
+			// since it did not match the knn query
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (hc *TopNCollector) prepareDocumentMatch(ctx *search.SearchContext,
 	reader index.IndexReader, d *search.DocumentMatch) (err error) {
 
@@ -279,7 +337,7 @@ func (hc *TopNCollector) prepareDocumentMatch(ctx *search.SearchContext,
 	}
 
 	// see if we need to load ID (at this early stage, for example to sort on it)
-	if hc.needDocIds {
+	if hc.needDocIds && d.ID == "" {
 		d.ID, err = reader.ExternalID(d.IndexInternalID)
 		if err != nil {
 			return err
@@ -314,6 +372,7 @@ func MakeTopNDocumentMatchHandler(
 				// but we want to allow for exact match, so we pretend
 				hc.searchAfter.HitNumber = d.HitNumber
 				if hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, d, hc.searchAfter) <= 0 {
+					ctx.DocumentMatchPool.Put(d)
 					return nil
 				}
 			}
@@ -434,4 +493,26 @@ func (hc *TopNCollector) FacetResults() search.FacetResults {
 		return hc.facetsBuilder.Results()
 	}
 	return nil
+}
+
+func (hc *TopNCollector) SetKNNHits(knnHits search.DocumentMatchCollection,
+	newScoreComputer func(d *search.DocumentMatch, knnHit *search.DocumentMatch) float64,
+	isOperatorAnd func() bool) {
+
+	hc.knnHits = make(map[string]*search.DocumentMatch, len(knnHits))
+	for _, hit := range knnHits {
+		hc.knnHits[hit.ID] = hit
+	}
+	hc.computeNewScore = newScoreComputer
+	hc.isKnnOperatorAnd = isOperatorAnd
+	// now that we have the knnHits
+	// when we run the top N search for just the
+	// basic Query object, we need to load the docIds
+	// for the hits -> this is because there might be overlap
+	// or common documents between the knnHits and the top N hits
+	// which indicates that a document matches both a knn query
+	// and the top N query. This means we need to improve the score
+	// of the doc match received as part of the top N search to also incorporate
+	// the score from the knn search.
+	hc.needDocIds = true
 }

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -66,6 +66,36 @@ type ValidatableQuery interface {
 }
 
 // ParseQuery deserializes a JSON representation of
+// a Metadata object.
+func ParseMetadata(input []byte) (map[string]interface{}, error) {
+	var rv map[string]interface{}
+
+	var tmp map[string]json.RawMessage
+	err := util.UnmarshalJSON(input, &tmp)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range tmp {
+		switch k {
+		case search.KnnMetadataKey:
+			var value []*search.DocumentMatch
+			if v != nil {
+				err := util.UnmarshalJSON(v, &value)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if rv == nil {
+				rv = make(map[string]interface{})
+			}
+			rv[search.KnnMetadataKey] = value
+		}
+	}
+	return rv, nil
+}
+
+// ParseQuery deserializes a JSON representation of
 // a Query object.
 func ParseQuery(input []byte) (Query, error) {
 	var tmp map[string]interface{}

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -66,8 +66,8 @@ type ValidatableQuery interface {
 }
 
 // ParseQuery deserializes a JSON representation of
-// a Metadata object.
-func ParseMetadata(input []byte) (map[string]interface{}, error) {
+// a PreSearchData object.
+func ParsePreSearchData(input []byte) (map[string]interface{}, error) {
 	var rv map[string]interface{}
 
 	var tmp map[string]json.RawMessage
@@ -78,7 +78,7 @@ func ParseMetadata(input []byte) (map[string]interface{}, error) {
 
 	for k, v := range tmp {
 		switch k {
-		case search.KnnMetadataKey:
+		case search.KnnPreSearchDataKey:
 			var value []*search.DocumentMatch
 			if v != nil {
 				err := util.UnmarshalJSON(v, &value)
@@ -89,7 +89,7 @@ func ParseMetadata(input []byte) (map[string]interface{}, error) {
 			if rv == nil {
 				rv = make(map[string]interface{})
 			}
-			rv[search.KnnMetadataKey] = value
+			rv[search.KnnPreSearchDataKey] = value
 		}
 	}
 	return rv, nil

--- a/search/search.go
+++ b/search/search.go
@@ -184,7 +184,11 @@ type DocumentMatch struct {
 
 	// internal variable used in PreSearch phase of search in alias
 	// indicated the index id of the index that this match came from
-	IndexId int
+	// used in vector search.
+	// it is a stack of index ids, the top of the stack is the index id
+	// of the index that this match came from
+	// of the current alias view, used in alias of aliases scenario
+	IndexId []int `json:"index_id,omitempty"`
 }
 
 func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {
@@ -346,7 +350,7 @@ func (dm *DocumentMatch) Complete(prealloc []Location) []Location {
 }
 
 func (dm *DocumentMatch) String() string {
-	return fmt.Sprintf("[%s-%f]", string(dm.IndexInternalID), dm.Score)
+	return fmt.Sprintf("[%s-%f]", dm.ID, dm.Score)
 }
 
 type DocumentMatchCollection []*DocumentMatch

--- a/search/search.go
+++ b/search/search.go
@@ -181,6 +181,10 @@ type DocumentMatch struct {
 	// in the DisjunctionQuery or ConjunctionQuery. The map value is the
 	// sub-score for that sub-query.
 	ScoreBreakdown map[int]float64 `json:"score_breakdown,omitempty"`
+
+	// internal variable used in PreSearch phase of search in alias
+	// indicated the index id of the index that this match came from
+	IndexId int
 }
 
 func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -16,6 +16,7 @@ package searcher
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"sort"
 
@@ -33,17 +34,16 @@ func init() {
 }
 
 type ConjunctionSearcher struct {
-	indexReader     index.IndexReader
-	searchers       []search.Searcher
-	originalPos     []int
-	queryNorm       float64
-	queryNormForKNN float64
-	currs           []*search.DocumentMatch
-	maxIDIdx        int
-	scorer          *scorer.ConjunctionQueryScorer
-	initialized     bool
-	options         search.SearcherOptions
-	bytesRead       uint64
+	indexReader index.IndexReader
+	searchers   []search.Searcher
+	originalPos []int
+	queryNorm   float64
+	currs       []*search.DocumentMatch
+	maxIDIdx    int
+	scorer      *scorer.ConjunctionQueryScorer
+	initialized bool
+	options     search.SearcherOptions
+	bytesRead   uint64
 }
 
 func NewConjunctionSearcher(ctx context.Context, indexReader index.IndexReader,
@@ -123,6 +123,20 @@ func NewConjunctionSearcher(ctx context.Context, indexReader index.IndexReader,
 	}
 
 	return &c, nil
+}
+
+func (s *ConjunctionSearcher) computeQueryNorm() {
+	// first calculate sum of squared weights
+	sumOfSquaredWeights := 0.0
+	for _, searcher := range s.searchers {
+		sumOfSquaredWeights += searcher.Weight()
+	}
+	// now compute query norm from this
+	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
+	// finally tell all the downstream searchers the norm
+	for _, searcher := range s.searchers {
+		searcher.SetQueryNorm(s.queryNorm)
+	}
 }
 
 func (s *ConjunctionSearcher) Size() int {

--- a/search/searcher/util_knn.go
+++ b/search/searcher/util_knn.go
@@ -19,65 +19,10 @@ package searcher
 
 import (
 	"context"
-	"math"
 
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
-
-// util func used by both disjunction and conjunction searchers
-// to compute the query norm.
-// This follows a separate code path from the non-knn version
-// because we need to separate out the weights from the KNN searchers
-// and the rest of the searchers to make the knn
-// score completely independent of tf-idf.
-// the sumOfSquaredWeights depends on the tf-idf weights
-// and using the same value for knn searchers will make the
-// knn score dependent on tf-idf.
-func computeQueryNorm(searchers []search.Searcher) (float64, float64) {
-	var queryNorm float64
-	var queryNormForKNN float64
-	// first calculate sum of squared weights
-	sumOfSquaredWeights := 0.0
-
-	sumOfSquaredWeightsForKNN := 0.0
-
-	for _, searcher := range searchers {
-		if knnSearcher, ok := searcher.(*KNNSearcher); ok {
-			sumOfSquaredWeightsForKNN += knnSearcher.Weight()
-		} else {
-			sumOfSquaredWeights += searcher.Weight()
-		}
-	}
-	// now compute query norm from this
-	if sumOfSquaredWeights != 0.0 {
-		queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
-	}
-	if sumOfSquaredWeightsForKNN != 0.0 {
-		queryNormForKNN = 1.0 / math.Sqrt(sumOfSquaredWeightsForKNN)
-	}
-	// finally tell all the downstream searchers the norm
-	for _, searcher := range searchers {
-		if knnSearcher, ok := searcher.(*KNNSearcher); ok {
-			knnSearcher.SetQueryNorm(queryNormForKNN)
-		} else {
-			searcher.SetQueryNorm(queryNorm)
-		}
-	}
-	return queryNorm, queryNormForKNN
-}
-
-func (s *DisjunctionSliceSearcher) computeQueryNorm() {
-	s.queryNorm, s.queryNormForKNN = computeQueryNorm(s.searchers)
-}
-
-func (s *DisjunctionHeapSearcher) computeQueryNorm() {
-	s.queryNorm, s.queryNormForKNN = computeQueryNorm(s.searchers)
-}
-
-func (s *ConjunctionSearcher) computeQueryNorm() {
-	s.queryNorm, s.queryNormForKNN = computeQueryNorm(s.searchers)
-}
 
 func optimizeCompositeSearcher(ctx context.Context, optimizationKind string,
 	indexReader index.IndexReader, qsearchers []search.Searcher,

--- a/search/searcher/util_no_knn.go
+++ b/search/searcher/util_no_knn.go
@@ -19,53 +19,10 @@ package searcher
 
 import (
 	"context"
-	"math"
 
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
-
-func (s *DisjunctionSliceSearcher) computeQueryNorm() {
-	// first calculate sum of squared weights
-	sumOfSquaredWeights := 0.0
-	for _, searcher := range s.searchers {
-		sumOfSquaredWeights += searcher.Weight()
-	}
-	// now compute query norm from this
-	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
-	// finally tell all the downstream searchers the norm
-	for _, searcher := range s.searchers {
-		searcher.SetQueryNorm(s.queryNorm)
-	}
-}
-
-func (s *DisjunctionHeapSearcher) computeQueryNorm() {
-	// first calculate sum of squared weights
-	sumOfSquaredWeights := 0.0
-	for _, searcher := range s.searchers {
-		sumOfSquaredWeights += searcher.Weight()
-	}
-	// now compute query norm from this
-	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
-	// finally tell all the downstream searchers the norm
-	for _, searcher := range s.searchers {
-		searcher.SetQueryNorm(s.queryNorm)
-	}
-}
-
-func (s *ConjunctionSearcher) computeQueryNorm() {
-	// first calculate sum of squared weights
-	sumOfSquaredWeights := 0.0
-	for _, searcher := range s.searchers {
-		sumOfSquaredWeights += searcher.Weight()
-	}
-	// now compute query norm from this
-	s.queryNorm = 1.0 / math.Sqrt(sumOfSquaredWeights)
-	// finally tell all the downstream searchers the norm
-	for _, searcher := range s.searchers {
-		searcher.SetQueryNorm(s.queryNorm)
-	}
-}
 
 func optimizeCompositeSearcher(ctx context.Context, optimizationKind string,
 	indexReader index.IndexReader, qsearchers []search.Searcher,

--- a/search/util.go
+++ b/search/util.go
@@ -135,6 +135,6 @@ const MinGeoBufPoolSize = 24
 
 type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
 
-const KnnMetadataKey = "_knn_metadata_key"
+const KnnPreSearchDataKey = "_knn_pre_search_data_key"
 
 const PreSearchKey = "_presearch_key"

--- a/search/util.go
+++ b/search/util.go
@@ -134,3 +134,7 @@ const MaxGeoBufPoolSize = 24 * 1024
 const MinGeoBufPoolSize = 24
 
 type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
+
+const KnnMetadataKey = "_knn_metadata_key"
+
+const PreSearchKey = "_presearch_key"

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -20,13 +20,13 @@ package bleve
 import (
 	"archive/zip"
 	"encoding/json"
-	"math"
 	"math/rand"
 	"strconv"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/analysis/lang/en"
 	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/query"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -37,12 +37,117 @@ const testQueryFileName = "knn_queries.json"
 
 const testDatasetDims = 384
 
-func TestSimilaritySearchPartitionedIndexRandomized(t *testing.T) {
-	runKNNTest(t, true)
-}
+var knnOperators []knnOperator = []knnOperator{knnOperatorAnd, knnOperatorOr}
 
-func TestSimilaritySearchPartitionedIndexNotRandomized(t *testing.T) {
-	runKNNTest(t, false)
+func TestSimilaritySearchPartitionedIndex(t *testing.T) {
+	dataset, searchRequests, err := readDatasetAndQueries(testInputCompressedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	documents := makeDatasetIntoDocuments(dataset)
+	contentFieldMapping := NewTextFieldMapping()
+	contentFieldMapping.Analyzer = en.AnalyzerName
+
+	vecFieldMappingL2 := mapping.NewVectorFieldMapping()
+	vecFieldMappingL2.Dims = testDatasetDims
+	vecFieldMappingL2.Similarity = index.EuclideanDistance
+
+	indexMappingL2Norm := NewIndexMapping()
+	indexMappingL2Norm.DefaultMapping.AddFieldMappingsAt("content", contentFieldMapping)
+	indexMappingL2Norm.DefaultMapping.AddFieldMappingsAt("vector", vecFieldMappingL2)
+
+	vecFieldMappingDot := mapping.NewVectorFieldMapping()
+	vecFieldMappingDot.Dims = testDatasetDims
+	vecFieldMappingDot.Similarity = index.CosineSimilarity
+
+	indexMappingDotProduct := NewIndexMapping()
+	indexMappingDotProduct.DefaultMapping.AddFieldMappingsAt("content", contentFieldMapping)
+	indexMappingDotProduct.DefaultMapping.AddFieldMappingsAt("vector", vecFieldMappingDot)
+
+	type testCase struct {
+		testType           string
+		queryIndex         int
+		numIndexPartitions int
+		mapping            mapping.IndexMapping
+	}
+
+	testCases := []testCase{
+		// l2 norm similarity
+		{
+			testType:           "multi_partition:match_none:oneKNNreq:k=3",
+			queryIndex:         0,
+			numIndexPartitions: 4,
+			mapping:            indexMappingL2Norm,
+		},
+		{
+			testType:           "multi_partition:match_none:oneKNNreq:k=2",
+			queryIndex:         0,
+			numIndexPartitions: 10,
+			mapping:            indexMappingL2Norm,
+		},
+		{
+			testType:           "multi_partition:match:oneKNNreq:k=2",
+			queryIndex:         1,
+			numIndexPartitions: 5,
+			mapping:            indexMappingL2Norm,
+		},
+		{
+			testType:           "multi_partition:disjunction:twoKNNreq:k=2,2",
+			queryIndex:         2,
+			numIndexPartitions: 4,
+			mapping:            indexMappingL2Norm,
+		},
+		// dot product similarity
+		{
+			testType:           "multi_partition:match_none:oneKNNreq:k=3",
+			queryIndex:         0,
+			numIndexPartitions: 4,
+			mapping:            indexMappingDotProduct,
+		},
+		{
+			testType:           "multi_partition:match_none:oneKNNreq:k=2",
+			queryIndex:         0,
+			numIndexPartitions: 10,
+			mapping:            indexMappingDotProduct,
+		},
+		{
+			testType:           "multi_partition:match:oneKNNreq:k=2",
+			queryIndex:         1,
+			numIndexPartitions: 5,
+			mapping:            indexMappingDotProduct,
+		},
+		{
+			testType:           "multi_partition:disjunction:twoKNNreq:k=2,2",
+			queryIndex:         2,
+			numIndexPartitions: 4,
+			mapping:            indexMappingDotProduct,
+		},
+	}
+
+	index := NewIndexAlias()
+	for testCaseNum, testCase := range testCases {
+		for _, operator := range knnOperators {
+			index.indexes = make([]Index, 0)
+			query := searchRequests[testCase.queryIndex]
+			query.AddKNNOperator(operator)
+
+			indexPaths := createPartitionedIndex(documents, index, 1, testCase.mapping, t)
+			controlResult, err := index.Search(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanUp(t, indexPaths, index.indexes...)
+
+			index.indexes = make([]Index, 0)
+			indexPaths = createPartitionedIndex(documents, index, testCase.numIndexPartitions, testCase.mapping, t)
+			experimentalResult, err := index.Search(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifyResult(t, controlResult, experimentalResult, testCaseNum, true)
+			cleanUp(t, indexPaths, index.indexes...)
+		}
+	}
 }
 
 type testDocument struct {
@@ -186,748 +291,63 @@ func createMultipleSegmentsIndex(documents []map[string]interface{}, index Index
 	return nil
 }
 
-// Fisher-Yates shuffle
-func shuffleDocuments(documents []map[string]interface{}) []map[string]interface{} {
-	for i := range documents {
-		j := i + rand.Intn(len(documents)-i)
-		documents[i], documents[j] = documents[j], documents[i]
-	}
-	return documents
-}
-
 func truncateScore(score float64) float64 {
 	return float64(int(score*1e6)) / 1e6
 }
 
-type testResult struct {
-	score          float64
-	scoreBreakdown map[int]float64
-}
-
-func verifyResult(t *testing.T, actualResult *SearchResult, expectedResult map[string]testResult, randomizeDocuments bool, testCaseNum int, skipScoreCheck bool) {
-	if len(actualResult.Hits) != len(expectedResult) {
-		t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(expectedResult), len(actualResult.Hits))
+func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult *SearchResult, testCaseNum int, verifyOnlyDocIDs bool) {
+	if len(controlResult.Hits) != len(experimentalResult.Hits) {
+		t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(controlResult.Hits), len(experimentalResult.Hits))
 	}
-	if skipScoreCheck {
+	if controlResult.Total != experimentalResult.Total {
+		t.Errorf("test case #%d: expected total hits to be %d, got %d", testCaseNum, controlResult.Total, experimentalResult.Total)
+	}
+	if verifyOnlyDocIDs {
+		// in multi partitioned index, we cannot be sure of the score or the ordering of the hits as the tf-idf scores are localized to each partition
+		// so we only check the ids
+		controlMap := make(map[string]struct{})
+		experimentalMap := make(map[string]struct{})
+		for _, hit := range controlResult.Hits {
+			controlMap[hit.ID] = struct{}{}
+		}
+		for _, hit := range experimentalResult.Hits {
+			experimentalMap[hit.ID] = struct{}{}
+		}
+		if len(controlMap) != len(experimentalMap) {
+			t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(controlMap), len(experimentalMap))
+		}
+		for id := range controlMap {
+			if _, ok := experimentalMap[id]; !ok {
+				t.Fatalf("testcase %d failed: expected id %s to be in experimental result", testCaseNum, id)
+			}
+		}
 		return
 	}
-	for i, hit := range actualResult.Hits {
-		var expectedHit testResult
-		var ok bool
-		if expectedHit, ok = expectedResult[hit.ID]; !ok {
-			t.Fatalf("testcase %d failed: unexpected result %s", testCaseNum, hit.ID)
+
+	for i := 0; i < len(controlResult.Hits); i++ {
+		if controlResult.Hits[i].ID != experimentalResult.Hits[i].ID {
+			t.Fatalf("testcase %d failed: expected hit %d to have id %s, got %s", testCaseNum, i, controlResult.Hits[i].ID, experimentalResult.Hits[i].ID)
 		}
 		// Truncate to 6 decimal places
-		actualScore := truncateScore(hit.Score)
-		expectScore := truncateScore(expectedHit.score)
-		if !randomizeDocuments && expectScore != actualScore {
-			t.Fatalf("testcase %d failed: expected hit %d to have score %f, got %f", testCaseNum, i, expectedHit.score, hit.Score)
-		}
-		if len(hit.ScoreBreakdown) != len(expectedHit.scoreBreakdown) {
-			t.Fatalf("testcase %d failed: expected hit %d to have %d score breakdowns, got %d", testCaseNum, i, len(expectedHit.scoreBreakdown), len(hit.ScoreBreakdown))
-		}
-		if !randomizeDocuments {
-			actualScore := truncateScore(hit.ScoreBreakdown[0])
-			expectScore := truncateScore(expectedHit.scoreBreakdown[0])
-			if expectScore != actualScore {
-				t.Fatalf("testcase %d failed: expected hit %d to have score breakdown %f, got %f", testCaseNum, i, expectedHit.scoreBreakdown[0], hit.ScoreBreakdown[0])
-			}
-		}
-		for j := 1; j < len(hit.ScoreBreakdown); j++ {
-			// Truncate to 6 decimal places
-			actualScore := truncateScore(hit.ScoreBreakdown[j])
-			expectScore := truncateScore(expectedHit.scoreBreakdown[j])
-			if expectScore != actualScore {
-				t.Fatalf("testcase %d failed: expected hit %d to have score breakdown %f, got %f", testCaseNum, i, expectedHit.scoreBreakdown[j], hit.ScoreBreakdown[j])
-			}
+		actualScore := truncateScore(experimentalResult.Hits[i].Score)
+		expectScore := truncateScore(controlResult.Hits[i].Score)
+		if expectScore != actualScore {
+			t.Fatalf("testcase %d failed: expected hit %d to have score %f, got %f", testCaseNum, i, expectScore, actualScore)
 		}
 	}
-}
-
-func runKNNTest(t *testing.T, randomizeDocuments bool) {
-	dataset, searchRequests, err := readDatasetAndQueries(testInputCompressedFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	documents := makeDatasetIntoDocuments(dataset)
-	if randomizeDocuments {
-		documents = shuffleDocuments(documents)
-	}
-	contentFieldMapping := NewTextFieldMapping()
-	contentFieldMapping.Analyzer = en.AnalyzerName
-
-	vecFieldMappingL2 := mapping.NewVectorFieldMapping()
-	vecFieldMappingL2.Dims = testDatasetDims
-	vecFieldMappingL2.Similarity = index.EuclideanDistance
-
-	indexMappingL2Norm := NewIndexMapping()
-	indexMappingL2Norm.DefaultMapping.AddFieldMappingsAt("content", contentFieldMapping)
-	indexMappingL2Norm.DefaultMapping.AddFieldMappingsAt("vector", vecFieldMappingL2)
-
-	vecFieldMappingDot := mapping.NewVectorFieldMapping()
-	vecFieldMappingDot.Dims = testDatasetDims
-	vecFieldMappingDot.Similarity = index.CosineSimilarity
-
-	indexMappingDotProduct := NewIndexMapping()
-	indexMappingDotProduct.DefaultMapping.AddFieldMappingsAt("content", contentFieldMapping)
-	indexMappingDotProduct.DefaultMapping.AddFieldMappingsAt("vector", vecFieldMappingDot)
-
-	type testCase struct {
-		testType           string
-		queryIndex         int
-		numIndexPartitions int
-		mapping            mapping.IndexMapping
-		expectedResults    map[string]testResult
+	if truncateScore(controlResult.MaxScore) != truncateScore(experimentalResult.MaxScore) {
+		t.Errorf("test case #%d: expected maxScore to be %f, got %f", testCaseNum, controlResult.MaxScore, experimentalResult.MaxScore)
 	}
 
-	testCases := []testCase{
-		// l2 norm similarity
-		{
-			testType:           "single_partition:match_none:oneKNNreq:k=3",
-			queryIndex:         0,
-			numIndexPartitions: 1,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.5547758085810349,
-					scoreBreakdown: map[int]float64{1: 1.1095516171620698},
-				},
-				"doc23": {
-					score:          0.3817633037007331,
-					scoreBreakdown: map[int]float64{1: 0.7635266074014662},
-				},
-				"doc28": {
-					score:          0.33983667469689355,
-					scoreBreakdown: map[int]float64{1: 0.6796733493937871},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match_none:oneKNNreq:k=3",
-			queryIndex:         0,
-			numIndexPartitions: 4,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.5547758085810349,
-					scoreBreakdown: map[int]float64{1: 1.1095516171620698},
-				},
-				"doc23": {
-					score:          0.3817633037007331,
-					scoreBreakdown: map[int]float64{1: 0.7635266074014662},
-				},
-				"doc28": {
-					score:          0.33983667469689355,
-					scoreBreakdown: map[int]float64{1: 0.6796733493937871},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match_none:oneKNNreq:k=2",
-			queryIndex:         0,
-			numIndexPartitions: 10,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.5547758085810349,
-					scoreBreakdown: map[int]float64{1: 1.1095516171620698},
-				},
-				"doc23": {
-					score:          0.3817633037007331,
-					scoreBreakdown: map[int]float64{1: 0.7635266074014662},
-				},
-				"doc28": {
-					score:          0.33983667469689355,
-					scoreBreakdown: map[int]float64{1: 0.6796733493937871},
-				},
-			},
-		},
-		{
-			testType:           "single_partition:match:oneKNNreq:k=2",
-			queryIndex:         1,
-			numIndexPartitions: 1,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          1.8859816084399936,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237, 1: 1.1095516171620698},
-				},
-				"doc23": {
-					score:          1.8615644255330264,
-					scoreBreakdown: map[int]float64{0: 1.0980378181315602, 1: 0.7635266074014662},
-				},
-				"doc27": {
-					score:          0.4640056648691007,
-					scoreBreakdown: map[int]float64{0: 0.9280113297382014},
-				},
-				"doc28": {
-					score:          0.434037555556026,
-					scoreBreakdown: map[int]float64{0: 0.868075111112052},
-				},
-				"doc30": {
-					score:          0.38821499563896184,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237},
-				},
-				"doc24": {
-					score:          0.38821499563896184,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match:oneKNNreq:k=2",
-			queryIndex:         1,
-			numIndexPartitions: 5,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc23": {
-					score:          1.5207250366637521,
-					scoreBreakdown: map[int]float64{0: 0.7571984292622859, 1: 0.7635266074014662},
-				},
-				"doc29": {
-					score:          1.4834345192674083,
-					scoreBreakdown: map[int]float64{0: 0.3738829021053385, 1: 1.1095516171620698},
-				},
-				"doc24": {
-					score:          0.2677100734235977,
-					scoreBreakdown: map[int]float64{0: 0.5354201468471954},
-				},
-				"doc27": {
-					score:          0.22343776840593196,
-					scoreBreakdown: map[int]float64{0: 0.4468755368118639},
-				},
-				"doc28": {
-					score:          0.20900689401100958,
-					scoreBreakdown: map[int]float64{0: 0.41801378802201916},
-				},
-				"doc30": {
-					score:          0.18694145105266924,
-					scoreBreakdown: map[int]float64{0: 0.3738829021053385},
-				},
-			},
-		},
-		{
-			testType:           "single_partition:disjunction:twoKNNreq:k=2,2",
-			queryIndex:         2,
-			numIndexPartitions: 1,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc7": {
-					score:          math.MaxFloat64 / 3.0,
-					scoreBreakdown: map[int]float64{2: math.MaxFloat64},
-				},
-				"doc29": {
-					score:          0.6774608026082964,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517, 1: 0.7845714725717996},
-				},
-				"doc23": {
-					score:          0.5783030702431613,
-					scoreBreakdown: map[int]float64{0: 0.32755976365480655, 1: 0.5398948417099355},
-				},
-				"doc3": {
-					score:          0.2550334160459894,
-					scoreBreakdown: map[int]float64{0: 0.7651002481379682},
-				},
-				"doc13": {
-					score:          0.2208654210738964,
-					scoreBreakdown: map[int]float64{0: 0.6625962632216892},
-				},
-				"doc5": {
-					score:          0.21180931116413285,
-					scoreBreakdown: map[int]float64{2: 0.6354279334923986},
-				},
-				"doc27": {
-					score:          0.09227950890170131,
-					scoreBreakdown: map[int]float64{0: 0.2768385267051039},
-				},
-				"doc28": {
-					score:          0.0863195764709126,
-					scoreBreakdown: map[int]float64{0: 0.2589587294127378},
-				},
-				"doc30": {
-					score:          0.07720657711354839,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517},
-				},
-				"doc24": {
-					score:          0.07720657711354839,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:disjunction:twoKNNreq:k=2,2",
-			queryIndex:         2,
-			numIndexPartitions: 4,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc7": {
-					score:          math.MaxFloat64 / 3.0,
-					scoreBreakdown: map[int]float64{2: math.MaxFloat64},
-				},
-				"doc29": {
-					score:          0.567426591648309,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398, 1: 0.7845714725717996},
-				},
-				"doc23": {
-					score:          0.5639255136185979,
-					scoreBreakdown: map[int]float64{0: 0.3059934287179615, 1: 0.5398948417099355},
-				},
-				"doc5": {
-					score:          0.21180931116413285,
-					scoreBreakdown: map[int]float64{2: 0.6354279334923986},
-				},
-				"doc3": {
-					score:          0.14064944169372873,
-					scoreBreakdown: map[int]float64{0: 0.4219483250811862},
-				},
-				"doc13": {
-					score:          0.12180599172106943,
-					scoreBreakdown: map[int]float64{0: 0.3654179751632083},
-				},
-				"doc27": {
-					score:          0.026521491065731144,
-					scoreBreakdown: map[int]float64{0: 0.07956447319719343},
-				},
-				"doc28": {
-					score:          0.024808583220893122,
-					scoreBreakdown: map[int]float64{0: 0.07442574966267937},
-				},
-				"doc30": {
-					score:          0.02218947163355466,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398},
-				},
-				"doc24": {
-					score:          0.02218947163355466,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398},
-				},
-			},
-		},
-		{
-			// control:
-			// from = 0
-			// size = 8
-			testType:           "pagination",
-			queryIndex:         3,
-			numIndexPartitions: 4,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc24": {
-					score:          1.22027994094805,
-					scoreBreakdown: map[int]float64{0: 0.027736154383370196, 1: 0.3471022633855392, 2: 0.5085619451465123, 3: 0.33687957803262836},
-				},
-				"doc17": {
-					score:          0.7851856993753307,
-					scoreBreakdown: map[int]float64{0: 0.3367753689069724, 2: 0.3892791754255179, 3: 0.320859721501284},
-				},
-				"doc21": {
-					score:          0.5927148028393034,
-					scoreBreakdown: map[int]float64{0: 0.06974846263723515, 2: 0.3914133076090359, 3: 0.3291246335394669},
-				},
-				"doc14": {
-					score:          0.45680756875853035,
-					scoreBreakdown: map[int]float64{0: 0.5968461853543279, 3: 0.31676895216273276},
-				},
-				"doc25": {
-					score:          0.292014972318407,
-					scoreBreakdown: map[int]float64{0: 0.17861510907524708, 2: 0.405414835561567},
-				},
-				"doc23": {
-					score:          0.24706850662359503,
-					scoreBreakdown: map[int]float64{0: 0.09761951136424651, 2: 0.39651750188294355},
-				},
-				"doc15": {
-					score:          0.24489276164017085,
-					scoreBreakdown: map[int]float64{0: 0.17216818679645968, 3: 0.317617336483882},
-				},
-				"doc5": {
-					score:          0.10331722282971788,
-					scoreBreakdown: map[int]float64{1: 0.4132688913188715},
-				},
-			},
-		},
-		{
-			// experimental:
-			// from = 0
-			// size = 3
-			testType:           "pagination",
-			queryIndex:         4,
-			numIndexPartitions: 4,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc24": {
-					score:          1.22027994094805,
-					scoreBreakdown: map[int]float64{0: 0.027736154383370196, 1: 0.3471022633855392, 2: 0.5085619451465123, 3: 0.33687957803262836},
-				},
-				"doc17": {
-					score:          0.7851856993753307,
-					scoreBreakdown: map[int]float64{0: 0.3367753689069724, 2: 0.3892791754255179, 3: 0.320859721501284},
-				},
-				"doc21": {
-					score:          0.5927148028393034,
-					scoreBreakdown: map[int]float64{0: 0.06974846263723515, 2: 0.3914133076090359, 3: 0.3291246335394669},
-				},
-			},
-		},
-		{
-			// from = 3
-			// size = 3
-			testType:           "pagination",
-			queryIndex:         5,
-			numIndexPartitions: 4,
-			mapping:            indexMappingL2Norm,
-			expectedResults: map[string]testResult{
-				"doc14": {
-					score:          0.45680756875853035,
-					scoreBreakdown: map[int]float64{0: 0.5968461853543279, 3: 0.31676895216273276},
-				},
-				"doc25": {
-					score:          0.292014972318407,
-					scoreBreakdown: map[int]float64{0: 0.17861510907524708, 2: 0.405414835561567},
-				},
-				"doc23": {
-					score:          0.24706850662359503,
-					scoreBreakdown: map[int]float64{0: 0.09761951136424651, 2: 0.39651750188294355},
-				},
-			},
-		},
-		// dot product similarity
-		{
-			testType:           "single_partition:match_none:oneKNNreq:k=3",
-			queryIndex:         0,
-			numIndexPartitions: 1,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.2746838331222534,
-					scoreBreakdown: map[int]float64{1: 0.5493676662445068},
-				},
-				"doc23": {
-					score:          0.17257216572761536,
-					scoreBreakdown: map[int]float64{1: 0.3451443314552307},
-				},
-				"doc28": {
-					score:          0.13217630982398987,
-					scoreBreakdown: map[int]float64{1: 0.26435261964797974},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match_none:oneKNNreq:k=3",
-			queryIndex:         0,
-			numIndexPartitions: 4,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.2746838331222534,
-					scoreBreakdown: map[int]float64{1: 0.5493676662445068},
-				},
-				"doc23": {
-					score:          0.17257216572761536,
-					scoreBreakdown: map[int]float64{1: 0.3451443314552307},
-				},
-				"doc28": {
-					score:          0.13217630982398987,
-					scoreBreakdown: map[int]float64{1: 0.26435261964797974},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match_none:oneKNNreq:k=2",
-			queryIndex:         0,
-			numIndexPartitions: 10,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.2746838331222534,
-					scoreBreakdown: map[int]float64{1: 0.5493676662445068},
-				},
-				"doc23": {
-					score:          0.17257216572761536,
-					scoreBreakdown: map[int]float64{1: 0.3451443314552307},
-				},
-				"doc28": {
-					score:          0.13217630982398987,
-					scoreBreakdown: map[int]float64{1: 0.26435261964797974},
-				},
-			},
-		},
-		{
-			testType:           "single_partition:match:oneKNNreq:k=2",
-			queryIndex:         1,
-			numIndexPartitions: 1,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc23": {
-					score:          1.443182149586791,
-					scoreBreakdown: map[int]float64{0: 1.0980378181315602, 1: 0.3451443314552307},
-				},
-				"doc29": {
-					score:          1.3257976575224304,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237, 1: 0.5493676662445068},
-				},
-				"doc27": {
-					score:          0.4640056648691007,
-					scoreBreakdown: map[int]float64{0: 0.9280113297382014},
-				},
-				"doc28": {
-					score:          0.434037555556026,
-					scoreBreakdown: map[int]float64{0: 0.868075111112052},
-				},
-				"doc30": {
-					score:          0.38821499563896184,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237},
-				},
-				"doc24": {
-					score:          0.38821499563896184,
-					scoreBreakdown: map[int]float64{0: 0.7764299912779237},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:match:oneKNNreq:k=2",
-			queryIndex:         1,
-			numIndexPartitions: 5,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc23": {
-					score:          1.1023427607175167,
-					scoreBreakdown: map[int]float64{0: 0.7571984292622859, 1: 0.3451443314552307},
-				},
-				"doc29": {
-					score:          0.9232505683498453,
-					scoreBreakdown: map[int]float64{0: 0.3738829021053385, 1: 0.5493676662445068},
-				},
-				"doc24": {
-					score:          0.2677100734235977,
-					scoreBreakdown: map[int]float64{0: 0.5354201468471954},
-				},
-				"doc27": {
-					score:          0.22343776840593196,
-					scoreBreakdown: map[int]float64{0: 0.4468755368118639},
-				},
-				"doc28": {
-					score:          0.20900689401100958,
-					scoreBreakdown: map[int]float64{0: 0.41801378802201916},
-				},
-				"doc30": {
-					score:          0.18694145105266924,
-					scoreBreakdown: map[int]float64{0: 0.3738829021053385},
-				},
-			},
-		},
-		{
-			testType:           "single_partition:disjunction:twoKNNreq:k=2,2",
-			queryIndex:         2,
-			numIndexPartitions: 1,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc29": {
-					score:          0.4133875556711759,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517, 1: 0.38846160216611875},
-				},
-				"doc23": {
-					score:          0.3810757739432651,
-					scoreBreakdown: map[int]float64{0: 0.32755976365480655, 1: 0.24405389726009102},
-				},
-				"doc3": {
-					score:          0.2550334160459894,
-					scoreBreakdown: map[int]float64{0: 0.7651002481379682},
-				},
-				"doc7": {
-					score:          0.23570219015076832,
-					scoreBreakdown: map[int]float64{2: 0.707106570452305},
-				},
-				"doc13": {
-					score:          0.2208654210738964,
-					scoreBreakdown: map[int]float64{0: 0.6625962632216892},
-				},
-				"doc5": {
-					score:          0.10455702372648192,
-					scoreBreakdown: map[int]float64{2: 0.31367107117944576},
-				},
-				"doc27": {
-					score:          0.09227950890170131,
-					scoreBreakdown: map[int]float64{0: 0.2768385267051039},
-				},
-				"doc28": {
-					score:          0.0863195764709126,
-					scoreBreakdown: map[int]float64{0: 0.2589587294127378},
-				},
-				"doc30": {
-					score:          0.07720657711354839,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517},
-				},
-				"doc24": {
-					score:          0.07720657711354839,
-					scoreBreakdown: map[int]float64{0: 0.23161973134064517},
-				},
-			},
-		},
-		{
-			testType:           "multi_partition:disjunction:twoKNNreq:k=2,2",
-			queryIndex:         2,
-			numIndexPartitions: 4,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc23": {
-					score:          0.36669821731870167,
-					scoreBreakdown: map[int]float64{0: 0.3059934287179615, 1: 0.24405389726009102},
-				},
-				"doc29": {
-					score:          0.30335334471118847,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398, 1: 0.38846160216611875},
-				},
-				"doc7": {
-					score:          0.23570219015076832,
-					scoreBreakdown: map[int]float64{2: 0.707106570452305},
-				},
-				"doc3": {
-					score:          0.14064944169372873,
-					scoreBreakdown: map[int]float64{0: 0.4219483250811862},
-				},
-				"doc13": {
-					score:          0.12180599172106943,
-					scoreBreakdown: map[int]float64{0: 0.3654179751632083},
-				},
-				"doc5": {
-					score:          0.10455702372648192,
-					scoreBreakdown: map[int]float64{2: 0.31367107117944576},
-				},
-				"doc27": {
-					score:          0.026521491065731144,
-					scoreBreakdown: map[int]float64{0: 0.07956447319719343},
-				},
-				"doc28": {
-					score:          0.024808583220893122,
-					scoreBreakdown: map[int]float64{0: 0.07442574966267937},
-				},
-				"doc30": {
-					score:          0.02218947163355466,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398},
-				},
-				"doc24": {
-					score:          0.02218947163355466,
-					scoreBreakdown: map[int]float64{0: 0.06656841490066398},
-				},
-			},
-		},
-		{
-			// control:
-			// from = 0
-			// size = 8
-			testType:           "pagination",
-			queryIndex:         3,
-			numIndexPartitions: 4,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc24": {
-					score:          0.45716299530348536,
-					scoreBreakdown: map[int]float64{0: 0.027736154383370196, 1: 0.09718442379837483, 2: 0.24962871627005187, 3: 0.08261370085168844},
-				},
-				"doc17": {
-					score:          0.40792221729717437,
-					scoreBreakdown: map[int]float64{0: 0.3367753689069724, 2: 0.14920840064225363, 3: 0.05791252018033977},
-				},
-				"doc14": {
-					score:          0.3240253778614369,
-					scoreBreakdown: map[int]float64{0: 0.5968461853543279, 3: 0.05120457036854595},
-				},
-				"doc21": {
-					score:          0.2191859820036201,
-					scoreBreakdown: map[int]float64{0: 0.06974846263723515, 2: 0.1515430653633034, 3: 0.0709564480042883},
-				},
-				"doc25": {
-					score:          0.1724318546817751,
-					scoreBreakdown: map[int]float64{0: 0.17861510907524708, 2: 0.16624860028830313},
-				},
-				"doc23": {
-					score:          0.12732176553007302,
-					scoreBreakdown: map[int]float64{0: 0.09761951136424651, 2: 0.15702401969589952},
-				},
-				"doc15": {
-					score:          0.11238897955499198,
-					scoreBreakdown: map[int]float64{0: 0.17216818679645968, 3: 0.052609772313524296},
-				},
-				"doc20": {
-					score:          0.06759830898809112,
-					scoreBreakdown: map[int]float64{0: 0.2703932359523645},
-				},
-			},
-		},
-		{
-			// experimental:
-			// from = 0
-			// size = 3
-			testType:           "pagination",
-			queryIndex:         4,
-			numIndexPartitions: 4,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc24": {
-					score:          0.45716299530348536,
-					scoreBreakdown: map[int]float64{0: 0.027736154383370196, 1: 0.09718442379837483, 2: 0.24962871627005187, 3: 0.08261370085168844},
-				},
-				"doc17": {
-					score:          0.40792221729717437,
-					scoreBreakdown: map[int]float64{0: 0.3367753689069724, 2: 0.14920840064225363, 3: 0.05791252018033977},
-				},
-				"doc14": {
-					score:          0.3240253778614369,
-					scoreBreakdown: map[int]float64{0: 0.5968461853543279, 3: 0.05120457036854595},
-				},
-			},
-		},
-		{
-			// from = 3
-			// size = 3
-			testType:           "pagination",
-			queryIndex:         5,
-			numIndexPartitions: 4,
-			mapping:            indexMappingDotProduct,
-			expectedResults: map[string]testResult{
-				"doc21": {
-					score:          0.2191859820036201,
-					scoreBreakdown: map[int]float64{0: 0.06974846263723515, 2: 0.1515430653633034, 3: 0.0709564480042883},
-				},
-				"doc25": {
-					score:          0.1724318546817751,
-					scoreBreakdown: map[int]float64{0: 0.17861510907524708, 2: 0.16624860028830313},
-				},
-				"doc23": {
-					score:          0.12732176553007302,
-					scoreBreakdown: map[int]float64{0: 0.09761951136424651, 2: 0.15702401969589952},
-				},
-			},
-		},
-	}
-
-	index := NewIndexAlias()
-	for testCaseNum, testCase := range testCases {
-		index.indexes = make([]Index, 0)
-		indexPaths := createPartitionedIndex(documents, index, testCase.numIndexPartitions, testCase.mapping, t)
-		query := searchRequests[testCase.queryIndex]
-		res, err := index.Search(query)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// pagination test case -> scores are not deterministic
-		skipScoreCheck := testCase.testType == "pagination"
-		verifyResult(t, res, testCase.expectedResults, randomizeDocuments, testCaseNum, skipScoreCheck)
-		cleanUp(t, indexPaths, index.indexes...)
-	}
-}
-
-func getExpectedResultFromSearchResult(res *SearchResult) map[string]testResult {
-	rv := make(map[string]testResult)
-	for _, hit := range res.Hits {
-		rv[hit.ID] = testResult{
-			score:          hit.Score,
-			scoreBreakdown: hit.ScoreBreakdown,
-		}
-	}
-	return rv
 }
 func TestSimilaritySearchMultipleSegments(t *testing.T) {
+	// to run this test you must first add the line
+	// 				return nil
+	// in the scorch.go file just before these two lines
+	// 				s.asyncTasks.Add(1)
+	//				go s.mergerLoop()
+	// this is to prevent the merger from running and merging the segments
+	// before we can test the search on multiple segments
 	dataset, searchRequests, err := readDatasetAndQueries(testInputCompressedFile)
 	if err != nil {
 		t.Fatal(err)
@@ -957,8 +377,9 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 		numSegments int
 		queryIndex  int
 		mapping     mapping.IndexMapping
+		scoreValue  string
 	}{
-		// L2 norm similarity
+		// // L2 norm similarity
 		{
 			numSegments: 6,
 			queryIndex:  0,
@@ -975,6 +396,22 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			mapping:     indexMappingL2Norm,
 		},
 		{
+			numSegments: 9,
+			queryIndex:  3,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 10,
+			queryIndex:  4,
+			mapping:     indexMappingL2Norm,
+		},
+		{
+			numSegments: 11,
+			queryIndex:  5,
+			mapping:     indexMappingL2Norm,
+		},
+		// dot_product similarity
+		{
 			numSegments: 6,
 			queryIndex:  0,
 			mapping:     indexMappingDotProduct,
@@ -988,52 +425,117 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			numSegments: 8,
 			queryIndex:  2,
 			mapping:     indexMappingDotProduct,
+		},
+		{
+			numSegments: 9,
+			queryIndex:  3,
+			mapping:     indexMappingDotProduct,
+		},
+		{
+			numSegments: 10,
+			queryIndex:  4,
+			mapping:     indexMappingDotProduct,
+		},
+		{
+			numSegments: 11,
+			queryIndex:  5,
+			mapping:     indexMappingDotProduct,
+		},
+		// score none test
+		{
+			numSegments: 3,
+			queryIndex:  0,
+			mapping:     indexMappingL2Norm,
+			scoreValue:  "none",
+		},
+		{
+			numSegments: 7,
+			queryIndex:  1,
+			mapping:     indexMappingL2Norm,
+			scoreValue:  "none",
+		},
+		{
+			numSegments: 8,
+			queryIndex:  2,
+			mapping:     indexMappingL2Norm,
+			scoreValue:  "none",
+		},
+		{
+			numSegments: 3,
+			queryIndex:  0,
+			mapping:     indexMappingDotProduct,
+			scoreValue:  "none",
+		},
+		{
+			numSegments: 7,
+			queryIndex:  1,
+			mapping:     indexMappingDotProduct,
+			scoreValue:  "none",
+		},
+		{
+			numSegments: 8,
+			queryIndex:  2,
+			mapping:     indexMappingDotProduct,
+			scoreValue:  "none",
 		},
 	}
 	for testCaseNum, testCase := range testCases {
-		// run single segment test first
-		tmpIndexPath := createTmpIndexPath(t)
-		index, err := New(tmpIndexPath, testCase.mapping)
-		if err != nil {
-			t.Fatal(err)
-		}
-		query := searchRequests[testCase.queryIndex]
-		err = createMultipleSegmentsIndex(documents, index, 1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		res, err := index.Search(query)
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedResult := getExpectedResultFromSearchResult(res)
-		err = index.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		cleanupTmpIndexPath(t, tmpIndexPath)
+		for _, operator := range knnOperators {
+			// run single segment test first
+			tmpIndexPath := createTmpIndexPath(t)
+			index, err := New(tmpIndexPath, testCase.mapping)
+			if err != nil {
+				t.Fatal(err)
+			}
+			query := searchRequests[testCase.queryIndex]
+			query.Sort = search.SortOrder{&search.SortScore{Desc: true}, &search.SortDocID{Desc: true}}
+			query.AddKNNOperator(operator)
+			err = createMultipleSegmentsIndex(documents, index, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			controlResult, err := index.Search(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if testCase.scoreValue == "none" {
+				query.Score = testCase.scoreValue
+				expectedResultScoreNone, err := index.Search(query)
+				if err != nil {
+					t.Fatal(err)
+				}
+				verifyResult(t, controlResult, expectedResultScoreNone, testCaseNum, true)
+				query.Score = ""
+			}
+			err = index.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupTmpIndexPath(t, tmpIndexPath)
 
-		// run multiple segments test
-		tmpIndexPath = createTmpIndexPath(t)
-		index, err = New(tmpIndexPath, testCase.mapping)
-		if err != nil {
-			t.Fatal(err)
+			// run multiple segments test
+			tmpIndexPath = createTmpIndexPath(t)
+			index, err = New(tmpIndexPath, testCase.mapping)
+			if err != nil {
+				t.Fatal(err)
+			}
+			query = searchRequests[testCase.queryIndex]
+			query.AddKNNOperator(operator)
+			err = createMultipleSegmentsIndex(documents, index, testCase.numSegments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			experimentalResult, err := index.Search(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifyResult(t, controlResult, experimentalResult, testCaseNum, false)
+			err = index.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupTmpIndexPath(t, tmpIndexPath)
 		}
-		query = searchRequests[testCase.queryIndex]
-		err = createMultipleSegmentsIndex(documents, index, testCase.numSegments)
-		if err != nil {
-			t.Fatal(err)
-		}
-		actualResult, err := index.Search(query)
-		if err != nil {
-			t.Fatal(err)
-		}
-		verifyResult(t, actualResult, expectedResult, false, testCaseNum, false)
-		err = index.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		cleanupTmpIndexPath(t, tmpIndexPath)
 	}
 }
 
@@ -1109,29 +611,23 @@ func TestKNNOperator(t *testing.T) {
 
 	// Conjunction
 	searchRequest.AddKNNOperator(knnOperatorAnd)
-	conjunction, err := queryWithKNN(searchRequest)
+	conjunction, _, _, err := createKNNQuery(searchRequest)
 	if err != nil {
 		t.Fatalf("unexpected error for AND knn operator")
 	}
 
-	conj, ok := conjunction.(*query.ConjunctionQuery)
+	conj, ok := conjunction.(*query.DisjunctionQuery)
 	if !ok {
-		t.Fatalf("expected conjunction query")
+		t.Fatalf("expected disjunction query")
 	}
 
-	if len(conj.Conjuncts) == 3 {
-		_, ok := conj.Conjuncts[0].(*query.TermQuery)
-		if !ok {
-			t.Fatalf("expected first query to be a term query,"+
-				" but it's %T", conj.Conjuncts[0])
-		}
-	} else {
-		t.Fatalf("expected 3 conjuncts")
+	if len(conj.Disjuncts) != 2 {
+		t.Fatalf("expected 2 disjuncts")
 	}
 
 	// Disjunction
 	searchRequest.AddKNNOperator(knnOperatorOr)
-	disjunction, err := queryWithKNN(searchRequest)
+	disjunction, _, _, err := createKNNQuery(searchRequest)
 	if err != nil {
 		t.Fatalf("unexpected error for OR knn operator")
 	}
@@ -1141,19 +637,13 @@ func TestKNNOperator(t *testing.T) {
 		t.Fatalf("expected disjunction query")
 	}
 
-	if len(disj.Disjuncts) == 3 {
-		_, ok := disj.Disjuncts[0].(*query.TermQuery)
-		if !ok {
-			t.Fatalf("expected first query to be a term query,"+
-				" but it's %T", conj.Conjuncts[0])
-		}
-	} else {
-		t.Fatalf("expected 3 disjuncts")
+	if len(disj.Disjuncts) != 2 {
+		t.Fatalf("expected 2 disjuncts")
 	}
 
 	// Incorrect operator.
 	searchRequest.AddKNNOperator("bs_op")
-	searchRequest.Query, err = queryWithKNN(searchRequest)
+	searchRequest.Query, _, _, err = createKNNQuery(searchRequest)
 	if err == nil {
 		t.Fatalf("expected error for incorrect knn operator")
 	}

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -182,3 +182,7 @@ func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {
 
 func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch, mergeOut []map[string]interface{}) {
 }
+
+func redistributeKNNMetadata(req *SearchRequest, mergedOut []map[string]interface{}) error {
+	return nil
+}

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -82,19 +82,19 @@ type SearchRequest struct {
 // a SearchRequest
 func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	var temp struct {
-		Q                json.RawMessage        `json:"query"`
-		Size             *int                   `json:"size"`
-		From             int                    `json:"from"`
-		Highlight        *HighlightRequest      `json:"highlight"`
-		Fields           []string               `json:"fields"`
-		Facets           FacetsRequest          `json:"facets"`
-		Explain          bool                   `json:"explain"`
-		Sort             []json.RawMessage      `json:"sort"`
-		IncludeLocations bool                   `json:"includeLocations"`
-		Score            string                 `json:"score"`
-		SearchAfter      []string               `json:"search_after"`
-		SearchBefore     []string               `json:"search_before"`
-		PreSearchData    map[string]interface{} `json:"pre_search_data"`
+		Q                json.RawMessage   `json:"query"`
+		Size             *int              `json:"size"`
+		From             int               `json:"from"`
+		Highlight        *HighlightRequest `json:"highlight"`
+		Fields           []string          `json:"fields"`
+		Facets           FacetsRequest     `json:"facets"`
+		Explain          bool              `json:"explain"`
+		Sort             []json.RawMessage `json:"sort"`
+		IncludeLocations bool              `json:"includeLocations"`
+		Score            string            `json:"score"`
+		SearchAfter      []string          `json:"search_after"`
+		SearchBefore     []string          `json:"search_before"`
+		PreSearchData    json.RawMessage   `json:"pre_search_data"`
 	}
 
 	err := json.Unmarshal(input, &temp)


### PR DESCRIPTION
- Reverts commit https://github.com/blevesearch/bleve/pull/1910, which was an earlier attempt to address this issue.
- Implements the PreSearch Construct in Bleve alias search, enabling a preliminary query to collect metadata from all alias indexes before executing the main search query in MultiSearch. PreSearch gathers KNN results from all alias indexes, selecting the top K results. This facilitates the main Bleve Query to operate within the context of documents that matched the KNN query, ensuring seamless functionality of existing Bleve constructs such as Faceting, Sorting, Pagination, SearchAfter, and SearchBefore.
- Introduces the KNN Collector construct to merge and obtain accurate Top K results from multiple Zap Segments' KNN results.
- Enhances KNN Unit Tests for greater generality.
- Addresses an issue where errors generated within the Top N Document handler were being discarded.
- Resolves an issue where document matches failing to meet the SearchAfter clause weren't being returned to the pool.

