### PR TITLE
Revert "MB-60971: Avoiding unnecessary persister notifs from merger (#2003)"

### DIFF
--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -99,7 +99,6 @@ type Stats struct {
 	TotFileMergePlanNone uint64
 	TotFileMergePlanOk   uint64
 
-	TotFileMergePlanZeroTasks          uint64
 	TotFileMergePlanTasks              uint64
 	TotFileMergePlanTasksDone          uint64
 	TotFileMergePlanTasksErr           uint64


### PR DESCRIPTION


This reverts commit 4fd8313c54855717d27e281fd2fb1faa00c0937f.