### PR TITLE
go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.1-0.20231215153441-18737168eeaf
+	github.com/blevesearch/zapx/v16 v16.0.1-0.20231222105758-4e3a9b86dbd9
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20231215153441-18737168eeaf h1:7+PlR8PP6if2xSJ5e+dZNIK0oSm04vSIyEfFjydYIBo=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20231215153441-18737168eeaf/go.mod h1:WIOW42mP6pIF9TyeUYG3u7KIhy0ml8Hnt3R5O925tjI=
+github.com/blevesearch/zapx/v16 v16.0.1-0.20231222105758-4e3a9b86dbd9 h1:yo3is3kV0Qu4lckTKWUyurpm5V5z1ApjGQTzz9rixxs=
+github.com/blevesearch/zapx/v16 v16.0.1-0.20231222105758-4e3a9b86dbd9/go.mod h1:WIOW42mP6pIF9TyeUYG3u7KIhy0ml8Hnt3R5O925tjI=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
includes the zap changes from 
- https://github.com/blevesearch/zapx/pull/199 
- https://github.com/blevesearch/zapx/pull/200

unit test passes on my local bleve setup 

```
...
ok  	github.com/blevesearch/bleve/v2/search/query	1.097s
ok  	github.com/blevesearch/bleve/v2/search/scorer	1.707s
ok  	github.com/blevesearch/bleve/v2/search/searcher	10.095s
ok  	github.com/blevesearch/bleve/v2/test	51.131s
```
