### PR TITLE
MB-60971: Avoiding unnecessary persister notifs from merger

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -300,6 +300,7 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	go cw.listen()
 
 	if len(resultMergePlan.Tasks) == 0 {
+		atomic.AddUint64(&s.stats.TotFileMergePlanZeroTasks, 1)
 		return errNoOpMerge
 	}
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -77,6 +77,21 @@ OUTER:
 				// lets get started
 				err := s.planMergeAtSnapshot(ctrlMsg.ctx, ctrlMsg.options,
 					ourSnapshot)
+
+				// if there were no segments merged because there were no tasks
+				// present, continue the next iteration of merger loop and don't
+				// notify the persister since there was no change in the index snapshot.
+				if err == errNoOpMerge {
+					// index has been closed
+					_ = ourSnapshot.DecRef()
+
+					// continue the workloop on a user triggered cancel
+					if ctrlMsg.doneCh != nil {
+						close(ctrlMsg.doneCh)
+						ctrlMsg = nil
+					}
+					continue OUTER
+				}
 				if err != nil {
 					atomic.StoreUint64(&s.iStats.mergeEpoch, 0)
 					if err == segment.ErrClosed {
@@ -247,6 +262,8 @@ func (w *closeChWrapper) listen() {
 	}
 }
 
+var errNoOpMerge = fmt.Errorf("no merge was performed due to empty task list")
+
 func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	options *mergeplan.MergePlanOptions, ourSnapshot *IndexSnapshot) error {
 	// build list of persisted segments in this snapshot
@@ -281,6 +298,10 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	defer cw.close()
 
 	go cw.listen()
+
+	if len(resultMergePlan.Tasks) == 0 {
+		return errNoOpMerge
+	}
 
 	for _, task := range resultMergePlan.Tasks {
 		if len(task.Segments) == 0 {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -88,8 +88,8 @@ OUTER:
 					// continue the workloop on a user triggered cancel
 					if ctrlMsg.doneCh != nil {
 						close(ctrlMsg.doneCh)
-						ctrlMsg = nil
 					}
+					ctrlMsg = nil
 					continue OUTER
 				}
 				if err != nil {

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -99,6 +99,7 @@ type Stats struct {
 	TotFileMergePlanNone uint64
 	TotFileMergePlanOk   uint64
 
+	TotFileMergePlanZeroTasks          uint64
 	TotFileMergePlanTasks              uint64
 	TotFileMergePlanTasksDone          uint64
 	TotFileMergePlanTasksErr           uint64


### PR DESCRIPTION
- There are chances that the merger doesn't see any eligible segments to be merged in the current iteration which causes the tasks list to be empty. In this situation, merger which didn't update the root snapshot would notify the persister. 
- Now, if the persister was napping at this point of time, and assuming there were mutations coming into the system (so the root snapshot would be updated by the introducer) would lead to the persister to be awoken and start flushing out the in-memory segments to disk. 
- Perhaps a better behaviour would be to not let the merger notify the persister when there is no change in the root snapshot. This would help the persister to perform healthier in memory merging of the segments before persisting out to disk thereby helping in controlling the number of IO ops scorch would do. 

Some numbers on local testing (~4.18M dataset with lorem ipsum content)

With patch
```
  "num_bytes_used_ram": 186097560,
  "test_bucket:test_bucket._default.test:num_file_merge_ops": 7,
  "test_bucket:test_bucket._default.test:num_mutations_to_index": 0,
  "test_bucket:test_bucket._default.test:num_persister_nap_merger_break": 4,
  "test_bucket:test_bucket._default.test:num_persister_nap_pause_completed": 80,
```

Without patch
```
  "num_bytes_used_ram": 265234328,
  "test_bucket:test_bucket._default.test:num_file_merge_ops": 10,
  "test_bucket:test_bucket._default.test:num_mutations_to_index": 0,
  "test_bucket:test_bucket._default.test:num_persister_nap_merger_break": 69,
  "test_bucket:test_bucket._default.test:num_persister_nap_pause_completed": 45,
```
