### PR TITLE
MB-60971: Avoiding work on persister side on no-op notifs from merger

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -77,21 +77,6 @@ OUTER:
 				// lets get started
 				err := s.planMergeAtSnapshot(ctrlMsg.ctx, ctrlMsg.options,
 					ourSnapshot)
-
-				// if there were no segments merged because there were no tasks
-				// present, continue the next iteration of merger loop and don't
-				// notify the persister since there was no change in the index snapshot.
-				if err == errNoOpMerge {
-					// index has been closed
-					_ = ourSnapshot.DecRef()
-
-					// continue the workloop on a user triggered cancel
-					if ctrlMsg.doneCh != nil {
-						close(ctrlMsg.doneCh)
-					}
-					ctrlMsg = nil
-					continue OUTER
-				}
 				if err != nil {
 					atomic.StoreUint64(&s.iStats.mergeEpoch, 0)
 					if err == segment.ErrClosed {
@@ -262,8 +247,6 @@ func (w *closeChWrapper) listen() {
 	}
 }
 
-var errNoOpMerge = fmt.Errorf("no merge was performed due to empty task list")
-
 func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	options *mergeplan.MergePlanOptions, ourSnapshot *IndexSnapshot) error {
 	// build list of persisted segments in this snapshot
@@ -301,7 +284,7 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 
 	if len(resultMergePlan.Tasks) == 0 {
 		atomic.AddUint64(&s.stats.TotFileMergePlanZeroTasks, 1)
-		return errNoOpMerge
+		return nil
 	}
 
 	for _, task := range resultMergePlan.Tasks {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -300,6 +300,7 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	go cw.listen()
 
 	if len(resultMergePlan.Tasks) == 0 {
+		atomic.AddUint64(&s.stats.TotFileMergePlanZeroTasks, 1)
 		return errNoOpMerge
 	}
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -77,6 +77,21 @@ OUTER:
 				// lets get started
 				err := s.planMergeAtSnapshot(ctrlMsg.ctx, ctrlMsg.options,
 					ourSnapshot)
+
+				// if there were no segments merged because there were no tasks
+				// present, continue the next iteration of merger loop and don't
+				// notify the persister since there was no change in the index snapshot.
+				if err == errNoOpMerge {
+					// index has been closed
+					_ = ourSnapshot.DecRef()
+
+					// continue the workloop on a user triggered cancel
+					if ctrlMsg.doneCh != nil {
+						close(ctrlMsg.doneCh)
+						ctrlMsg = nil
+					}
+					continue OUTER
+				}
 				if err != nil {
 					atomic.StoreUint64(&s.iStats.mergeEpoch, 0)
 					if err == segment.ErrClosed {
@@ -247,6 +262,8 @@ func (w *closeChWrapper) listen() {
 	}
 }
 
+var errNoOpMerge = fmt.Errorf("no merge was performed due to empty task list")
+
 func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	options *mergeplan.MergePlanOptions, ourSnapshot *IndexSnapshot) error {
 	// build list of persisted segments in this snapshot
@@ -281,6 +298,10 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 	defer cw.close()
 
 	go cw.listen()
+
+	if len(resultMergePlan.Tasks) == 0 {
+		return errNoOpMerge
+	}
 
 	for _, task := range resultMergePlan.Tasks {
 		if len(task.Segments) == 0 {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -88,8 +88,8 @@ OUTER:
 					// continue the workloop on a user triggered cancel
 					if ctrlMsg.doneCh != nil {
 						close(ctrlMsg.doneCh)
-						ctrlMsg = nil
 					}
+					ctrlMsg = nil
 					continue OUTER
 				}
 				if err != nil {

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -267,17 +267,33 @@ func (s *Scorch) pausePersisterForMergerCatchUp(lastPersistedEpoch uint64,
 	// memory merge cum persist loop.
 	if numFilesOnDisk < uint64(po.PersisterNapUnderNumFiles) &&
 		po.PersisterNapTimeMSec > 0 && s.NumEventsBlocking() == 0 {
+		s.rootLock.RLock()
+		rootEpoch := s.root.epoch
+		s.rootLock.RUnlock()
+		lastRootEpoch := rootEpoch
+		expectedNapTime := time.Now().Add(time.Millisecond * time.Duration(po.PersisterNapTimeMSec))
+
 		select {
 		case <-s.closeCh:
 		case <-time.After(time.Millisecond * time.Duration(po.PersisterNapTimeMSec)):
 			atomic.AddUint64(&s.stats.TotPersisterNapPauseCompleted, 1)
 
 		case ew := <-s.persisterNotifier:
+			// if the snapshot didn't change when the merger notified the persister,
+			// it means that there weren't any meaningful merging operation done.
+			// in which case, let the persister nap for remaining time and then
+			// let the persister do some meaningful work.
+			if lastRootEpoch == ew.epoch {
+				remainingNapDuration := time.Until(expectedNapTime)
+				time.Sleep(remainingNapDuration)
+				atomic.AddUint64(&s.stats.TotPersisterNapPauseCompleted, 1)
+			} else {
+				atomic.AddUint64(&s.stats.TotPersisterMergerNapBreak, 1)
+			}
 			// unblock the merger in meantime
 			persistWatchers = append(persistWatchers, ew)
 			lastMergedEpoch = ew.epoch
 			persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
-			atomic.AddUint64(&s.stats.TotPersisterMergerNapBreak, 1)
 		}
 		return lastMergedEpoch, persistWatchers
 	}

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -99,6 +99,7 @@ type Stats struct {
 	TotFileMergePlanNone uint64
 	TotFileMergePlanOk   uint64
 
+	TotFileMergePlanZeroTasks          uint64
 	TotFileMergePlanTasks              uint64
 	TotFileMergePlanTasksDone          uint64
 	TotFileMergePlanTasksErr           uint64


### PR DESCRIPTION
Authored-by: @Thejas-bhat 
Original: https://github.com/blevesearch/bleve/pull/2003

- There are chances that the merger doesn't see any eligible segments to
be merged in the current iteration which causes the tasks list to be
empty. In this situation, merger which didn't update the root snapshot
would notify the persister.
- Now, if the persister was napping at this point of time, and assuming
there were mutations coming into the system (so the root snapshot would
be updated by the introducer) would lead to the persister to be awoken
and start flushing out the in-memory segments to disk.
- Perhaps a better behaviour would be to let the persister nap for the remaining 
duration such and then let the persister do some work. This would also help in merger
waiting for the notification reply (which is like an interrupt fashion type of wait) 
rather than doing something more expensive of letting merger continue to do work
(which the earlier commits of this PR was doing). 

Some numbers on local testing (~4.18M dataset with lorem ipsum content)

With patch
```
"num_bytes_used_ram": 224100280,
"num_files_on_disk": 34,
"test_bucket:test_bucket._default.travel:num_file_merge_ops": 6,
"test_bucket:test_bucket._default.travel:num_file_merge_plan": 0,
"test_bucket:test_bucket._default.travel:num_files_on_disk": 34,
"test_bucket:test_bucket._default.travel:num_mem_merge_ops": 70,
"test_bucket:test_bucket._default.travel:num_persister_nap_merger_break": 4,
"test_bucket:test_bucket._default.travel:num_persister_nap_pause_completed": 69,
"test_bucket:test_bucket._default.travel:num_root_filesegments": 16,
"test_bucket:test_bucket._default.travel:num_root_memorysegments": 0,

"TotFileMergePlan": 45,
"TotFileMergePlanErr": 0,
"TotFileMergePlanNone": 1,
"TotFileMergePlanOk": 44,
```

Without patch
```
"num_bytes_used_ram": 252726152,
"num_files_on_disk": 45,
"test_bucket:test_bucket._default.travel:num_file_merge_ops": 11,
"test_bucket:test_bucket._default.travel:num_file_merge_plan": 0,
"test_bucket:test_bucket._default.travel:num_files_on_disk": 45,
"test_bucket:test_bucket._default.travel:num_mem_merge_ops": 129,
"test_bucket:test_bucket._default.travel:num_persister_nap_merger_break": 85,
"test_bucket:test_bucket._default.travel:num_persister_nap_pause_completed": 44,
"test_bucket:test_bucket._default.travel:num_root_filesegments": 33,
"test_bucket:test_bucket._default.travel:num_root_memorysegments": 0,

"TotFileMergePlan": 96,
"TotFileMergePlanErr": 0,
"TotFileMergePlanNone": 1,
"TotFileMergePlanOk": 95,

```