### PR TITLE
MB-60081: Fix Score Explanation

### DIFF
--- a/search/collector/knn.go
+++ b/search/collector/knn.go
@@ -83,9 +83,11 @@ func (c *collectStoreKNN) Final(fixup collectorFixup) (search.DocumentMatchColle
 	rv := make(search.DocumentMatchCollection, size)
 	i := 0
 	for doc := range c.allHits {
-		err := fixup(doc)
-		if err != nil {
-			return nil, err
+		if fixup != nil {
+			err := fixup(doc)
+			if err != nil {
+				return nil, err
+			}
 		}
 		rv[i] = doc
 		i++

--- a/search/scorer/scorer_knn_test.go
+++ b/search/scorer/scorer_knn_test.go
@@ -59,12 +59,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.5,
 				Expl: &search.Explanation{
 					Value:   1 / 0.5,
-					Message: "fieldWeight(desc in doc one), score of:",
-					Children: []*search.Explanation{
-						{Value: 1 / 0.5,
-							Message: "vector(field(desc:one) with similarity_metric(l2_norm)=2.000000e+00",
-						},
-					},
+					Message: "vector(field(desc) with similarity_metric(l2_norm)=2.000000e+00",
 				},
 			},
 		},
@@ -84,12 +79,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.0,
 				Expl: &search.Explanation{
 					Value:   maxKNNScore,
-					Message: "fieldWeight(desc in doc one), score of:",
-					Children: []*search.Explanation{
-						{Value: maxKNNScore,
-							Message: "vector(field(desc:one) with similarity_metric(l2_norm)=1.797693e+308",
-						},
-					},
+					Message: "vector(field(desc) with similarity_metric(l2_norm)=1.797693e+308",
 				},
 			},
 		},
@@ -107,12 +97,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.5,
 				Expl: &search.Explanation{
 					Value:   0.5,
-					Message: "fieldWeight(desc in doc one), score of:",
-					Children: []*search.Explanation{
-						{Value: 0.5,
-							Message: "vector(field(desc:one) with similarity_metric(dot_product)=5.000000e-01",
-						},
-					},
+					Message: "vector(field(desc) with similarity_metric(dot_product)=5.000000e-01",
 				},
 			},
 		},
@@ -130,7 +115,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.25,
 				Expl: &search.Explanation{
 					Value:   0.125,
-					Message: "weight(desc:query Vector^1.000000 in one), product of:",
+					Message: "weight(desc:query Vector^1.000000), product of:",
 					Children: []*search.Explanation{
 						{
 							Value:   0.5,
@@ -148,13 +133,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 						},
 						{
 							Value:   0.25,
-							Message: "fieldWeight(desc in doc one), score of:",
-							Children: []*search.Explanation{
-								{
-									Value:   0.25,
-									Message: "vector(field(desc:one) with similarity_metric(dot_product)=2.500000e-01",
-								},
-							},
+							Message: "vector(field(desc) with similarity_metric(dot_product)=2.500000e-01",
 						},
 					},
 				},

--- a/search/scorer/scorer_knn_test.go
+++ b/search/scorer/scorer_knn_test.go
@@ -59,7 +59,13 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.5,
 				Expl: &search.Explanation{
 					Value:   1 / 0.5,
-					Message: "vector(field(desc) with similarity_metric(l2_norm)=2.000000e+00",
+					Message: "fieldWeight(desc in doc one), score of:",
+					Children: []*search.Explanation{
+						{
+							Value:   1 / 0.5,
+							Message: "vector(field(desc:one) with similarity_metric(l2_norm)=2.000000e+00",
+						},
+					},
 				},
 			},
 		},
@@ -79,7 +85,13 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.0,
 				Expl: &search.Explanation{
 					Value:   maxKNNScore,
-					Message: "vector(field(desc) with similarity_metric(l2_norm)=1.797693e+308",
+					Message: "fieldWeight(desc in doc one), score of:",
+					Children: []*search.Explanation{
+						{
+							Value:   maxKNNScore,
+							Message: "vector(field(desc:one) with similarity_metric(l2_norm)=1.797693e+308",
+						},
+					},
 				},
 			},
 		},
@@ -97,7 +109,13 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.5,
 				Expl: &search.Explanation{
 					Value:   0.5,
-					Message: "vector(field(desc) with similarity_metric(dot_product)=5.000000e-01",
+					Message: "fieldWeight(desc in doc one), score of:",
+					Children: []*search.Explanation{
+						{
+							Value:   0.5,
+							Message: "vector(field(desc:one) with similarity_metric(dot_product)=5.000000e-01",
+						},
+					},
 				},
 			},
 		},
