### PR TITLE
MB-60914: Supporting field specific metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1
 	github.com/blevesearch/gtreap v0.1.1
-	github.com/blevesearch/scorch_segment_api/v2 v2.2.8
+	github.com/blevesearch/scorch_segment_api/v2 v2.2.9
 	github.com/blevesearch/segment v0.9.1
 	github.com/blevesearch/snowball v0.6.1
 	github.com/blevesearch/snowballstem v0.9.0
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.11
+	github.com/blevesearch/zapx/v16 v16.0.12
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.8 h1:+OLW38LuRKio6N6V0gIk1srwFz79FJ5v2sNqHz2HVAA=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.8/go.mod h1:ckbeb7knyOOvAdZinn/ASbB7EA3HoagnJkmEV3J7+sg=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.9 h1:3nBaSBRFokjE4FtPW3eUDgcAu3KphBg1GP07zy/6Uyk=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.9/go.mod h1:ckbeb7knyOOvAdZinn/ASbB7EA3HoagnJkmEV3J7+sg=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.11 h1:YK7fShQ5NTPAbOnrVdxA9rvc8B7S+vrdq2Y0BDkXOco=
-github.com/blevesearch/zapx/v16 v16.0.11/go.mod h1:fN9n4RlFI8kST69yUeSSKJf/zZzZfP5bpcjmoRinKrk=
+github.com/blevesearch/zapx/v16 v16.0.12 h1:Uccxvjmn+hQ6ywQP+wIiTpdq9LnAviGoryJOmGwAo/I=
+github.com/blevesearch/zapx/v16 v16.0.12/go.mod h1:MYnOshRfSm4C4drxx1LGRI+MVFByykJ2anDY1fxdk9Q=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -30,7 +30,7 @@ type segmentIntroduction struct {
 	obsoletes map[uint64]*roaring.Bitmap
 	ids       []string
 	internal  map[string][]byte
-	stats     map[string]map[string]int
+	stats     *fieldStats
 
 	applied           chan error
 	persisted         chan error
@@ -427,7 +427,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 	if nextMerge.new != nil &&
 		nextMerge.new.Count() > newSegmentDeleted.GetCardinality() {
 
-		stats := initFieldStats()
+		stats := newFieldStats()
 		if fsr, ok := nextMerge.new.(segment.FieldStatsReporter); ok {
 			fsr.UpdateFieldStats(stats)
 		}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -605,8 +605,9 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 			}
 		}
 
+		// store segment stats
 		if segmentSnapshot.stats != nil {
-			b, err := json.Marshal(segmentSnapshot.stats.GetStatsMap())
+			b, err := json.Marshal(segmentSnapshot.stats.Fetch())
 			if err != nil {
 				return nil, nil, err
 			}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/blevesearch/bleve/v2/index/scorch/mergeplan"
 	"github.com/blevesearch/bleve/v2/mapping"
 	index "github.com/blevesearch/bleve_index_api"
-	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
 func init() {
@@ -2672,7 +2671,7 @@ func BenchmarkAggregateFieldStats(b *testing.B) {
 	for i := range fieldStatsArray {
 		fieldStatsArray[i] = newFieldStats()
 
-		fieldStatsArray[i].Store(segment.NumVecsStat, "vector", uint64(rand.Intn(1000)))
+		fieldStatsArray[i].Store("num_vectors", "vector", uint64(rand.Intn(1000)))
 	}
 
 	b.ResetTimer()

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/blevesearch/bleve/v2/index/scorch/mergeplan"
 	"github.com/blevesearch/bleve/v2/mapping"
 	index "github.com/blevesearch/bleve_index_api"
+	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
 func init() {
@@ -2661,5 +2662,26 @@ func TestReadOnlyIndex(t *testing.T) {
 	}
 	if docCount != 1 {
 		t.Errorf("Expected document count to be %d got %d", 1, docCount)
+	}
+}
+
+func BenchmarkAggregateFieldStats(b *testing.B) {
+
+	fieldStatsArray := make([]*fieldStats, 1000)
+
+	for i := range fieldStatsArray {
+		fieldStatsArray[i] = newFieldStats()
+
+		fieldStatsArray[i].Store(segment.NumVecsStat, "vector", uint64(rand.Intn(1000)))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		aggFieldStats := newFieldStats()
+
+		for _, fs := range fieldStatsArray {
+			aggFieldStats.Aggregate(fs)
+		}
 	}
 }

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -39,6 +39,7 @@ type SegmentSnapshot struct {
 	segment segment.Segment
 	deleted *roaring.Bitmap
 	creator string
+	stats   map[string]map[string]int
 
 	cachedMeta *cachedMeta
 

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -39,7 +39,7 @@ type SegmentSnapshot struct {
 	segment segment.Segment
 	deleted *roaring.Bitmap
 	creator string
-	stats   map[string]map[string]int
+	stats   *fieldStats
 
 	cachedMeta *cachedMeta
 


### PR DESCRIPTION
 - These metrics are calculated based on analysis results initially and directly from the SegmentBase after a merge
 - This map will be stored in segment Introduction and segment snapshot
 - After merge, field level stats are collected from segment base after checking if it implements the FieldStatsReporter interface defined in scorch_segment_api
 - This map is also persisted in bolt to avoid recomputation under the key "stats" as part of the persisted part of the segment snapshot
 - FieldStats have been added to the StatsMap function of scorch. This will give an aggregated value of the stats with respect to the segments but specific to the field name and the stat using the stat name field:<field name>:<stat name>. For example, field:vector:num_vectors