### PR TITLE
MB-60945 - Add scorch event for pre merge check

### DIFF
--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -22,11 +22,7 @@ var RegistryAsyncErrorCallbacks = map[string]func(error, string){}
 
 // RegistryEventCallbacks should be treated as read-only after
 // process init()'ialization.
-var RegistryEventCallbacks = map[string]func(Event){}
-
-// RegistryContinueEventCallback should be treated as read-only after
-// process init()'ialization.
-var RegistryContinueEventCallback = map[string]func(Event) bool{}
+var RegistryEventCallbacks = map[string]func(Event) bool{}
 
 // Event represents the information provided in an OnEvent() callback.
 type Event struct {

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -67,6 +67,6 @@ var EventKindMergeTaskIntroductionStart = EventKind(7)
 // the introduction of merged segment from a single merge task.
 var EventKindMergeTaskIntroduction = EventKind(8)
 
-// Fired before the merge begins to check if there's sufficient memory to
-// proceed with the merge.
-var EventKindPreMergeMemoryCheck = EventKind(9)
+// EventKindPreMergeCheck is fired before the merge begins to check if
+// the caller should proceed with the merge.
+var EventKindPreMergeCheck = EventKind(9)

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -22,6 +22,7 @@ var RegistryAsyncErrorCallbacks = map[string]func(error, string){}
 
 // RegistryEventCallbacks should be treated as read-only after
 // process init()'ialization.
+// In the event of not having a callback, these return true.
 var RegistryEventCallbacks = map[string]func(Event) bool{}
 
 // Event represents the information provided in an OnEvent() callback.

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -24,6 +24,10 @@ var RegistryAsyncErrorCallbacks = map[string]func(error, string){}
 // process init()'ialization.
 var RegistryEventCallbacks = map[string]func(Event){}
 
+// RegistryContinueEventCallback should be treated as read-only after
+// process init()'ialization.
+var RegistryContinueEventCallback = map[string]func(Event) bool{}
+
 // Event represents the information provided in an OnEvent() callback.
 type Event struct {
 	Kind     EventKind
@@ -62,3 +66,7 @@ var EventKindMergeTaskIntroductionStart = EventKind(7)
 // EventKindMergeTaskIntroduction is fired when the merger has completed
 // the introduction of merged segment from a single merge task.
 var EventKindMergeTaskIntroduction = EventKind(8)
+
+// Fired before the merge begins to check if there's sufficient memory to
+// proceed with the merge.
+var EventKindPreMergeMemoryCheck = EventKind(9)

--- a/index/scorch/event_test.go
+++ b/index/scorch/event_test.go
@@ -35,10 +35,11 @@ func TestEventBatchIntroductionStart(t *testing.T) {
 	}()
 
 	var count int
-	RegistryEventCallbacks["test"] = func(e Event) {
+	RegistryEventCallbacks["test"] = func(e Event) bool {
 		if e.Kind == EventKindBatchIntroductionStart {
 			count++
 		}
+		return true
 	}
 
 	ourConfig := make(map[string]interface{}, len(testConfig))

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -72,6 +72,16 @@ OUTER:
 				ctrlMsg = ctrlMsgDflt
 			}
 			if ctrlMsg != nil {
+				continueMerge := s.continueEvent(EventKindPreMergeMemoryCheck)
+				if !continueMerge {
+					// If it's decided that this merge can't take place now,
+					// begin the merge process all over again.
+					// Retry instead of blocking/waiting here since a long wait
+					// can result in more segments introduced i.e. s.root will
+					// be updated.
+					continue OUTER
+				}
+
 				startTime := time.Now()
 
 				// lets get started

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -72,7 +72,7 @@ OUTER:
 				ctrlMsg = ctrlMsgDflt
 			}
 			if ctrlMsg != nil {
-				continueMerge := s.continueEvent(EventKindPreMergeMemoryCheck)
+				continueMerge := s.continueEvent(EventKindPreMergeCheck)
 				if !continueMerge {
 					// If it's decided that this merge can't take place now,
 					// begin the merge process all over again.

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -73,6 +73,7 @@ OUTER:
 			}
 			if ctrlMsg != nil {
 				continueMerge := s.fireEvent(EventKindPreMergeCheck, 0)
+				// The default, if there's no handler, is to continue the merge.
 				if !continueMerge {
 					// If it's decided that this merge can't take place now,
 					// begin the merge process all over again.

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -72,7 +72,7 @@ OUTER:
 				ctrlMsg = ctrlMsgDflt
 			}
 			if ctrlMsg != nil {
-				continueMerge := s.continueEvent(EventKindPreMergeCheck)
+				continueMerge := s.fireEvent(EventKindPreMergeCheck, 0)
 				if !continueMerge {
 					// If it's decided that this merge can't take place now,
 					// begin the merge process all over again.

--- a/index/scorch/merge_test.go
+++ b/index/scorch/merge_test.go
@@ -41,7 +41,7 @@ func TestObsoleteSegmentMergeIntroduction(t *testing.T) {
 	mergeIntroStart.Add(1)
 	mergeIntroComplete.Add(1)
 	var segIntroCompleted int
-	RegistryEventCallbacks["test"] = func(e Event) {
+	RegistryEventCallbacks["test"] = func(e Event) bool {
 		if e.Kind == EventKindBatchIntroduction {
 			segIntroCompleted++
 			if segIntroCompleted == 3 {
@@ -61,6 +61,7 @@ func TestObsoleteSegmentMergeIntroduction(t *testing.T) {
 			mergeIntroComplete.Done()
 
 		}
+		return true
 	}
 
 	ourConfig := make(map[string]interface{}, len(testConfig))

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -176,7 +176,7 @@ func (s *Scorch) NumEventsBlocking() uint64 {
 }
 
 func (s *Scorch) fireEvent(kind EventKind, dur time.Duration) bool {
-	var res bool
+	res := true
 	if s.onEvent != nil {
 		atomic.AddUint64(&s.stats.TotEventTriggerStarted, 1)
 		res = s.onEvent(Event{Kind: kind, Scorch: s, Duration: dur})


### PR DESCRIPTION
This PR adds an event to check whether a merge can proceed based on criteria set by the caller(eg. cbft). If not, it's aborted and the merger loop continues its next iteration. 
Also includes minor refactor to the function signature of the event callback registry to accommodate the new event type.
