### PR TITLE
MB-60241: Add consistency checks for redistribution of KNN hits

### DIFF
--- a/error.go
+++ b/error.go
@@ -26,7 +26,7 @@ const (
 	ErrorUnknownIndexType
 	ErrorEmptyID
 	ErrorIndexReadInconsistency
-	ErrorSearchInconsistency
+	ErrorTwoPhaseSearchInconsistency
 )
 
 // Error represents a more strongly typed bleve error for detecting
@@ -38,15 +38,15 @@ func (e Error) Error() string {
 }
 
 var errorMessages = map[Error]string{
-	ErrorIndexPathExists:        "cannot create new index, path already exists",
-	ErrorIndexPathDoesNotExist:  "cannot open index, path does not exist",
-	ErrorIndexMetaMissing:       "cannot open index, metadata missing",
-	ErrorIndexMetaCorrupt:       "cannot open index, metadata corrupt",
-	ErrorIndexClosed:            "index is closed",
-	ErrorAliasMulti:             "cannot perform single index operation on multiple index alias",
-	ErrorAliasEmpty:             "cannot perform operation on empty alias",
-	ErrorUnknownIndexType:       "unknown index type",
-	ErrorEmptyID:                "document ID cannot be empty",
-	ErrorIndexReadInconsistency: "index read inconsistency detected",
-	ErrorSearchInconsistency:    "topology change caused two phase search to fail",
+	ErrorIndexPathExists:             "cannot create new index, path already exists",
+	ErrorIndexPathDoesNotExist:       "cannot open index, path does not exist",
+	ErrorIndexMetaMissing:            "cannot open index, metadata missing",
+	ErrorIndexMetaCorrupt:            "cannot open index, metadata corrupt",
+	ErrorIndexClosed:                 "index is closed",
+	ErrorAliasMulti:                  "cannot perform single index operation on multiple index alias",
+	ErrorAliasEmpty:                  "cannot perform operation on empty alias",
+	ErrorUnknownIndexType:            "unknown index type",
+	ErrorEmptyID:                     "document ID cannot be empty",
+	ErrorIndexReadInconsistency:      "index read inconsistency detected",
+	ErrorTwoPhaseSearchInconsistency: "2-phase search failed, likely due to an overlapping topology change",
 }

--- a/error.go
+++ b/error.go
@@ -26,7 +26,7 @@ const (
 	ErrorUnknownIndexType
 	ErrorEmptyID
 	ErrorIndexReadInconsistency
-	ErrorPreSearchFailed
+	ErrorSearchInconsistency
 )
 
 // Error represents a more strongly typed bleve error for detecting
@@ -48,5 +48,5 @@ var errorMessages = map[Error]string{
 	ErrorUnknownIndexType:       "unknown index type",
 	ErrorEmptyID:                "document ID cannot be empty",
 	ErrorIndexReadInconsistency: "index read inconsistency detected",
-	ErrorPreSearchFailed:        "index pre-search failed, inconsistency in results detected, due to a topology change/rebalance. Please retry the search",
+	ErrorSearchInconsistency:    "topology change caused two phase search to fail",
 }

