### PR TITLE
MB-60202: Upgrade zapx/v16 for fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.1-0.20240110163247-cefd4af61cea
+	github.com/blevesearch/zapx/v16 v16.0.1-0.20240112173957-c19e7ab032d8
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/blevesearch/go-faiss v1.0.4 // indirect
+	github.com/blevesearch/go-faiss v1.0.5 // indirect
 	github.com/blevesearch/mmap-go v1.0.4 // indirect
 	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/blevesearch/bleve_index_api v1.1.4 h1:n9Ilxlb80g9DAhchR95IcVrzohamDSr
 github.com/blevesearch/bleve_index_api v1.1.4/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/geo v0.1.18 h1:Np8jycHTZ5scFe7VEPLrDoHnnb9C4j636ue/CGrhtDw=
 github.com/blevesearch/geo v0.1.18/go.mod h1:uRMGWG0HJYfWfFJpK3zTdnnr1K+ksZTuWKhXeSokfnM=
-github.com/blevesearch/go-faiss v1.0.4 h1:SfTVaqGF116umb1Kw90EWdO2FJhQZVYRNTlPH0J/TOg=
-github.com/blevesearch/go-faiss v1.0.4/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
+github.com/blevesearch/go-faiss v1.0.5 h1:IWlOZGF3GXFOUdLVW9JkqgWPQ3gEIYqqdp88rbrAcc4=
+github.com/blevesearch/go-faiss v1.0.5/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20240110163247-cefd4af61cea h1:iSmIhRSjZs3m2QQq/UDzJsf8/SdWMN4e5E9NEGQXtHI=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20240110163247-cefd4af61cea/go.mod h1:OBvgVZ3lhW3mKnanvWFTSd04kPp+Fc5qCsj8GAVbFCE=
+github.com/blevesearch/zapx/v16 v16.0.1-0.20240112173957-c19e7ab032d8 h1:dJfTV12JRZ9zkAukNSmKRY8P9iGbETJt2SqW71AvkUM=
+github.com/blevesearch/zapx/v16 v16.0.1-0.20240112173957-c19e7ab032d8/go.mod h1:ih5Q8QhWQjgqVCnkSko/zMc5AR1BWyYbRyb/a+trB+Y=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
Includes:
* c19e7ab Aditi Ahuja | MB-60202 - Filtering deleted documents during FAISS vector index search (https://github.com/blevesearch/zapx/pull/205)