### PR TITLE
MB-60274: Set an upper bound for K value for KNN queries

### DIFF
--- a/search_knn.go
+++ b/search_knn.go
@@ -31,6 +31,8 @@ import (
 
 type knnOperator string
 
+const MaxKValue = 10000
+
 type SearchRequest struct {
 	Query            query.Query       `json:"query"`
 	Size             int               `json:"size"`
@@ -229,6 +231,9 @@ func validateKNN(req *SearchRequest) error {
 		}
 		if q.K <= 0 || len(q.Vector) == 0 {
 			return fmt.Errorf("k must be greater than 0 and vector must be non-empty")
+		}
+		if q.K > MaxKValue {
+			return fmt.Errorf("k must be less than %d", MaxKValue)
 		}
 	}
 	switch req.KNNOperator {


### PR DESCRIPTION
# JIRA

https://issues.couchbase.com/browse/MB-60274

# Description

Currently, the value of K in KNN queries is only lower-bounded to 1 without an upper limit. This lack of an upper boundary leads to issues where users setting K to extremely high values, such as 999999999, cause a crash due to excessive memory allocation exceeding 8GB.

To address this issue, this commit introduces an upper bound check for variable K. Setting an upper limit of 10000 for K prevents excessive memory demands, capping the maximum memory requirement at a reasonable 120KB. This change ensures system stability by preventing memory overflow issues caused by excessively high K values."