@@ -115,7 +133,7 @@ func TestKNNScorerExplanation(t *testing.T) {
 				Score:           0.25,
 				Expl: &search.Explanation{
 					Value:   0.125,
-					Message: "weight(desc:query Vector^1.000000), product of:",
+					Message: "weight(desc:query Vector^1.000000 in one), product of:",
 					Children: []*search.Explanation{
 						{
 							Value:   0.5,
@@ -133,7 +151,13 @@ func TestKNNScorerExplanation(t *testing.T) {
 						},
 						{
 							Value:   0.25,
-							Message: "vector(field(desc) with similarity_metric(dot_product)=2.500000e-01",
+							Message: "fieldWeight(desc in doc one), score of:",
+							Children: []*search.Explanation{
+								{
+									Value:   0.25,
+									Message: "vector(field(desc:one) with similarity_metric(dot_product)=2.500000e-01",
+								},
+							},
 						},
 					},
 				},

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -51,7 +51,6 @@ type DisjunctionHeapSearcher struct {
 	scorer                 *scorer.DisjunctionQueryScorer
 	min                    int
 	queryNorm              float64
-	queryNormForKNN        float64
 	retrieveScoreBreakdown bool
 	initialized            bool
 	searchers              []search.Searcher
@@ -213,10 +212,16 @@ func (s *DisjunctionHeapSearcher) Next(ctx *search.SearchContext) (
 	for !found && len(s.matching) > 0 {
 		if len(s.matching) >= s.min {
 			found = true
-			partialMatch := len(s.matching) != len(s.searchers)
-			// score this match
-			rv = s.scorer.Score(ctx, s.matching, len(s.matching), s.numSearchers, s.matchingIdxs, nil, s.retrieveScoreBreakdown)
-			rv.PartialMatch = partialMatch
+			if s.retrieveScoreBreakdown {
+				// just return score and expl breakdown here, since it is a disjunction over knn searchers,
+				// and the final score and expl is calculated in the knn collector
+				rv = s.scorer.ScoreAndExplBreakdown(ctx, s.matching, s.matchingIdxs, nil, s.numSearchers)
+			} else {
+				// score this match
+				partialMatch := len(s.matching) != len(s.searchers)
+				rv = s.scorer.Score(ctx, s.matching, len(s.matching), s.numSearchers)
+				rv.PartialMatch = partialMatch
+			}
 		}
 
 		// invoke next on all the matching searchers

--- a/search/util.go
+++ b/search/util.go
@@ -138,3 +138,5 @@ type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
 const KnnPreSearchDataKey = "_knn_pre_search_data_key"
 
 const PreSearchKey = "_presearch_key"
+
+type ScoreExplCorrectionCallbackFunc func(queryMatch *DocumentMatch, knnMatch *DocumentMatch) (float64, *Explanation)

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -21,6 +21,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"math/rand"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -296,6 +297,38 @@ func truncateScore(score float64) float64 {
 	return float64(int(score*1e6)) / 1e6
 }
 
+// Function to compare two Explanation structs recursively
+func compareExplanation(a, b *search.Explanation) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	if a.Value != b.Value || len(a.Children) != len(b.Children) {
+		return false
+	}
+
+	// Sort the children slices before comparison
+	sortChildren(a.Children)
+	sortChildren(b.Children)
+
+	for i := range a.Children {
+		if !compareExplanation(a.Children[i], b.Children[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Function to sort the children slices
+func sortChildren(children []*search.Explanation) {
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].Value < children[j].Value
+	})
+}
+
 func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult *SearchResult, testCaseNum int, verifyOnlyDocIDs bool) {
 	if controlResult.Hits.Len() == 0 || experimentalResult.Hits.Len() == 0 {
 		t.Fatalf("testcase %d failed: 0 hits returned", testCaseNum)
@@ -338,6 +371,10 @@ func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult 
 		if expectScore != actualScore {
 			t.Fatalf("testcase %d failed: expected hit %d to have score %f, got %f", testCaseNum, i, expectScore, actualScore)
 		}
+		if !compareExplanation(controlResult.Hits[i].Expl, experimentalResult.Hits[i].Expl) {
+			t.Fatalf("testcase %d failed: expected hit %d to have explanation %v, got %v", testCaseNum, i, controlResult.Hits[i].Expl, experimentalResult.Hits[i].Expl)
+		}
+
 	}
 	if truncateScore(controlResult.MaxScore) != truncateScore(experimentalResult.MaxScore) {
 		t.Errorf("test case #%d: expected maxScore to be %f, got %f", testCaseNum, controlResult.MaxScore, experimentalResult.MaxScore)

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -130,6 +130,7 @@ func TestSimilaritySearchPartitionedIndex(t *testing.T) {
 			index.indexes = make([]Index, 0)
 			query := searchRequests[testCase.queryIndex]
 			query.AddKNNOperator(operator)
+			query.Explain = true
 
 			indexPaths := createPartitionedIndex(documents, index, 1, testCase.mapping, t)
 			controlResult, err := index.Search(query)
@@ -296,6 +297,9 @@ func truncateScore(score float64) float64 {
 }
 
 func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult *SearchResult, testCaseNum int, verifyOnlyDocIDs bool) {
+	if controlResult.Hits.Len() == 0 || experimentalResult.Hits.Len() == 0 {
+		t.Fatalf("testcase %d failed: 0 hits returned", testCaseNum)
+	}
 	if len(controlResult.Hits) != len(experimentalResult.Hits) {
 		t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(controlResult.Hits), len(experimentalResult.Hits))
 	}
@@ -490,6 +494,7 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			query := searchRequests[testCase.queryIndex]
 			query.Sort = search.SortOrder{&search.SortScore{Desc: true}, &search.SortDocID{Desc: true}}
 			query.AddKNNOperator(operator)
+			query.Explain = true
 			err = createMultipleSegmentsIndex(documents, index, 1)
 			if err != nil {
 				t.Fatal(err)

--- a/search_test.go
+++ b/search_test.go
@@ -3531,11 +3531,6 @@ func TestScoreBreakdown(t *testing.T) {
 					scoreBreakdown: map[int]float64{0: 0.040398807605268316, 2: 0.040398807605268316, 5: 0.0669862776967768, 6: 0.040398807605268316, 7: 0.040398807605268316, 8: 0.0669862776967768, 10: 0.040398807605268316, 12: 0.040398807605268316, 14: 0.040398807605268316, 15: 0.040398807605268316, 16: 0.0669862776967768},
 				},
 				{
-					docID:          "doc4",
-					score:          0.15956816751152955,
-					scoreBreakdown: map[int]float64{0: 0.04737179972998534, 2: 0.04737179972998534, 6: 0.04737179972998534, 7: 0.04737179972998534, 10: 0.04737179972998534, 12: 0.04737179972998534, 14: 0.04737179972998534, 15: 0.04737179972998534},
-				},
-				{
 					docID:          "doc2",
 					score:          0.14725661652397853,
 					scoreBreakdown: map[int]float64{0: 0.05470024557900147, 5: 0.09069985124905133, 7: 0.05470024557900147, 10: 0.05470024557900147, 13: 0.15681178542754148, 15: 0.05470024557900147},
@@ -3544,6 +3539,11 @@ func TestScoreBreakdown(t *testing.T) {
 					docID:          "doc3",
 					score:          0.12637916362550797,
 					scoreBreakdown: map[int]float64{2: 0.05470024557900147, 6: 0.05470024557900147, 8: 0.09069985124905133, 12: 0.05470024557900147, 14: 0.05470024557900147, 16: 0.09069985124905133},
+				},
+				{
+					docID:          "doc4",
+					score:          0.15956816751152955,
+					scoreBreakdown: map[int]float64{0: 0.04737179972998534, 2: 0.04737179972998534, 6: 0.04737179972998534, 7: 0.04737179972998534, 10: 0.04737179972998534, 12: 0.04737179972998534, 14: 0.04737179972998534, 15: 0.04737179972998534},
 				},
 			},
 		},
@@ -3559,11 +3559,6 @@ func TestScoreBreakdown(t *testing.T) {
 					scoreBreakdown: map[int]float64{1: 0.05756326446708409, 2: 0.05756326446708409, 5: 0.09544709478559595, 6: 0.05756326446708409},
 				},
 				{
-					docID:          "doc4",
-					score:          0.07593627256602972,
-					scoreBreakdown: map[int]float64{1: 0.06749890894758198, 2: 0.06749890894758198, 6: 0.06749890894758198},
-				},
-				{
 					docID:          "doc2",
 					score:          0.05179425287147191,
 					scoreBreakdown: map[int]float64{1: 0.0779410306721006, 5: 0.129235980813787},
@@ -3572,6 +3567,11 @@ func TestScoreBreakdown(t *testing.T) {
 					docID:          "doc3",
 					score:          0.0389705153360503,
 					scoreBreakdown: map[int]float64{2: 0.0779410306721006, 6: 0.0779410306721006},
+				},
+				{
+					docID:          "doc4",
+					score:          0.07593627256602972,
+					scoreBreakdown: map[int]float64{1: 0.06749890894758198, 2: 0.06749890894758198, 6: 0.06749890894758198},
 				},
 			},
 		},
@@ -3596,6 +3596,7 @@ func TestScoreBreakdown(t *testing.T) {
 			q = &rv
 		}
 		sr := NewSearchRequest(q)
+		sr.SortBy([]string{"_id"})
 		sr.Explain = true
 		res, err := idx.Search(sr)
 		if err != nil {
@@ -3607,11 +3608,6 @@ func TestScoreBreakdown(t *testing.T) {
 		for i, hit := range res.Hits {
 			if hit.ID != dtq.expectHits[i].docID {
 				t.Fatalf("expected docID %s, got %s", dtq.expectHits[i].docID, hit.ID)
-			}
-			hit.Score = roundToDecimalPlace(hit.Score, 3)
-			expectScore := roundToDecimalPlace(dtq.expectHits[i].score, 3)
-			if hit.Score != expectScore {
-				t.Fatalf("expected score %f, got %f", dtq.expectHits[i].score, hit.Score)
 			}
 			if len(hit.ScoreBreakdown) != len(dtq.expectHits[i].scoreBreakdown) {
 				t.Fatalf("expected %d score breakdown, got %d", len(dtq.expectHits[i].scoreBreakdown), len(hit.ScoreBreakdown))


### PR DESCRIPTION
- The score explanation is now accurate. It's determined by establishing the final score and its explanation only when the KNN hits are finalized. This happens after a PreSearch for an index alias or at the end of the KNN collector phase for a single index.