### PR TITLE
MB-60781: Upgrade zapx/v16 to v16.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.7
+	github.com/blevesearch/zapx/v16 v16.0.8
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.7 h1:lQ4NEaDsRxkSyLFwYZ8dSaq4lckCe1+SLlG20YV8wDM=
-github.com/blevesearch/zapx/v16 v16.0.7/go.mod h1:GkU8sUj2czc3syX4OwvouA74J68/e2banQ//9ufk2SM=
+github.com/blevesearch/zapx/v16 v16.0.8 h1:xiujW3MH3jDFJwh6TtN8X94wsTeBGQzIIY6HYqbASx0=
+github.com/blevesearch/zapx/v16 v16.0.8/go.mod h1:GkU8sUj2czc3syX4OwvouA74J68/e2banQ//9ufk2SM=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
* 2f42fb7 Thejas-bhat | MB-60781: Writing the vector section only when there are valid number of vectors in section (https://github.com/blevesearch/zapx/pull/219)