### PR TITLE
MB-60367: App herder check on seacher creation path

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -147,6 +147,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			id:         root.segment[i].id,
 			segment:    root.segment[i].segment,
 			cachedDocs: root.segment[i].cachedDocs,
+			cachedMeta: root.segment[i].cachedMeta,
 			creator:    root.segment[i].creator,
 		}
 
@@ -189,6 +190,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			id:         next.id,
 			segment:    next.data, // take ownership of next.data's ref-count
 			cachedDocs: &cachedDocs{cache: nil},
+			cachedMeta: &cachedMeta{meta: nil},
 			creator:    "introduceSegment",
 		}
 		newSnapshot.segment = append(newSnapshot.segment, newSegmentSnapshot)
@@ -276,6 +278,7 @@ func (s *Scorch) introducePersist(persist *persistIntroduction) {
 				segment:    replacement,
 				deleted:    segmentSnapshot.deleted,
 				cachedDocs: segmentSnapshot.cachedDocs,
+				cachedMeta: segmentSnapshot.cachedMeta,
 				creator:    "introducePersist",
 				mmaped:     1,
 			}
@@ -375,6 +378,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				segment:    root.segment[i].segment,
 				deleted:    root.segment[i].deleted,
 				cachedDocs: root.segment[i].cachedDocs,
+				cachedMeta: root.segment[i].cachedMeta,
 				creator:    root.segment[i].creator,
 			})
 			root.segment[i].segment.AddRef()
@@ -421,6 +425,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 			segment:    nextMerge.new, // take ownership for nextMerge.new's ref-count
 			deleted:    newSegmentDeleted,
 			cachedDocs: &cachedDocs{cache: nil},
+			cachedMeta: &cachedMeta{meta: nil},
 			creator:    "introduceMerge",
 			mmaped:     nextMerge.mmaped,
 		})

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -858,6 +858,7 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket) (*SegmentSnapshot, erro
 	rv := &SegmentSnapshot{
 		segment:    segment,
 		cachedDocs: &cachedDocs{cache: nil},
+		cachedMeta: &cachedMeta{meta: nil},
 	}
 	deletedBytes := segmentBucket.Get(boltDeletedKey)
 	if deletedBytes != nil {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -40,6 +40,8 @@ type SegmentSnapshot struct {
 	deleted *roaring.Bitmap
 	creator string
 
+	cachedMeta *cachedMeta
+
 	cachedDocs *cachedDocs
 }
 
@@ -281,4 +283,31 @@ func (c *cachedDocs) visitDoc(localDocNum uint64,
 	}
 
 	c.m.Unlock()
+}
+
+// the purpose of the cachedMeta is to simply allow the user of this type to record
+// and cache certain meta data information (specific to the segment) that can be
+// used across calls to save compute on the same.
+// for example searcher creations on the same index snapshot can use this struct
+// to help and fetch the backing index size information which can be used in
+// memory usage calculation thereby deciding whether to allow a query or not.
+type cachedMeta struct {
+	m    sync.RWMutex
+	meta map[string]interface{}
+}
+
+func (c *cachedMeta) updateMeta(field string, val interface{}) {
+	c.m.Lock()
+	if c.meta == nil {
+		c.meta = make(map[string]interface{})
+	}
+	c.meta[field] = val
+	c.m.Unlock()
+}
+
+func (c *cachedMeta) fetchMeta(field string) (rv interface{}) {
+	c.m.RLock()
+	rv = c.meta[field]
+	c.m.RUnlock()
+	return rv
 }

--- a/search/scorer/scorer_knn.go
+++ b/search/scorer/scorer_knn.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 
 	"github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/size"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
@@ -42,6 +43,17 @@ type KNNQueryScorer struct {
 	options                search.SearcherOptions
 	similarityMetric       string
 	queryWeightExplanation *search.Explanation
+}
+
+func (s *KNNQueryScorer) Size() int {
+	sizeInBytes := reflectStaticSizeKNNQueryScorer + size.SizeOfPtr +
+		(len(s.queryVector) * size.SizeOfFloat32) + len(s.queryField)
+
+	if s.queryWeightExplanation != nil {
+		sizeInBytes += s.queryWeightExplanation.Size()
+	}
+
+	return sizeInBytes
 }
 
 func NewKNNQueryScorer(queryVector []float32, queryField string, queryBoost float64,

--- a/search/searcher/optimize_knn.go
+++ b/search/searcher/optimize_knn.go
@@ -36,7 +36,7 @@ func optimizeKNN(ctx context.Context, indexReader index.IndexReader,
 			continue
 		}
 
-		octx, err = o.VectorOptimize(octx)
+		octx, err = o.VectorOptimize(ctx, octx)
 		if err != nil {
 			return err
 		}

--- a/search/searcher/search_knn.go
+++ b/search/searcher/search_knn.go
@@ -19,12 +19,21 @@ package searcher
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/scorer"
+	"github.com/blevesearch/bleve/v2/size"
 	index "github.com/blevesearch/bleve_index_api"
 )
+
+var reflectStaticSizeKNNSearcher int
+
+func init() {
+	var ks KNNSearcher
+	reflectStaticSizeKNNSearcher = int(reflect.TypeOf(ks).Size())
+}
 
 type KNNSearcher struct {
 	field        string
@@ -60,11 +69,11 @@ func NewKNNSearcher(ctx context.Context, i index.IndexReader, m mapping.IndexMap
 	return nil, nil
 }
 
-func (s *KNNSearcher) VectorOptimize(octx index.VectorOptimizableContext) (
+func (s *KNNSearcher) VectorOptimize(ctx context.Context, octx index.VectorOptimizableContext) (
 	index.VectorOptimizableContext, error) {
 	o, ok := s.vectorReader.(index.VectorOptimizable)
 	if ok {
-		return o.VectorOptimize(octx)
+		return o.VectorOptimize(ctx, octx)
 	}
 
 	return nil, nil
@@ -122,7 +131,10 @@ func (s *KNNSearcher) SetQueryNorm(qnorm float64) {
 }
 
 func (s *KNNSearcher) Size() int {
-	return 0
+	return reflectStaticSizeKNNSearcher + size.SizeOfPtr +
+		s.vectorReader.Size() +
+		s.vd.Size() +
+		s.scorer.Size()
 }
 
 func (s *KNNSearcher) Weight() float64 {

--- a/search/util.go
+++ b/search/util.go
@@ -140,3 +140,9 @@ const KnnPreSearchDataKey = "_knn_pre_search_data_key"
 const PreSearchKey = "_presearch_key"
 
 type ScoreExplCorrectionCallbackFunc func(queryMatch *DocumentMatch, knnMatch *DocumentMatch) (float64, *Explanation)
+
+type SearchSearcherStartCallbackFn func(size uint64) error
+type SearchSearcherEndCallbackFn func(size uint64) error
+
+const SearchSearcherStartCallbackKey = "_search_searcher_start_callback_key"
+const SearchSearcherEndCallbackKey = "_search_searcher_end_callback_key"


### PR DESCRIPTION
- invoking an app_herder check during the searcher creation time so that if the memory is spiking we don't do the expensive job of loading the vector index from buffer (which can be big) and searching it. 
- the approach is to leverage the segmentSnapshot struct to get what's the size of the vec index so that the future searcher creations will get limited when there is memory pressure as per app_herder decision
- the app_herder check to mark the start of the operation to be limited (which is the searcher creation) is invoked at the VectorOptimize() level and the check marking the end of it is invoked at the defer of the Finish() call