### PR TITLE
Revert "MB-60971: Avoiding work on persister side on no-op notifs from merger"

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -282,11 +282,6 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 
 	go cw.listen()
 
-	if len(resultMergePlan.Tasks) == 0 {
-		atomic.AddUint64(&s.stats.TotFileMergePlanZeroTasks, 1)
-		return nil
-	}
-
 	for _, task := range resultMergePlan.Tasks {
 		if len(task.Segments) == 0 {
 			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -267,36 +267,17 @@ func (s *Scorch) pausePersisterForMergerCatchUp(lastPersistedEpoch uint64,
 	// memory merge cum persist loop.
 	if numFilesOnDisk < uint64(po.PersisterNapUnderNumFiles) &&
 		po.PersisterNapTimeMSec > 0 && s.NumEventsBlocking() == 0 {
-		s.rootLock.RLock()
-		lastRootEpoch := s.root.epoch
-		s.rootLock.RUnlock()
-		expectedNapTime := time.Now().Add(time.Millisecond * time.Duration(po.PersisterNapTimeMSec))
-
 		select {
 		case <-s.closeCh:
 		case <-time.After(time.Millisecond * time.Duration(po.PersisterNapTimeMSec)):
 			atomic.AddUint64(&s.stats.TotPersisterNapPauseCompleted, 1)
 
 		case ew := <-s.persisterNotifier:
-			s.rootLock.RLock()
-			currRootEpoch := s.root.epoch
-			s.rootLock.RUnlock()
-
-			// if the snapshot didn't change when the merger notified the persister,
-			// it means that there weren't any meaningful merging operation done.
-			// in which case, let the persister nap for remaining time and then
-			// let the persister do some meaningful work.
-			if lastRootEpoch == currRootEpoch {
-				remainingNapDuration := time.Until(expectedNapTime)
-				time.Sleep(remainingNapDuration)
-				atomic.AddUint64(&s.stats.TotPersisterNapPauseCompleted, 1)
-			} else {
-				atomic.AddUint64(&s.stats.TotPersisterMergerNapBreak, 1)
-			}
 			// unblock the merger in meantime
 			persistWatchers = append(persistWatchers, ew)
 			lastMergedEpoch = ew.epoch
 			persistWatchers = notifyMergeWatchers(lastPersistedEpoch, persistWatchers)
+			atomic.AddUint64(&s.stats.TotPersisterMergerNapBreak, 1)
 		}
 		return lastMergedEpoch, persistWatchers
 	}

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -99,7 +99,6 @@ type Stats struct {
 	TotFileMergePlanNone uint64
 	TotFileMergePlanOk   uint64
 
-	TotFileMergePlanZeroTasks          uint64
 	TotFileMergePlanTasks              uint64
 	TotFileMergePlanTasksDone          uint64
 	TotFileMergePlanTasksErr           uint64


### PR DESCRIPTION
This reverts commit 2d81bf0aef3a9bd33a9abe6597618dcb4f469123 ( https://github.com/blevesearch/bleve/pull/2006 ) on account of the regression highlighted with MB-61447.