### PR TITLE
MB-60844: MapReduce for PreSearch

### DIFF
--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -640,7 +640,9 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 				// create a new presearch result processor
 				presearchResultProcessor = CreatePreSearchResultProcessor(req)
 			}
-			presearchResultProcessor.Add(asr.Result, asr.Name)
+			if presearchResultProcessor != nil {
+				presearchResultProcessor.Add(asr.Result, asr.Name)
+			}
 			if sr == nil {
 				// first result
 				sr = &SearchResult{
@@ -678,7 +680,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 			sr.Status.Total++
 			sr.Status.Failed++
 		}
-	} else {
+	} else if presearchResultProcessor != nil {
 		presearchResultProcessor.Finalize(sr)
 	}
 	return sr, nil

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -856,16 +856,3 @@ func (f *indexAliasImplFieldDict) Close() error {
 	defer f.index.mutex.RUnlock()
 	return f.fieldDict.Close()
 }
-
-func finalizePreSearchResult(req *SearchRequest, preSearchResult *SearchResult) {
-	if requestHasKNN(req) {
-		preSearchResult.Hits = finalizeKNNResults(req, preSearchResult.Hits)
-	}
-}
-
-func createPreSearchResultProcessor(req *SearchRequest) preSearchResultProcessor {
-	if requestHasKNN(req) {
-		return newKnnPreSearchResultProcessor(req)
-	}
-	return &knnPreSearchResultProcessor{} // equivalent to nil
-}

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -640,9 +640,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 				// create a new presearch result processor
 				presearchResultProcessor = CreatePreSearchResultProcessor(req)
 			}
-			if presearchResultProcessor != nil {
-				presearchResultProcessor.Add(asr.Result, asr.Name)
-			}
+			presearchResultProcessor.Add(asr.Result, asr.Name)
 			if sr == nil {
 				// first result
 				sr = &SearchResult{
@@ -680,7 +678,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 			sr.Status.Total++
 			sr.Status.Failed++
 		}
-	} else if presearchResultProcessor != nil {
+	} else {
 		presearchResultProcessor.Finalize(sr)
 	}
 	return sr, nil

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -640,7 +640,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 				// create a new presearch result processor
 				presearchResultProcessor = CreatePreSearchResultProcessor(req)
 			}
-			presearchResultProcessor.AddPreSearchResult(asr.Result, asr.Name)
+			presearchResultProcessor.Add(asr.Result, asr.Name)
 			if sr == nil {
 				// first result
 				sr = &SearchResult{
@@ -679,7 +679,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, indexes ...Ind
 			sr.Status.Failed++
 		}
 	} else {
-		presearchResultProcessor.SetProcessedData(sr)
+		presearchResultProcessor.Finalize(sr)
 	}
 	return sr, nil
 }
@@ -887,13 +887,13 @@ func CreatePreSearchResultProcessor(req *SearchRequest) *PreSearchResultProcesso
 	}
 }
 
