### PR TITLE
MB-60400: Do not walk document if vector is processed successfully

### DIFF
--- a/mapping/document.go
+++ b/mapping/document.go
@@ -532,12 +532,14 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 			dm.walkDocument(property, path, indexes, context)
 		}
 	case reflect.Map, reflect.Slice:
+		var isPropertyVector bool
 		if subDocMapping != nil {
 			for _, fieldMapping := range subDocMapping.Fields {
 				switch fieldMapping.Type {
 				case "vector":
-					fieldMapping.processVector(property, pathString, path,
+					processed := fieldMapping.processVector(property, pathString, path,
 						indexes, context)
+					isPropertyVector = isPropertyVector && processed
 				case "geopoint":
 					fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
 				case "IP":
@@ -550,7 +552,9 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 				}
 			}
 		}
-		dm.walkDocument(property, path, indexes, context)
+		if !isPropertyVector {
+			dm.walkDocument(property, path, indexes, context)
+		}
 	case reflect.Ptr:
 		if !propertyValue.IsNil() {
 			switch property := property.(type) {

--- a/mapping/mapping_no_vectors.go
+++ b/mapping/mapping_no_vectors.go
@@ -22,8 +22,8 @@ func NewVectorFieldMapping() *FieldMapping {
 }
 
 func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
-	pathString string, path []string, indexes []uint64, context *walkContext) {
-
+	pathString string, path []string, indexes []uint64, context *walkContext) bool {
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -122,11 +122,11 @@ func processVector(vecI interface{}, dims int) ([]float32, bool) {
 }
 
 func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
-	pathString string, path []string, indexes []uint64, context *walkContext) {
+	pathString string, path []string, indexes []uint64, context *walkContext) bool {
 	vector, ok := processVector(propertyMightBeVector, fm.Dims)
 	// Don't add field to document if vector is invalid
 	if !ok {
-		return
+		return false
 	}
 
 	fieldName := getFieldName(pathString, path, fm)
@@ -137,6 +137,7 @@ func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 
 	// "_all" composite field is not applicable for vector field
 	context.excludedFromAll = append(context.excludedFromAll, fieldName)
+	return true
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Currently, the walkDocument function is called after processing every vector, regardless of whether the vector was processed successfully or not. This results in the execution of the following code:

		for i := 0; i < val.Len(); i++ {
			if val.Index(i).CanInterface() {
				fieldVal := val.Index(i).Interface()
				dm.processProperty(fieldVal, path, append(indexes, uint64(i)), context)
			}
		}

- In this code, val.Len() will be equal to the dimension of the vector, which could potentially be very high (up to 2048). For each iteration of the loop, processProperty() is called on each float value extracted from the vector. Within processProperty(), it attempts to add a numeric field and creates a new array using append().
- If the property has already been successfully processed as a vector, then each individual float value within the vector cannot be processed as a separate numeric field. This is because the same path variable is passed, ensuring that the fieldMapping will always be of type vector, not number.
- The check introduced here ensures that if the vector is successfully processed and a vector field is added, we skip calling walkDocument on it.
- This assertion is supported by the memory profiles obtained while indexing 1528-dimensional vectors, where approximately 65 GB (8% of the total allocated space) was dedicated to this process. The check introduced here allows us to avoid such excessive allocation.
