### PR TITLE
Upgrade to zapx/v16@v16.0.1 @ go-faiss@v1.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.1-0.20240117165423-8662175b037b
+	github.com/blevesearch/zapx/v16 v16.0.1
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/blevesearch/go-faiss v1.0.5 // indirect
+	github.com/blevesearch/go-faiss v1.0.6 // indirect
 	github.com/blevesearch/mmap-go v1.0.4 // indirect
 	github.com/couchbase/ghistogram v0.1.0 // indirect
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/blevesearch/bleve_index_api v1.1.5 h1:0q05mzu6GT/kebzqKywCpou/eUea9wT
 github.com/blevesearch/bleve_index_api v1.1.5/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/geo v0.1.19 h1:hlX1YpBZ+X+xfjS8hEpmM/tdPUFbqBME3mdAWKHo2s0=
 github.com/blevesearch/geo v0.1.19/go.mod h1:EPyr3iJCcESYa830PnkFhqzJkOP7/daHT/ocun43WRY=
-github.com/blevesearch/go-faiss v1.0.5 h1:IWlOZGF3GXFOUdLVW9JkqgWPQ3gEIYqqdp88rbrAcc4=
-github.com/blevesearch/go-faiss v1.0.5/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
+github.com/blevesearch/go-faiss v1.0.6 h1:UqGq55UccPCq2+hgefBHN7/URT+q26DxL1zRgO0DMvo=
+github.com/blevesearch/go-faiss v1.0.6/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20240117165423-8662175b037b h1:jZs0UQurWmVaNlrNolROktccw36F/U/z7+AaNLrvwHU=
-github.com/blevesearch/zapx/v16 v16.0.1-0.20240117165423-8662175b037b/go.mod h1:FVQ8/6UMCPWFOJQ2sTJVju4d2XtTyPRhe1A6aQvNM5c=
+github.com/blevesearch/zapx/v16 v16.0.1 h1:XOTMDVMdU2Qj3l7rQemHfmwa9S8sDsydwCdnEwCBf/M=
+github.com/blevesearch/zapx/v16 v16.0.1/go.mod h1:aIgXIIRHzFMNlierxoIXQJLOBv8VAMcDcI7vXFo2fOQ=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
* 84be009 Abhi Dangeti | Upgrade to go-faiss@v1.0.6 + additional commentary (https://github.com/blevesearch/zapx/pull/207) * d9e6c45 Thejas-bhat | MB-60367: Avoiding extra allocation on C heap while reading index from buffer (https://github.com/blevesearch/go-faiss/pull/12)
* 72fc813 Thejas-bhat | MB-60367: Handle memory allocations more responsibly  (https://github.com/blevesearch/zapx/pull/206)