-func (p *PreSearchResultProcessor) AddPreSearchResult(sr *SearchResult, indexName string) {
+func (p *PreSearchResultProcessor) Add(sr *SearchResult, indexName string) {
 	if p.knnProcessor != nil {
 		p.knnProcessor.Add(sr, indexName)
 	}
 }
 
-func (p *PreSearchResultProcessor) SetProcessedData(sr *SearchResult) {
+func (p *PreSearchResultProcessor) Finalize(sr *SearchResult) {
 	if p.knnProcessor != nil {
 		p.knnProcessor.Finalize(sr)
 	}

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -881,11 +881,15 @@ type KnnPreSearchResultProcessor struct {
 }
 
 func (k *KnnPreSearchResultProcessor) Add(sr *SearchResult, indexName string) {
-	k.add(sr, indexName)
+	if k.add != nil {
+		k.add(sr, indexName)
+	}
 }
 
 func (k *KnnPreSearchResultProcessor) Finalize(sr *SearchResult) {
-	k.finalize(sr)
+	if k.finalize != nil {
+		k.finalize(sr)
+	}
 }
 
 func CreatePreSearchResultProcessor(req *SearchRequest) PreSearchResultProcessor {

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -869,8 +869,8 @@ func finalizePreSearchResult(req *SearchRequest, preSearchResult *SearchResult) 
 // to the KNNCollectorStore, and then calls the Final method to get the
 // final KNN hits.
 type KnnPreSearchResultProcessor struct {
-	AddPreSearchResult      func(*SearchResult, string)
-	FinalizePreSearchResult func(*SearchResult)
+	Add      func(*SearchResult, string)
+	Finalize func(*SearchResult)
 }
 
 type PreSearchResultProcessor struct {
@@ -889,12 +889,12 @@ func CreatePreSearchResultProcessor(req *SearchRequest) *PreSearchResultProcesso
 
 func (p *PreSearchResultProcessor) AddPreSearchResult(sr *SearchResult, indexName string) {
 	if p.knnProcessor != nil {
-		p.knnProcessor.AddPreSearchResult(sr, indexName)
+		p.knnProcessor.Add(sr, indexName)
 	}
 }
 
 func (p *PreSearchResultProcessor) SetProcessedData(sr *SearchResult) {
 	if p.knnProcessor != nil {
-		p.knnProcessor.FinalizePreSearchResult(sr)
+		p.knnProcessor.Finalize(sr)
 	}
 }

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -875,6 +875,19 @@ type PreSearchResultProcessor interface {
 	Finalize(*SearchResult)
 }
 
+type KnnPreSearchResultProcessor struct {
+	add      func(sr *SearchResult, indexName string)
+	finalize func(sr *SearchResult)
+}
+
+func (k *KnnPreSearchResultProcessor) Add(sr *SearchResult, indexName string) {
+	k.add(sr, indexName)
+}
+
+func (k *KnnPreSearchResultProcessor) Finalize(sr *SearchResult) {
+	k.finalize(sr)
+}
+
 func CreatePreSearchResultProcessor(req *SearchRequest) PreSearchResultProcessor {
 	if requestHasKNN(req) {
 		return NewKnnPreSearchResultProcessor(req)

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -203,9 +203,9 @@ func (i *indexAliasImpl) SearchInContext(ctx context.Context, req *SearchRequest
 	// check if preSearchData needs to be gathered from all indexes
 	// before executing the query
 	var err error
-	// only perform pre-search if
+	// only perform preSearch if
 	//  - the request does not already have preSearchData
-	//  - the request requires pre-search
+	//  - the request requires preSearch
 	var preSearchDuration time.Duration
 	var sr *SearchResult
 	if req.PreSearchData == nil && preSearchRequired(req) {
@@ -214,19 +214,19 @@ func (i *indexAliasImpl) SearchInContext(ctx context.Context, req *SearchRequest
 		if err != nil {
 			return nil, err
 		}
-		// check if the pre-search result has any errors and if so
+		// check if the preSearch result has any errors and if so
 		// return the search result as is without executing the query
 		// so that the errors are not lost
 		if preSearchResult.Status.Failed > 0 || len(preSearchResult.Status.Errors) > 0 {
 			return preSearchResult, nil
 		}
-		// finalize the pre-search result now
+		// finalize the preSearch result now
 		finalizePreSearchResult(req, preSearchResult)
 
-		// if there are no errors, then merge the data in the pre-search result
+		// if there are no errors, then merge the data in the preSearch result
 		// and construct the preSearchData to be used in the actual search
-		// if the request is satisfied by the pre-search result, then we can
-		// directly return the pre-search result as the final result
+		// if the request is satisfied by the preSearch result, then we can
+		// directly return the preSearch result as the final result
 		if requestSatisfiedByPreSearch(req) {
 			sr = finalizeSearchResult(req, preSearchResult)
 			// no need to run the 2nd phase MultiSearch(..)

--- a/index_impl.go
+++ b/index_impl.go
@@ -549,7 +549,6 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	ctx = context.WithValue(ctx, search.GeoBufferPoolCallbackKey,
 		search.GeoBufferPoolCallbackFunc(getBufferPool))
 
-
 	searcher, err := req.Query.Searcher(ctx, indexReader, i.m, search.SearcherOptions{
 		Explain:            req.Explain,
 		IncludeTermVectors: req.IncludeLocations || req.Highlight != nil,

--- a/pre_search.go
+++ b/pre_search.go
@@ -42,3 +42,18 @@ func (k *knnPreSearchResultProcessor) finalize(sr *SearchResult) {
 		k.finalizeFn(sr)
 	}
 }
+
+// -----------------------------------------------------------------------------
+
+func finalizePreSearchResult(req *SearchRequest, preSearchResult *SearchResult) {
+	if requestHasKNN(req) {
+		preSearchResult.Hits = finalizeKNNResults(req, preSearchResult.Hits)
+	}
+}
+
+func createPreSearchResultProcessor(req *SearchRequest) preSearchResultProcessor {
+	if requestHasKNN(req) {
+		return newKnnPreSearchResultProcessor(req)
+	}
+	return &knnPreSearchResultProcessor{} // equivalent to nil
+}

--- a/pre_search.go
+++ b/pre_search.go
@@ -19,9 +19,9 @@ package bleve
 // indexes in an alias and merges them together to
 // create the final preSearch result
 type preSearchResultProcessor interface {
-	// Add adds the preSearch result to the processor
+	// adds the preSearch result to the processor
 	add(*SearchResult, string)
-	// Update the final search result with the finalized
+	// updates the final search result with the finalized
 	// data from the processor
 	finalize(*SearchResult)
 }

--- a/pre_search.go
+++ b/pre_search.go
@@ -1,0 +1,44 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bleve
+
+// A presearchResultProcessor processes the data in
+// the presearch result from multiple
+// indexes in an alias and merges them together to
+// create the final presearch result
+type presearchResultProcessor interface {
+	// Add adds the presearch result to the processor
+	add(*SearchResult, string)
+	// Update the final search result with the finalized
+	// data from the processor
+	finalize(*SearchResult)
+}
+
+type knnPresearchResultProcessor struct {
+	addFn      func(sr *SearchResult, indexName string)
+	finalizeFn func(sr *SearchResult)
+}
+
+func (k *knnPresearchResultProcessor) add(sr *SearchResult, indexName string) {
+	if k.addFn != nil {
+		k.addFn(sr, indexName)
+	}
+}
+
+func (k *knnPresearchResultProcessor) finalize(sr *SearchResult) {
+	if k.finalizeFn != nil {
+		k.finalizeFn(sr)
+	}
+}

--- a/pre_search.go
+++ b/pre_search.go
@@ -14,30 +14,30 @@
 
 package bleve
 
-// A presearchResultProcessor processes the data in
-// the presearch result from multiple
+// A preSearchResultProcessor processes the data in
+// the preSearch result from multiple
 // indexes in an alias and merges them together to
-// create the final presearch result
-type presearchResultProcessor interface {
-	// Add adds the presearch result to the processor
+// create the final preSearch result
+type preSearchResultProcessor interface {
+	// Add adds the preSearch result to the processor
 	add(*SearchResult, string)
 	// Update the final search result with the finalized
 	// data from the processor
 	finalize(*SearchResult)
 }
 
-type knnPresearchResultProcessor struct {
+type knnPreSearchResultProcessor struct {
 	addFn      func(sr *SearchResult, indexName string)
 	finalizeFn func(sr *SearchResult)
 }
 
-func (k *knnPresearchResultProcessor) add(sr *SearchResult, indexName string) {
+func (k *knnPreSearchResultProcessor) add(sr *SearchResult, indexName string) {
 	if k.addFn != nil {
 		k.addFn(sr, indexName)
 	}
 }
 
-func (k *knnPresearchResultProcessor) finalize(sr *SearchResult) {
+func (k *knnPreSearchResultProcessor) finalize(sr *SearchResult) {
 	if k.finalizeFn != nil {
 		k.finalizeFn(sr)
 	}

--- a/search/scorer/scorer_knn.go
+++ b/search/scorer/scorer_knn.go
@@ -71,7 +71,7 @@ func NewKNNQueryScorer(queryVector []float32, queryField string, queryBoost floa
 
 // Score used when the knnMatch.Score = 0 ->
 // the query and indexed vector are exactly the same.
-const maxKNNScore = math.MaxFloat64
+const maxKNNScore = math.MaxFloat32
 
 func (sqs *KNNQueryScorer) Score(ctx *search.SearchContext,
 	knnMatch *index.VectorDoc) *search.DocumentMatch {

--- a/search_knn.go
+++ b/search_knn.go
@@ -296,7 +296,7 @@ func (i *indexImpl) runKnnCollector(ctx context.Context, req *SearchRequest, rea
 	if !preSearch {
 		knnHits = finalizeKNNResults(req, knnHits)
 	}
-	// at this point, irrespective of whether it is a presearch or not,
+	// at this point, irrespective of whether it is a preSearch or not,
 	// the knn hits are populated with Sort and Fields.
 	// it must be ensured downstream that the Sort and Fields are not
 	// re-evaluated, for these hits.
@@ -417,7 +417,7 @@ func requestHasKNN(req *SearchRequest) bool {
 }
 
 // returns true if the search request contains a KNN request that can be
-// satisfied by just performing a presearch, completely bypassing the
+// satisfied by just performing a preSearch, completely bypassing the
 // actual search.
 func isKNNrequestSatisfiedByPreSearch(req *SearchRequest) bool {
 	// if req.Query is not match_none => then we need to go to phase 2
@@ -496,13 +496,13 @@ func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[stri
 	return rv, nil
 }
 
-func newKnnPresearchResultProcessor(req *SearchRequest) *knnPresearchResultProcessor {
+func newKnnPreSearchResultProcessor(req *SearchRequest) *knnPreSearchResultProcessor {
 	kArray := make([]int64, len(req.KNN))
 	for i, knnReq := range req.KNN {
 		kArray[i] = knnReq.K
 	}
 	knnStore := collector.GetNewKNNCollectorStore(kArray)
-	return &knnPresearchResultProcessor{
+	return &knnPreSearchResultProcessor{
 		addFn: func(sr *SearchResult, indexName string) {
 			for _, hit := range sr.Hits {
 				// tag the hit with the index name, so that when the

--- a/search_knn.go
+++ b/search_knn.go
@@ -496,14 +496,14 @@ func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[stri
 	return rv, nil
 }
 
-func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
+func newKnnPresearchResultProcessor(req *SearchRequest) *knnPresearchResultProcessor {
 	kArray := make([]int64, len(req.KNN))
 	for i, knnReq := range req.KNN {
 		kArray[i] = knnReq.K
 	}
 	knnStore := collector.GetNewKNNCollectorStore(kArray)
-	return &KnnPreSearchResultProcessor{
-		add: func(sr *SearchResult, indexName string) {
+	return &knnPresearchResultProcessor{
+		addFn: func(sr *SearchResult, indexName string) {
 			for _, hit := range sr.Hits {
 				// tag the hit with the index name, so that when the
 				// final search result is constructed, the hit will have
@@ -513,7 +513,7 @@ func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProce
 				knnStore.AddDocument(hit)
 			}
 		},
-		finalize: func(sr *SearchResult) {
+		finalizeFn: func(sr *SearchResult) {
 			// passing nil as the document fixup function, because we don't need to
 			// fixup the document, since this was already done in the first phase,
 			// hence error is always nil.

--- a/search_knn.go
+++ b/search_knn.go
@@ -496,11 +496,6 @@ func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[stri
 	return rv, nil
 }
 
-type KnnPreSearchResultProcessor struct {
-	add      func(sr *SearchResult, indexName string)
-	finalize func(sr *SearchResult)
-}
-
 func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
 	kArray := make([]int64, len(req.KNN))
 	for i, knnReq := range req.KNN {
@@ -526,12 +521,4 @@ func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProce
 			sr.Hits, _ = knnStore.Final(nil)
 		},
 	}
-}
-
-func (k *KnnPreSearchResultProcessor) Add(sr *SearchResult, indexName string) {
-	k.add(sr, indexName)
-}
-
-func (k *KnnPreSearchResultProcessor) Finalize(sr *SearchResult) {
-	k.finalize(sr)
 }

--- a/search_knn.go
+++ b/search_knn.go
@@ -503,7 +503,7 @@ func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProce
 	}
 	knnStore := collector.GetNewKNNCollectorStore(kArray)
 	return &KnnPreSearchResultProcessor{
-		AddPreSearchResult: func(sr *SearchResult, indexName string) {
+		Add: func(sr *SearchResult, indexName string) {
 			for _, hit := range sr.Hits {
 				// tag the hit with the index name, so that when the
 				// final search result is constructed, the hit will have
@@ -513,7 +513,7 @@ func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProce
 				knnStore.AddDocument(hit)
 			}
 		},
-		FinalizePreSearchResult: func(sr *SearchResult) {
+		Finalize: func(sr *SearchResult) {
 			// passing nil as the document fixup function, because we don't need to
 			// fixup the document, since this was already done in the first phase,
 			// hence error is always nil.

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -202,6 +202,6 @@ func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch) []*
 	return knnHits
 }
 
-func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
-	return &KnnPreSearchResultProcessor{}
+func newKnnPresearchResultProcessor(req *SearchRequest) *knnPresearchResultProcessor {
+	return &knnPresearchResultProcessor{} // equivalent to nil
 }

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -202,6 +202,6 @@ func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch) []*
 	return knnHits
 }
 
-func newKnnPresearchResultProcessor(req *SearchRequest) *knnPresearchResultProcessor {
-	return &knnPresearchResultProcessor{} // equivalent to nil
+func newKnnPreSearchResultProcessor(req *SearchRequest) *knnPreSearchResultProcessor {
+	return &knnPreSearchResultProcessor{} // equivalent to nil
 }

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -203,5 +203,5 @@ func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch) []*
 }
 
 func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
-	return nil
+	return &KnnPreSearchResultProcessor{}
 }

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -185,10 +185,6 @@ func requestHasKNN(req *SearchRequest) bool {
 func addKnnToDummyRequest(dummyReq *SearchRequest, realReq *SearchRequest) {
 }
 
-func mergeKNNDocumentMatches(req *SearchRequest, knnHits []*search.DocumentMatch) []*search.DocumentMatch {
-	return nil
-}
-
 func redistributeKNNPreSearchData(req *SearchRequest, indexes []Index) (map[string]map[string]interface{}, error) {
 	return nil, nil
 }
@@ -197,7 +193,15 @@ func isKNNrequestSatisfiedByPreSearch(req *SearchRequest) bool {
 	return false
 }
 
-func constructKnnPresearchData(mergedOut map[string]map[string]interface{}, preSearchResult *SearchResult,
+func constructKnnPreSearchData(mergedOut map[string]map[string]interface{}, preSearchResult *SearchResult,
 	indexes []Index) (map[string]map[string]interface{}, error) {
 	return mergedOut, nil
+}
+
+func finalizeKNNResults(req *SearchRequest, knnHits []*search.DocumentMatch) []*search.DocumentMatch {
+	return knnHits
+}
+
+func NewKnnPreSearchResultProcessor(req *SearchRequest) *KnnPreSearchResultProcessor {
+	return nil
 }


### PR DESCRIPTION
- Instead of Merging all the PreSearch Results in one shot at the main coordinator node of an alias tree, merge them incrementally at each level of the tree instead, which would balance the reduction process across all the indexes in a distributed Bleve index, leading to a more even memory distribution.