### PR TITLE
MB-60844: MapReduce for PreSearch

### DIFF
--- a/search/scorer/scorer_knn.go
+++ b/search/scorer/scorer_knn.go
@@ -71,7 +71,7 @@ func NewKNNQueryScorer(queryVector []float32, queryField string, queryBoost floa
 
 // Score used when the knnMatch.Score = 0 ->
 // the query and indexed vector are exactly the same.
-const maxKNNScore = math.MaxFloat64
+const maxKNNScore = math.MaxFloat32
 
 func (sqs *KNNQueryScorer) Score(ctx *search.SearchContext,
 	knnMatch *index.VectorDoc) *search.DocumentMatch {

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -185,10 +185,6 @@ func requestHasKNN(req *SearchRequest) bool {
 func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {
 }
 
-func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch) []*search.DocumentMatch {
-	return nil
-}
-
 func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[string]map[string]interface{}, error) {
 	return nil, nil
 }
@@ -197,7 +193,15 @@ func isKNNrequestSatisfiedByPreSearch(req *SearchRequest) bool {
 	return false
 }
 
-func constructKnnPresearchData(mergedOut map[string]map[string]interface{}, preSearchResult *SearchResult,
+func constructKnnPreSearchData(mergedOut map[string]map[string]interface{}, preSearchResult *SearchResult,
 	indexes []Index) (map[string]map[string]interface{}, error) {
 	return mergedOut, nil
+}
+
+func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch) []*search.DocumentMatch {
+	return knnHits
+}
+
+func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
+	return nil
 }


### PR DESCRIPTION
- Instead of Merging all the PreSearch Results in one shot at the main coordinator node of an alias tree, merge them incrementally at each level of the tree instead, which would balance the reduction process across all the indexes in a distributed Bleve index, leading to a more even memory distribution.