--- a/error.go
+++ b/error.go
@@ -48,5 +48,5 @@ var errorMessages = map[Error]string{
 	ErrorUnknownIndexType:       "unknown index type",
 	ErrorEmptyID:                "document ID cannot be empty",
 	ErrorIndexReadInconsistency: "index read inconsistency detected",
-	ErrorPreSearchFailed:        "index pre-search failed",
+	ErrorPreSearchFailed:        "index pre-search failed, inconsistency in results detected, due to a topology change/rebalance. Please retry the search",
 }

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -179,21 +179,21 @@ func (i *indexAliasImpl) SearchInContext(ctx context.Context, req *SearchRequest
 	// preSearch step now, we call an optional function to
 	// redistribute the preSearchData to the individual indexes
 	// if necessary
-	var preSearchData []map[string]interface{}
+	var preSearchData map[string]map[string]interface{}
 	if req.PreSearchData != nil {
 		if requestHasKNN(req) {
-			preSearchData = make([]map[string]interface{}, len(i.indexes))
-			for i := 0; i < len(preSearchData); i++ {
-				preSearchData[i] = make(map[string]interface{})
+			var err error
+			preSearchData, err = redistributeKNNPreSearchData(req, i.indexes)
+			if err != nil {
+				return nil, err
 			}
-			redistributeKNNPreSearchData(req, preSearchData)
 		}
 	}
 
 	// short circuit the simple case
 	if len(i.indexes) == 1 {
 		if preSearchData != nil {
-			req.PreSearchData = preSearchData[0]
+			req.PreSearchData = preSearchData[i.indexes[0].Name()]
 		}
 		return i.indexes[0].SearchInContext(ctx, req)
 	}
@@ -220,7 +220,7 @@ func (i *indexAliasImpl) SearchInContext(ctx context.Context, req *SearchRequest
 		} else {
 			// if there are no errors, then use the presearch data
 			// to execute the query
-			preSearchData, err = mergePreSearchData(req, preSearchResult, len(i.indexes))
+			preSearchData, err = mergePreSearchData(req, preSearchResult, i.indexes)
 			if err != nil {
 				return nil, err
 			}
@@ -500,10 +500,9 @@ func createChildSearchRequest(req *SearchRequest, preSearchData map[string]inter
 }
 
 type asyncSearchResult struct {
-	Name     string
-	IndexNum int
-	Result   *SearchResult
-	Err      error
+	Name   string
+	Result *SearchResult
+	Err    error
 }
 
 func preSearchRequired(ctx context.Context, req *SearchRequest) bool {
@@ -523,19 +522,22 @@ func preSearch(ctx context.Context, req *SearchRequest, indexes ...Index) (*Sear
 	return preSearchDataSearch(newCtx, dummyRequest, indexes...)
 }
 
-func tagHitsWithIndexNum(sr *SearchResult, indexNum int) {
+func tagHitsWithIndexName(sr *SearchResult, indexName string) {
 	for _, hit := range sr.Hits {
-		hit.IndexId = append(hit.IndexId, indexNum)
+		hit.IndexNames = append(hit.IndexNames, indexName)
 	}
 }
 
-func mergePreSearchData(req *SearchRequest, res *SearchResult, numIndexes int) ([]map[string]interface{}, error) {
-	mergedOut := make([]map[string]interface{}, numIndexes)
-	for i := 0; i < len(mergedOut); i++ {
-		mergedOut[i] = make(map[string]interface{})
+func mergePreSearchData(req *SearchRequest, res *SearchResult, indexes []Index) (map[string]map[string]interface{}, error) {
+	mergedOut := make(map[string]map[string]interface{}, len(indexes))
+	for _, index := range indexes {
+		mergedOut[index.Name()] = make(map[string]interface{})
 	}
 	if requestHasKNN(req) {
-		mergeKNNDocumentMatches(req, res.Hits, mergedOut)
+		distributedHits := mergeKNNDocumentMatches(req, res.Hits)
+		for _, index := range indexes {
+			mergedOut[index.Name()][search.KnnPreSearchDataKey] = distributedHits[index.Name()]
+		}
 	}
 	return mergedOut, nil
 }
@@ -546,16 +548,16 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 	// run search on each index in separate go routine
 	var waitGroup sync.WaitGroup
 
-	var searchChildIndex = func(in Index, childReq *SearchRequest, idx int) {
-		rv := asyncSearchResult{Name: in.Name(), IndexNum: idx}
+	var searchChildIndex = func(in Index, childReq *SearchRequest) {
+		rv := asyncSearchResult{Name: in.Name()}
 		rv.Result, rv.Err = in.SearchInContext(ctx, childReq)
 		asyncResults <- &rv
 		waitGroup.Done()
 	}
 
 	waitGroup.Add(len(indexes))
-	for idx, in := range indexes {
-		go searchChildIndex(in, createChildSearchRequest(req, nil), idx)
+	for _, in := range indexes {
+		go searchChildIndex(in, createChildSearchRequest(req, nil))
 	}
 
 	// on another go routine, close after finished
@@ -572,10 +574,10 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 			if sr == nil {
 				// first result
 				sr = asr.Result
-				tagHitsWithIndexNum(sr, asr.IndexNum)
+				tagHitsWithIndexName(sr, asr.Name)
 			} else {
 				// merge with previous
-				tagHitsWithIndexNum(asr.Result, asr.IndexNum)
+				tagHitsWithIndexName(asr.Result, asr.Name)
 				sr.Merge(asr.Result)
 			}
 		} else {
@@ -612,7 +614,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 
 // MultiSearch executes a SearchRequest across multiple Index objects,
 // then merges the results.  The indexes must honor any ctx deadline.
-func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData []map[string]interface{}, indexes ...Index) (*SearchResult, error) {
+func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[string]map[string]interface{}, indexes ...Index) (*SearchResult, error) {
 
 	searchStart := time.Now()
 	asyncResults := make(chan *asyncSearchResult, len(indexes))
@@ -636,12 +638,12 @@ func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData []map[st
 	}
 
 	waitGroup.Add(len(indexes))
-	for idx, in := range indexes {
-		var md map[string]interface{}
+	for _, in := range indexes {
+		var payload map[string]interface{}
 		if preSearchData != nil {
-			md = preSearchData[idx]
+			payload = preSearchData[in.Name()]
 		}
-		go searchChildIndex(in, createChildSearchRequest(req, md))
+		go searchChildIndex(in, createChildSearchRequest(req, payload))
 	}
 
 	// on another go routine, close after finished

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -528,13 +528,18 @@ func tagHitsWithIndexName(sr *SearchResult, indexName string) {
 	}
 }
 
-func mergePreSearchData(req *SearchRequest, res *SearchResult, indexes []Index) (map[string]map[string]interface{}, error) {
+func mergePreSearchData(req *SearchRequest, res *SearchResult,
+	indexes []Index) (map[string]map[string]interface{}, error) {
+
 	mergedOut := make(map[string]map[string]interface{}, len(indexes))
 	for _, index := range indexes {
 		mergedOut[index.Name()] = make(map[string]interface{})
 	}
 	if requestHasKNN(req) {
-		distributedHits := mergeKNNDocumentMatches(req, res.Hits)
+		distributedHits, err := mergeKNNDocumentMatches(req, res.Hits, indexes)
+		if err != nil {
+			return nil, err
+		}
 		for _, index := range indexes {
 			mergedOut[index.Name()][search.KnnPreSearchDataKey] = distributedHits[index.Name()]
 		}

--- a/search/search.go
+++ b/search/search.go
@@ -183,12 +183,12 @@ type DocumentMatch struct {
 	ScoreBreakdown map[int]float64 `json:"score_breakdown,omitempty"`
 
 	// internal variable used in PreSearch phase of search in alias
-	// indicated the index id of the index that this match came from
-	// used in vector search.
-	// it is a stack of index ids, the top of the stack is the index id
+	// to indicate the name of the index that this match came from.
+	// used in knn search.
+	// it is a stack of index names, the top of the stack is the name
 	// of the index that this match came from
 	// of the current alias view, used in alias of aliases scenario
-	IndexId []int `json:"index_id,omitempty"`
+	IndexNames []string `json:"index_names,omitempty"`
 }
 
 func (dm *DocumentMatch) AddFieldValue(name string, value interface{}) {

--- a/search_knn.go
+++ b/search_knn.go
@@ -344,7 +344,7 @@ func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch
 // the preSearchData for I2 contains the top K hits from I2.
 func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Index) (map[string][]*search.DocumentMatch, error) {
 	// create a set of all the index names of this alias
-	indexNames := make(map[string]interface{})
+	indexNames := make(map[string]struct{}, len(indexes))
 	for _, index := range indexes {
 		indexNames[index.Name()] = struct{}{}
 	}

--- a/search_knn.go
+++ b/search_knn.go
@@ -362,7 +362,7 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		// performing this check to be safe. Since we extract the stack top
 		// in the following steps.
 		if len(hit.IndexNames) == 0 {
-			return nil, ErrorSearchInconsistency
+			return nil, ErrorTwoPhaseSearchInconsistency
 		}
 		// since the stack is not empty, we need to check if the top of the stack
 		// is a valid index name, of an index that is part of this alias. If not,
@@ -371,7 +371,7 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		stackTopIdx := len(hit.IndexNames) - 1
 		top := hit.IndexNames[stackTopIdx]
 		if _, exists := indexNames[top]; !exists {
-			return nil, ErrorSearchInconsistency
+			return nil, ErrorTwoPhaseSearchInconsistency
 		}
 		hit.IndexNames = hit.IndexNames[:stackTopIdx]
 		segregatedKnnHits[top] = append(segregatedKnnHits[top], hit)

--- a/search_knn.go
+++ b/search_knn.go
@@ -314,6 +314,9 @@ func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch, num
 			}
 			hit.Expl = &search.Explanation{Value: hit.Score, Message: "sum of:", Children: childrenExpl}
 		}
+		// we don't need the score breakdown anymore
+		// so we can set it to nil
+		hit.ScoreBreakdown = nil
 	}
 	return knnHits
 }
@@ -351,10 +354,10 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 	segregatedKnnHits := make(map[string][]*search.DocumentMatch)
 	for _, hit := range knnHits {
 		if len(hit.IndexNames) == 0 {
-			return nil, ErrorPreSearchFailed
+			return nil, ErrorSearchInconsistency
 		}
 		if _, exists := indexNames[hit.IndexNames[len(hit.IndexNames)-1]]; !exists {
-			return nil, ErrorPreSearchFailed
+			return nil, ErrorSearchInconsistency
 		}
 		stackTopIdx := len(hit.IndexNames) - 1
 		top := hit.IndexNames[stackTopIdx]

--- a/search_knn.go
+++ b/search_knn.go
@@ -359,8 +359,8 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		// if the stack is empty, then we have an inconsistency/abnormality
 		// since any hit with an empty stack is supposed to land on a leaf index,
 		// and not an alias. This cannot happen in normal circumstances. But
-		// performing this check to be safe. Since we check the stack top
-		// in the next check.
+		// performing this check to be safe. Since we extract the stack top
+		// in the following steps.
 		if len(hit.IndexNames) == 0 {
 			return nil, ErrorSearchInconsistency
 		}
@@ -368,11 +368,11 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		// is a valid index name, of an index that is part of this alias. If not,
 		// then we have an inconsistency that could be caused due to a topology
 		// change.
-		if _, exists := indexNames[hit.IndexNames[len(hit.IndexNames)-1]]; !exists {
-			return nil, ErrorSearchInconsistency
-		}
 		stackTopIdx := len(hit.IndexNames) - 1
 		top := hit.IndexNames[stackTopIdx]
+		if _, exists := indexNames[top]; !exists {
+			return nil, ErrorSearchInconsistency
+		}
 		hit.IndexNames = hit.IndexNames[:stackTopIdx]
 		segregatedKnnHits[top] = append(segregatedKnnHits[top], hit)
 	}

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -185,8 +185,8 @@ func requestHasKNN(req *SearchRequest) bool {
 func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {
 }
 
-func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch) map[string][]*search.DocumentMatch {
-	return nil
+func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch, indexes []Index) (map[string][]*search.DocumentMatch, error) {
+	return nil, nil
 }
 
 func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[string]map[string]interface{}, error) {

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -185,9 +185,10 @@ func requestHasKNN(req *SearchRequest) bool {
 func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {
 }
 
-func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch, mergeOut []map[string]interface{}) {
+func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch) map[string][]*search.DocumentMatch {
+	return nil
 }
 
-func redistributeKNNPreSearchData(req *SearchRequest, mergedOut []map[string]interface{}) error {
-	return nil
+func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[string]map[string]interface{}, error) {
+	return nil, nil
 }


### PR DESCRIPTION
In a distributed indexing setup, the child indexes linked to an alias are labeled as `[IP]:[port]/[indexName]`. During a two-phase KNN search, if a node is taken out and re-added (by means of a rebalance operation) after the first phase but before the start of the second phase, the reference to the child index in the alias remains unchanged (with the same IP address, port, and indexName). However, the actual indexes present on that node will differ from those available during the first phase. This discrepancy causes inaccurate results due to inconsistencies in the indexId stack.

This method substitutes the indexId with the specific indexName, ensuring redistribution even if the index arrangement undergoes changes. Yet, if the index isn’t found within that alias, an error will be triggered.
