### PR TITLE
MB-60367: Move up to zapx/v16@v16.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.5
+	github.com/blevesearch/zapx/v16 v16.0.6
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.5 h1:dOGlKm9/sY2UTCOVs0aum9+hV5a8QyEbXSq/crt69/M=
-github.com/blevesearch/zapx/v16 v16.0.5/go.mod h1:KAymyo09vpS8yXWA9mm7u0qHi8FVr6ZM4hb5+nXQzKk=
+github.com/blevesearch/zapx/v16 v16.0.6 h1:AZp0spBK026aDlpZsp1RoCQiD85GMQ6c3iEkiEFrjKU=
+github.com/blevesearch/zapx/v16 v16.0.6/go.mod h1:KAymyo09vpS8yXWA9mm7u0qHi8FVr6ZM4hb5+nXQzKk=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
* eaf077c Thejas-bhat | MB-60367 Restructuring the code for better memory cleanup