### PR TITLE
MB-60400: Add a semaphore for concurrently reading vector indexes from zap segments

### DIFF
--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -32,6 +32,8 @@ type OptimizeVR struct {
 	vrs map[string][]*IndexSnapshotVectorReader
 }
 
+var BleveMaxKNNConcurrency = 10
+
 func (o *OptimizeVR) Finish() error {
 	// for each field, get the vector index --> invoke the zap func.
 	// for each VR, populate postings list and iterators
@@ -41,12 +43,17 @@ func (o *OptimizeVR) Finish() error {
 	var errors []error
 
 	wg := sync.WaitGroup{}
+	semaphore := make(chan struct{}, BleveMaxKNNConcurrency)
 	// Launch goroutines to get vector index for each segment
 	for i, seg := range o.snapshot.segment {
 		if sv, ok := seg.segment.(segment_api.VectorSegment); ok {
 			wg.Add(1)
+			semaphore <- struct{}{} // Acquire a semaphore slot
 			go func(index int, segment segment_api.VectorSegment, origSeg *SegmentSnapshot) {
-				defer wg.Done()
+				defer func() {
+					<-semaphore // Release the semaphore slot
+					wg.Done()
+				}()
 				for field, vrs := range o.vrs {
 					searchVectorIndex, closeVectorIndex, err := segment.InterpretVectorIndex(field)
 					if err != nil {
@@ -78,6 +85,7 @@ func (o *OptimizeVR) Finish() error {
 		}
 	}
 	wg.Wait()
+	close(semaphore)
 	if len(errors) > 0 {
 		return errors[0]
 	}

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -32,6 +32,7 @@ type OptimizeVR struct {
 	vrs map[string][]*IndexSnapshotVectorReader
 }
 
+// This setting _MUST_ only be changed during init and not after.
 var BleveMaxKNNConcurrency = 10
 
 func (o *OptimizeVR) Finish() error {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -306,7 +306,7 @@ func compareExplanation(a, b *search.Explanation) bool {
 		return false
 	}
 
-	if a.Value != b.Value || len(a.Children) != len(b.Children) {
+	if truncateScore(a.Value) != truncateScore(b.Value) || len(a.Children) != len(b.Children) {
 		return false
 	}
 


### PR DESCRIPTION
- Calling InterpretVectorIndex() with BleveMaxK = 10000 results in 200KB of memory usage per call. With a million documents and around 1000 Zap segments (a scenario that occurs while the index is still being built and the merger routine is still running), parallel calls consume 200MB, making it necessary to limit the concurrency involved.
- Created a global variable named BleveMaxKNNConcurrency with a value of 10, representing the maximum number of concurrent goroutines allowed. This ensures that 10 segments can be read concurrently at once.