### PR TITLE
Comprehensive Hybrid Search Test Plan

### DIFF
--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/search/collector"
 	"github.com/blevesearch/bleve/v2/search/query"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -544,14 +545,40 @@ func tagHitsWithIndexName(sr *SearchResult, indexName string) {
 func finalizeSearchResult(req *SearchRequest, preSearchResult *SearchResult) *SearchResult {
 	// global values across all hits irrespective of pagination settings
 	preSearchResult.Total = uint64(preSearchResult.Hits.Len())
+	maxScore := float64(0)
 	for i, hit := range preSearchResult.Hits {
-		if hit.Score > preSearchResult.MaxScore {
-			preSearchResult.MaxScore = hit.Score
+		// since we are now using the presearch result as the final result
+		// we can discard the indexNames from the hits as they are no longer
+		// relevant.
+		hit.IndexNames = nil
+		if hit.Score > maxScore {
+			maxScore = hit.Score
 		}
 		hit.HitNumber = uint64(i)
 	}
-	if requestHasKNN(req) {
-		preSearchResult = constructKNNSearchResult(req, preSearchResult)
+	preSearchResult.MaxScore = maxScore
+	// now apply pagination settings
+	var reverseQueryExecution bool
+	if req.SearchBefore != nil {
+		reverseQueryExecution = true
+		req.Sort.Reverse()
+		req.SearchAfter = req.SearchBefore
+	}
+	if req.SearchAfter != nil {
+		preSearchResult.Hits = collector.FilterHitsBySearchAfter(preSearchResult.Hits, req.Sort, req.SearchAfter)
+	}
+	preSearchResult.Hits = hitsInCurrentPage(req, preSearchResult.Hits)
+	if reverseQueryExecution {
+		// reverse the sort back to the original
+		req.Sort.Reverse()
+		// resort using the original order
+		mhs := newSearchHitSorter(req.Sort, preSearchResult.Hits)
+		req.SortFunc()(mhs)
+		req.SearchAfter = nil
+	}
+
+	if req.Explain {
+		preSearchResult.Request = req
 	}
 	return preSearchResult
 }
@@ -663,6 +690,28 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 	return sr, nil
 }
 
+// hitsInCurrentPage returns the hits in the current page
+// using the From and Size parameters in the request
+func hitsInCurrentPage(req *SearchRequest, hits []*search.DocumentMatch) []*search.DocumentMatch {
+	sortFunc := req.SortFunc()
+	// sort all hits with the requested order
+	if len(req.Sort) > 0 {
+		sorter := newSearchHitSorter(req.Sort, hits)
+		sortFunc(sorter)
+	}
+	// now skip over the correct From
+	if req.From > 0 && len(hits) > req.From {
+		hits = hits[req.From:]
+	} else if req.From > 0 {
+		hits = search.DocumentMatchCollection{}
+	}
+	// now trim to the correct size
+	if req.Size > 0 && len(hits) > req.Size {
+		hits = hits[0:req.Size]
+	}
+	return hits
+}
+
 // MultiSearch executes a SearchRequest across multiple Index objects,
 // then merges the results.  The indexes must honor any ctx deadline.
 func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[string]map[string]interface{}, indexes ...Index) (*SearchResult, error) {
@@ -732,24 +781,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[stri
 		}
 	}
 
-	sortFunc := req.SortFunc()
-	// sort all hits with the requested order
-	if len(req.Sort) > 0 {
-		sorter := newSearchHitSorter(req.Sort, sr.Hits)
-		sortFunc(sorter)
-	}
-
-	// now skip over the correct From
-	if req.From > 0 && len(sr.Hits) > req.From {
-		sr.Hits = sr.Hits[req.From:]
-	} else if req.From > 0 {
-		sr.Hits = search.DocumentMatchCollection{}
-	}
-
-	// now trim to the correct size
-	if req.Size > 0 && len(sr.Hits) > req.Size {
-		sr.Hits = sr.Hits[0:req.Size]
-	}
+	sr.Hits = hitsInCurrentPage(req, sr.Hits)
 
 	// fix up facets
 	for name, fr := range req.Facets {
@@ -761,7 +793,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[stri
 		req.Sort.Reverse()
 		// resort using the original order
 		mhs := newSearchHitSorter(req.Sort, sr.Hits)
-		sortFunc(mhs)
+		req.SortFunc()(mhs)
 		// reset request
 		req.SearchBefore = req.SearchAfter
 		req.SearchAfter = nil

--- a/index_impl.go
+++ b/index_impl.go
@@ -658,7 +658,9 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 
 	var storedFieldsCost uint64
 	for _, hit := range hits {
-		if i.name != "" {
+		// KNN documents will already have their Index value set as part of the knn collector output
+		// so check if the index is empty and set it to the current index name
+		if i.name != "" && hit.Index == "" {
 			hit.Index = i.name
 		}
 		err, storedFieldsBytes := LoadAndHighlightFields(hit, req, i.name, indexReader, highlighter)

--- a/search_knn.go
+++ b/search_knn.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/collector"
@@ -247,7 +246,7 @@ func validateKNN(req *SearchRequest) error {
 	return nil
 }
 
-func addSortAndFieldsToKNNHits(req *SearchRequest, knnHits []*search.DocumentMatch, reader index.IndexReader) (err error) {
+func addSortAndFieldsToKNNHits(req *SearchRequest, knnHits []*search.DocumentMatch, reader index.IndexReader, name string) (err error) {
 	requiredSortFields := req.Sort.RequiredFields()
 	var dvReader index.DocValueReader
 	var updateFieldVisitor index.DocValueVisitor
@@ -272,6 +271,7 @@ func addSortAndFieldsToKNNHits(req *SearchRequest, knnHits []*search.DocumentMat
 		if err != nil {
 			return err
 		}
+		hit.Index = name
 	}
 	return nil
 }
@@ -300,7 +300,10 @@ func (i *indexImpl) runKnnCollector(ctx context.Context, req *SearchRequest, rea
 	// the knn hits are populated with Sort and Fields.
 	// it must be ensured downstream that the Sort and Fields are not
 	// re-evaluated, for these hits.
-	err = addSortAndFieldsToKNNHits(req, knnHits, reader)
+	// also add the index names to the hits, so that when early
+	// exit takes place after the first phase, the hits will have
+	// a valid value for Index.
+	err = addSortAndFieldsToKNNHits(req, knnHits, reader, i.name)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +402,7 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		// and not an alias. This cannot happen in normal circumstances. But
 		// performing this check to be safe. Since we extract the stack top
 		// in the following steps.
-		if len(hit.IndexNames) == 0 {
+		if hit.IndexNames == nil || len(hit.IndexNames) == 0 {
 			return nil, ErrorTwoPhaseSearchInconsistency
 		}
 		// since the stack is not empty, we need to check if the top of the stack
@@ -411,7 +414,15 @@ func validateAndDistributeKNNHits(knnHits []*search.DocumentMatch, indexes []Ind
 		if _, exists := indexNames[top]; !exists {
 			return nil, ErrorTwoPhaseSearchInconsistency
 		}
-		hit.IndexNames = hit.IndexNames[:stackTopIdx]
+		if stackTopIdx == 0 {
+			// if the stack consists of only one index, then popping the top
+			// would result in an empty slice, and handle this case by setting
+			// indexNames to nil. So that the final search results will not
+			// contain the indexNames field.
+			hit.IndexNames = nil
+		} else {
+			hit.IndexNames = hit.IndexNames[:stackTopIdx]
+		}
 		segregatedKnnHits[top] = append(segregatedKnnHits[top], hit)
 	}
 	return segregatedKnnHits, nil
@@ -456,59 +467,6 @@ func constructKnnPresearchData(mergedOut map[string]map[string]interface{}, preS
 		mergedOut[index.Name()][search.KnnPreSearchDataKey] = distributedHits[index.Name()]
 	}
 	return mergedOut, nil
-}
-
-// if the search request is satisfied by preSearch, the merged KNN hits
-// are used to construct the final search result and returned, which bypasses
-// the actual search.
-func constructKNNSearchResult(req *SearchRequest, preSearchResult *SearchResult) *SearchResult {
-	if req.SearchAfter != nil || req.SearchBefore != nil {
-		var dummyDoc *search.DocumentMatch
-		for pos, ss := range req.Sort {
-			if ss.RequiresDocID() {
-				dummyDoc.ID = req.SearchAfter[pos]
-			}
-			if ss.RequiresScoring() {
-				if score, err := strconv.ParseFloat(req.SearchAfter[pos], 64); err == nil {
-					dummyDoc.Score = score
-				}
-			}
-		}
-		if req.SearchAfter != nil {
-			dummyDoc.Sort = req.SearchAfter
-		} else {
-			dummyDoc.Sort = req.SearchBefore
-		}
-		numDocs := 0
-		for _, hit := range preSearchResult.Hits {
-			dummyDoc.HitNumber = hit.HitNumber
-			if req.SearchAfter != nil && req.Sort.Compare(req.Sort.CacheIsScore(), req.Sort.CacheDescending(), hit, dummyDoc) > 0 {
-				preSearchResult.Hits[numDocs] = hit
-				numDocs++
-			} else if req.SearchBefore != nil && req.Sort.Compare(req.Sort.CacheIsScore(), req.Sort.CacheDescending(), hit, dummyDoc) < 0 {
-				preSearchResult.Hits[numDocs] = hit
-				numDocs++
-			}
-		}
-		preSearchResult.Hits = preSearchResult.Hits[:numDocs]
-	}
-	sortFunc := req.SortFunc()
-	// sort all hits with the requested order
-	if len(req.Sort) > 0 {
-		sorter := newSearchHitSorter(req.Sort, preSearchResult.Hits)
-		sortFunc(sorter)
-	}
-	// now skip over the correct From
-	if req.From > 0 && len(preSearchResult.Hits) > req.From {
-		preSearchResult.Hits = preSearchResult.Hits[req.From:]
-	} else if req.From > 0 {
-		preSearchResult.Hits = search.DocumentMatchCollection{}
-	}
-	// now trim to the correct size
-	if req.Size > 0 && len(preSearchResult.Hits) > req.Size {
-		preSearchResult.Hits = preSearchResult.Hits[0:req.Size]
-	}
-	return preSearchResult
 }
 
 func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -20,6 +20,8 @@ package bleve
 import (
 	"archive/zip"
 	"encoding/json"
+	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -27,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/analysis/lang/en"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/query"
@@ -130,25 +133,50 @@ func TestSimilaritySearchPartitionedIndex(t *testing.T) {
 	for testCaseNum, testCase := range testCases {
 		for _, operator := range knnOperators {
 			index.indexes = make([]Index, 0)
+
 			query := searchRequests[testCase.queryIndex]
 			query.AddKNNOperator(operator)
+			query.Sort = search.SortOrder{&search.SortScore{Desc: true}, &search.SortDocID{Desc: true}}
 			query.Explain = true
 
-			indexPaths := createPartitionedIndex(documents, index, 1, testCase.mapping, t)
+			nameToIndex := createPartitionedIndex(documents, index, 1, testCase.mapping, t, false)
 			controlResult, err := index.Search(query)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
 			}
-			cleanUp(t, indexPaths, index.indexes...)
-
+			if !finalHitsHaveValidIndex(controlResult.Hits, nameToIndex) {
+				cleanUp(t, nameToIndex)
+				t.Fatalf("test case #%d failed: expected control result hits to have valid `Index`", testCaseNum)
+			}
+			cleanUp(t, nameToIndex)
 			index.indexes = make([]Index, 0)
-			indexPaths = createPartitionedIndex(documents, index, testCase.numIndexPartitions, testCase.mapping, t)
+			nameToIndex = createPartitionedIndex(documents, index, testCase.numIndexPartitions, testCase.mapping, t, false)
 			experimentalResult, err := index.Search(query)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
 			}
+			if !finalHitsHaveValidIndex(experimentalResult.Hits, nameToIndex) {
+				cleanUp(t, nameToIndex)
+				t.Fatalf("test case #%d failed: expected experimental Result hits to have valid `Index`", testCaseNum)
+			}
 			verifyResult(t, controlResult, experimentalResult, testCaseNum, true)
-			cleanUp(t, indexPaths, index.indexes...)
+			cleanUp(t, nameToIndex)
+
+			index.indexes = make([]Index, 0)
+			nameToIndex = createPartitionedIndex(documents, index, testCase.numIndexPartitions, testCase.mapping, t, true)
+			multiLevelIndexResult, err := index.Search(query)
+			if err != nil {
+				cleanUp(t, nameToIndex)
+				t.Fatal(err)
+			}
+			if !finalHitsHaveValidIndex(multiLevelIndexResult.Hits, nameToIndex) {
+				cleanUp(t, nameToIndex)
+				t.Fatalf("test case #%d failed: expected experimental Result hits to have valid `Index`", testCaseNum)
+			}
+			verifyResult(t, multiLevelIndexResult, experimentalResult, testCaseNum, false)
+			cleanUp(t, nameToIndex)
 		}
 	}
 }
@@ -202,57 +230,88 @@ func makeDatasetIntoDocuments(dataset []testDocument) []map[string]interface{} {
 	return documents
 }
 
-func cleanUp(t *testing.T, indexPaths []string, indexes ...Index) {
-	for _, childIndex := range indexes {
+func cleanUp(t *testing.T, nameToIndex map[string]Index) {
+	for path, childIndex := range nameToIndex {
 		err := childIndex.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-	for _, indexPath := range indexPaths {
-		cleanupTmpIndexPath(t, indexPath)
+		cleanupTmpIndexPath(t, path)
 	}
 }
 
+func createChildIndex(docs []map[string]interface{}, mapping mapping.IndexMapping, t *testing.T, nameToIndex map[string]Index) Index {
+	tmpIndexPath := createTmpIndexPath(t)
+	index, err := New(tmpIndexPath, mapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nameToIndex[index.Name()] = index
+	batch := index.NewBatch()
+	for _, doc := range docs {
+		err := batch.Index(doc["id"].(string), doc)
+		if err != nil {
+			cleanUp(t, nameToIndex)
+			t.Fatal(err)
+		}
+	}
+	err = index.Batch(batch)
+	if err != nil {
+		cleanUp(t, nameToIndex)
+		t.Fatal(err)
+	}
+	return index
+}
+
 func createPartitionedIndex(documents []map[string]interface{}, index *indexAliasImpl, numPartitions int,
-	mapping mapping.IndexMapping, t *testing.T) []string {
+	mapping mapping.IndexMapping, t *testing.T, multiLevel bool) map[string]Index {
 
 	partitionSize := len(documents) / numPartitions
 	extraDocs := len(documents) % numPartitions
-	docsPerPartition := make([]int, numPartitions)
+	numDocsPerPartition := make([]int, numPartitions)
 	for i := 0; i < numPartitions; i++ {
-		docsPerPartition[i] = partitionSize
+		numDocsPerPartition[i] = partitionSize
 		if extraDocs > 0 {
-			docsPerPartition[i]++
+			numDocsPerPartition[i]++
 			extraDocs--
 		}
 	}
-	var rv []string
+	docsPerPartition := make([][]map[string]interface{}, numPartitions)
 	prevCutoff := 0
 	for i := 0; i < numPartitions; i++ {
-		tmpIndexPath := createTmpIndexPath(t)
-		rv = append(rv, tmpIndexPath)
-		childIndex, err := New(tmpIndexPath, mapping)
-		if err != nil {
-			cleanUp(t, rv)
-			t.Fatal(err)
+		docsPerPartition[i] = make([]map[string]interface{}, numDocsPerPartition[i])
+		for j := 0; j < numDocsPerPartition[i]; j++ {
+			docsPerPartition[i][j] = documents[prevCutoff+j]
 		}
-		batch := childIndex.NewBatch()
-		for j := prevCutoff; j < prevCutoff+docsPerPartition[i]; j++ {
-			doc := documents[j]
-			err := batch.Index(doc["id"].(string), doc)
-			if err != nil {
-				cleanUp(t, rv)
-				t.Fatal(err)
+		prevCutoff += numDocsPerPartition[i]
+	}
+
+	rv := make(map[string]Index)
+	if !multiLevel {
+		// all indexes are at the same level
+		for i := 0; i < numPartitions; i++ {
+			index.Add(createChildIndex(docsPerPartition[i], mapping, t, rv))
+		}
+	} else {
+		// alias tree
+		indexes := make([]Index, numPartitions)
+		for i := 0; i < numPartitions; i++ {
+			indexes[i] = createChildIndex(docsPerPartition[i], mapping, t, rv)
+		}
+		numAlias := int(math.Ceil(float64(numPartitions) / 2.0))
+		aliases := make([]IndexAlias, numAlias)
+		for i := 0; i < numAlias; i++ {
+			aliases[i] = NewIndexAlias()
+			aliases[i].SetName(fmt.Sprintf("alias%d", i))
+			for j := 0; j < 2; j++ {
+				if i*2+j < numPartitions {
+					aliases[i].Add(indexes[i*2+j])
+				}
 			}
 		}
-		prevCutoff += docsPerPartition[i]
-		err = childIndex.Batch(batch)
-		if err != nil {
-			cleanUp(t, rv)
-			t.Fatal(err)
+		for i := 0; i < numAlias; i++ {
+			index.Add(aliases[i])
 		}
-		index.Add(childIndex)
 	}
 	return rv
 }
@@ -343,15 +402,62 @@ func sortChildren(children []*search.Explanation) {
 	})
 }
 
+// All hits from a hybrid search/knn search should not have
+// index names or score breakdown.
+func finalHitsOmitKNNMetadata(hits []*search.DocumentMatch) bool {
+	for _, hit := range hits {
+		if hit.IndexNames != nil || hit.ScoreBreakdown != nil {
+			fmt.Println(len(hit.IndexNames))
+			return false
+		}
+	}
+	return true
+}
+
+func finalHitsHaveValidIndex(hits []*search.DocumentMatch, indexes map[string]Index) bool {
+	for _, hit := range hits {
+		if hit.Index == "" {
+			return false
+		}
+		var idx Index
+		var ok bool
+		if idx, ok = indexes[hit.Index]; !ok {
+			return false
+		}
+		if idx == nil {
+			return false
+		}
+		var doc index.Document
+		doc, err = idx.Document(hit.ID)
+		if err != nil {
+			return false
+		}
+		if doc == nil {
+			return false
+		}
+	}
+	return true
+}
+
 func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult *SearchResult, testCaseNum int, verifyOnlyDocIDs bool) {
 	if controlResult.Hits.Len() == 0 || experimentalResult.Hits.Len() == 0 {
-		t.Fatalf("testcase %d failed: 0 hits returned", testCaseNum)
+		t.Fatalf("test case #%d failed: 0 hits returned", testCaseNum)
 	}
 	if len(controlResult.Hits) != len(experimentalResult.Hits) {
-		t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(controlResult.Hits), len(experimentalResult.Hits))
+		t.Fatalf("test case #%d failed: expected %d results, got %d", testCaseNum, len(controlResult.Hits), len(experimentalResult.Hits))
 	}
 	if controlResult.Total != experimentalResult.Total {
-		t.Fatalf("test case #%d: expected total hits to be %d, got %d", testCaseNum, controlResult.Total, experimentalResult.Total)
+		t.Fatalf("test case #%d failed: expected total hits to be %d, got %d", testCaseNum, controlResult.Total, experimentalResult.Total)
+	}
+	// KNN Metadata -> Score Breakdown and IndexNames MUST be omitted from the final hits
+	if !finalHitsOmitKNNMetadata(controlResult.Hits) || !finalHitsOmitKNNMetadata(experimentalResult.Hits) {
+		t.Fatalf("test case #%d failed: expected no KNN metadata in hits", testCaseNum)
+	}
+	if controlResult.Took == 0 || experimentalResult.Took == 0 {
+		t.Fatalf("test case #%d failed: expected non-zero took time", testCaseNum)
+	}
+	if controlResult.Request == nil || experimentalResult.Request == nil {
+		t.Fatalf("test case #%d failed: expected non-nil request", testCaseNum)
 	}
 	if verifyOnlyDocIDs {
 		// in multi partitioned index, we cannot be sure of the score or the ordering of the hits as the tf-idf scores are localized to each partition
@@ -365,44 +471,39 @@ func verifyResult(t *testing.T, controlResult *SearchResult, experimentalResult 
 			experimentalMap[hit.ID] = struct{}{}
 		}
 		if len(controlMap) != len(experimentalMap) {
-			t.Fatalf("testcase %d failed: expected %d results, got %d", testCaseNum, len(controlMap), len(experimentalMap))
+			t.Fatalf("test case #%d failed: expected %d results, got %d", testCaseNum, len(controlMap), len(experimentalMap))
 		}
 		for id := range controlMap {
 			if _, ok := experimentalMap[id]; !ok {
-				t.Fatalf("testcase %d failed: expected id %s to be in experimental result", testCaseNum, id)
+				t.Fatalf("test case #%d failed: expected id %s to be in experimental result", testCaseNum, id)
 			}
 		}
 		return
 	}
-
 	for i := 0; i < len(controlResult.Hits); i++ {
 		if controlResult.Hits[i].ID != experimentalResult.Hits[i].ID {
-			t.Fatalf("testcase %d failed: expected hit %d to have id %s, got %s", testCaseNum, i, controlResult.Hits[i].ID, experimentalResult.Hits[i].ID)
+			t.Fatalf("test case #%d failed: expected hit %d to have id %s, got %s", testCaseNum, i, controlResult.Hits[i].ID, experimentalResult.Hits[i].ID)
 		}
 		// Truncate to 6 decimal places
 		actualScore := truncateScore(experimentalResult.Hits[i].Score)
 		expectScore := truncateScore(controlResult.Hits[i].Score)
 		if expectScore != actualScore {
-			t.Fatalf("testcase %d failed: expected hit %d to have score %f, got %f", testCaseNum, i, expectScore, actualScore)
+			t.Fatalf("test case #%d failed: expected hit %d to have score %f, got %f", testCaseNum, i, expectScore, actualScore)
 		}
 		if !compareExplanation(controlResult.Hits[i].Expl, experimentalResult.Hits[i].Expl) {
-			t.Fatalf("testcase %d failed: expected hit %d to have explanation %v, got %v", testCaseNum, i, controlResult.Hits[i].Expl, experimentalResult.Hits[i].Expl)
+			t.Fatalf("test case #%d failed: expected hit %d to have explanation %v, got %v", testCaseNum, i, controlResult.Hits[i].Expl, experimentalResult.Hits[i].Expl)
 		}
-
 	}
 	if truncateScore(controlResult.MaxScore) != truncateScore(experimentalResult.MaxScore) {
 		t.Fatalf("test case #%d: expected maxScore to be %f, got %f", testCaseNum, controlResult.MaxScore, experimentalResult.MaxScore)
 	}
-
 }
+
 func TestSimilaritySearchMultipleSegments(t *testing.T) {
-	// to run this test you must first add the line
-	// 				return nil
-	// in the scorch.go file just before these two lines
-	// 				s.asyncTasks.Add(1)
-	//				go s.mergerLoop()
-	// this is to prevent the merger from running and merging the segments
-	// before we can test the search on multiple segments
+	// using scorch options to prevent merges during the course of this test
+	// so that the knnCollector can be accurately tested
+	scorch.DefaultMemoryPressurePauseThreshold = 0
+	scorch.DefaultMinSegmentsForInMemoryMerge = math.MaxInt
 	dataset, searchRequests, err := readDatasetAndQueries(testInputCompressedFile)
 	if err != nil {
 		t.Fatal(err)
@@ -547,28 +648,38 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			query.AddKNNOperator(operator)
 			query.Explain = true
 
+			nameToIndex := make(map[string]Index)
+			nameToIndex[index.Name()] = index
+
 			err = createMultipleSegmentsIndex(documents, index, 1)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
 			}
 			controlResult, err := index.Search(query)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
+			}
+			if !finalHitsHaveValidIndex(controlResult.Hits, nameToIndex) {
+				cleanUp(t, nameToIndex)
+				t.Fatalf("test case #%d failed: expected control result hits to have valid `Index`", testCaseNum)
 			}
 			if testCase.scoreValue == "none" {
 				query.Score = testCase.scoreValue
 				expectedResultScoreNone, err := index.Search(query)
 				if err != nil {
+					cleanUp(t, nameToIndex)
 					t.Fatal(err)
+				}
+				if !finalHitsHaveValidIndex(expectedResultScoreNone.Hits, nameToIndex) {
+					cleanUp(t, nameToIndex)
+					t.Fatalf("test case #%d failed: expected score none hits to have valid `Index`", testCaseNum)
 				}
 				verifyResult(t, controlResult, expectedResultScoreNone, testCaseNum, true)
 				query.Score = ""
 			}
-			err = index.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-			cleanupTmpIndexPath(t, tmpIndexPath)
+			cleanUp(t, nameToIndex)
 
 			// run multiple segments test
 			tmpIndexPath = createTmpIndexPath(t)
@@ -576,20 +687,24 @@ func TestSimilaritySearchMultipleSegments(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			nameToIndex = make(map[string]Index)
+			nameToIndex[index.Name()] = index
 			err = createMultipleSegmentsIndex(documents, index, testCase.numSegments)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
 			}
 			experimentalResult, err := index.Search(query)
 			if err != nil {
+				cleanUp(t, nameToIndex)
 				t.Fatal(err)
+			}
+			if !finalHitsHaveValidIndex(experimentalResult.Hits, nameToIndex) {
+				cleanUp(t, nameToIndex)
+				t.Fatalf("test case #%d failed: expected experimental result hits to have valid `Index`", testCaseNum)
 			}
 			verifyResult(t, controlResult, experimentalResult, testCaseNum, false)
-			err = index.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-			cleanupTmpIndexPath(t, tmpIndexPath)
+			cleanUp(t, nameToIndex)
 		}
 	}
 }

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -192,9 +192,6 @@ func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch
 func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[string]map[string]interface{}, error) {
 	return nil, nil
 }
-func constructKNNSearchResult(req *SearchRequest, preSearchResult *SearchResult) *SearchResult {
-	return preSearchResult
-}
 
 func isKNNrequestSatisfiedByPreSearch(req *SearchRequest) bool {
 	return false


### PR DESCRIPTION
- Fixed Bug: `Index` was not showing up as part of the hits, but `Index Names` was being shown in the hits
- Added more versatile and comprehensive test cases revolving hybrid search
- Code refactoring