### PR TITLE
MB-59616: Adding vector_base64 field

### DIFF
--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -19,8 +19,9 @@ package document
 
 import (
 	"encoding/base64"
-	"encoding/json"
+	"encoding/binary"
 	"fmt"
+	"math"
 
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -100,11 +101,12 @@ func DecodeVector(encodedValue string) ([]float32, error) {
 		return nil, err
 	}
 
-	var decodedVector []float32
-	err = json.Unmarshal(decodedString, &decodedVector)
-	if err != nil {
-		fmt.Println("Error decoding string:", err)
-		return nil, err
+	dims := int(len(decodedString) / 4)
+	decodedVector := make([]float32, dims)
+
+	for i := 0; i < dims; i++ {
+		bytes := decodedString[i*4 : (i+1)*4]
+		decodedVector[i] = math.Float32frombits(binary.LittleEndian.Uint32(bytes))
 	}
 
 	return decodedVector, nil

--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/blevesearch/bleve/v2/size"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
@@ -106,16 +107,16 @@ func DecodeVector(encodedValue string) ([]float32, error) {
 
 	// The array is expected to be divisible by 4 because each float32
 	// should occupy 4 bytes
-	if len(decodedString)%4 != 0 {
-		return nil, fmt.Errorf("Decoded byte array not divisible by 4")
+	if len(decodedString)%size.SizeOfFloat32 != 0 {
+		return nil, fmt.Errorf("Decoded byte array not divisible by %d", size.SizeOfFloat32)
 	}
-	dims := int(len(decodedString) / 4)
+	dims := int(len(decodedString) / size.SizeOfFloat32)
 	decodedVector := make([]float32, dims)
 
 	// We iterate through the array 4 bytes at a time and convert each of
 	// them to a float32 value by reading them in a little endian notation
 	for i := 0; i < dims; i++ {
-		bytes := decodedString[i*4 : (i+1)*4]
+		bytes := decodedString[i*size.SizeOfFloat32 : (i+1)*size.SizeOfFloat32]
 		decodedVector[i] = math.Float32frombits(binary.LittleEndian.Uint32(bytes))
 	}
 

--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -1,0 +1,128 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package document
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+type VectorBase64Field struct {
+	vectorField  *VectorField
+	encodedValue string
+}
+
+func (n *VectorBase64Field) Size() int {
+	return n.vectorField.Size()
+}
+
+func (n *VectorBase64Field) Name() string {
+	return n.vectorField.Name()
+}
+
+func (n *VectorBase64Field) ArrayPositions() []uint64 {
+	return n.vectorField.ArrayPositions()
+}
+
+func (n *VectorBase64Field) Options() index.FieldIndexingOptions {
+	return n.vectorField.Options()
+}
+
+func (n *VectorBase64Field) NumPlainTextBytes() uint64 {
+	return n.vectorField.NumPlainTextBytes()
+}
+
+func (n *VectorBase64Field) AnalyzedLength() int {
+	return n.vectorField.AnalyzedLength()
+}
+
+func (n *VectorBase64Field) EncodedFieldType() byte {
+	return 'e' // CHECK
+}
+
+func (n *VectorBase64Field) AnalyzedTokenFrequencies() index.TokenFrequencies {
+	return n.vectorField.AnalyzedTokenFrequencies()
+}
+
+func (n *VectorBase64Field) Analyze() {
+	// CHECK
+}
+
+func (n *VectorBase64Field) Value() []byte {
+	return n.vectorField.Value()
+}
+
+func (n *VectorBase64Field) GoString() string {
+	return fmt.Sprintf("&document.vectorFieldBase64Field{Name:%s, Options: %s, "+
+		"Value: %+v}", n.vectorField.Name(), n.vectorField.Options(), n.vectorField.Value())
+}
+
+// For the sake of not polluting the API, we are keeping arrayPositions as a
+// parameter, but it is not used.
+func NewVectorBase64Field(name string, arrayPositions []uint64, encodedValue string,
+	dims int, similarity, vectorIndexOptimizedFor string) (*VectorBase64Field, error) {
+
+	vector, err := decodeVector(encodedValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VectorBase64Field{
+		vectorField: NewVectorFieldWithIndexingOptions(name, arrayPositions,
+			vector, dims, similarity,
+			vectorIndexOptimizedFor, DefaultVectorIndexingOptions),
+
+		encodedValue: encodedValue,
+	}, nil
+}
+
+func decodeVector(encodedValue string) ([]float32, error) {
+	decodedString, err := base64.StdEncoding.DecodeString(encodedValue)
+	if err != nil {
+		fmt.Println("Error decoding string:", err)
+		return nil, err
+	}
+
+	var decodedVector []float32
+	err = json.Unmarshal(decodedString, decodedVector)
+	if err != nil {
+		fmt.Println("Error decoding string:", err)
+		return nil, err
+	}
+
+	return decodedVector, nil
+}
+
+func (n *VectorBase64Field) Vector() []float32 {
+	return n.vectorField.Vector()
+}
+
+func (n *VectorBase64Field) Dims() int {
+	return n.vectorField.Dims()
+}
+
+func (n *VectorBase64Field) Similarity() string {
+	return n.vectorField.Similarity()
+}
+
+func (n *VectorBase64Field) IndexOptimizedFor() string {
+	return n.vectorField.IndexOptimizedFor()
+}

--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -80,7 +80,7 @@ func (n *VectorBase64Field) GoString() string {
 func NewVectorBase64Field(name string, arrayPositions []uint64, encodedValue string,
 	dims int, similarity, vectorIndexOptimizedFor string) (*VectorBase64Field, error) {
 
-	vector, err := decodeVector(encodedValue)
+	vector, err := DecodeVector(encodedValue)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func NewVectorBase64Field(name string, arrayPositions []uint64, encodedValue str
 	}, nil
 }
 
-func decodeVector(encodedValue string) ([]float32, error) {
+func DecodeVector(encodedValue string) ([]float32, error) {
 	decodedString, err := base64.StdEncoding.DecodeString(encodedValue)
 	if err != nil {
 		fmt.Println("Error decoding string:", err)
@@ -102,7 +102,7 @@ func decodeVector(encodedValue string) ([]float32, error) {
 	}
 
 	var decodedVector []float32
-	err = json.Unmarshal(decodedString, decodedVector)
+	err = json.Unmarshal(decodedString, &decodedVector)
 	if err != nil {
 		fmt.Println("Error decoding string:", err)
 		return nil, err

--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -26,8 +26,8 @@ import (
 )
 
 type VectorBase64Field struct {
-	vectorField  *VectorField
-	encodedValue string
+	vectorField    *VectorField
+	base64Encoding string
 }
 
 func (n *VectorBase64Field) Size() int {
@@ -55,7 +55,7 @@ func (n *VectorBase64Field) AnalyzedLength() int {
 }
 
 func (n *VectorBase64Field) EncodedFieldType() byte {
-	return 'e' // CHECK
+	return 'e'
 }
 
 func (n *VectorBase64Field) AnalyzedTokenFrequencies() index.TokenFrequencies {
@@ -63,7 +63,6 @@ func (n *VectorBase64Field) AnalyzedTokenFrequencies() index.TokenFrequencies {
 }
 
 func (n *VectorBase64Field) Analyze() {
-	// CHECK
 }
 
 func (n *VectorBase64Field) Value() []byte {
@@ -77,10 +76,10 @@ func (n *VectorBase64Field) GoString() string {
 
 // For the sake of not polluting the API, we are keeping arrayPositions as a
 // parameter, but it is not used.
-func NewVectorBase64Field(name string, arrayPositions []uint64, encodedValue string,
+func NewVectorBase64Field(name string, arrayPositions []uint64, vectorBase64 string,
 	dims int, similarity, vectorIndexOptimizedFor string) (*VectorBase64Field, error) {
 
-	vector, err := DecodeVector(encodedValue)
+	vector, err := DecodeVector(vectorBase64)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +89,7 @@ func NewVectorBase64Field(name string, arrayPositions []uint64, encodedValue str
 			vector, dims, similarity,
 			vectorIndexOptimizedFor, DefaultVectorIndexingOptions),
 
-		encodedValue: encodedValue,
+		base64Encoding: vectorBase64,
 	}, nil
 }
 

--- a/document/field_vector_base64.go
+++ b/document/field_vector_base64.go
@@ -94,16 +94,26 @@ func NewVectorBase64Field(name string, arrayPositions []uint64, vectorBase64 str
 	}, nil
 }
 
+// This function takes a base64 encoded string and decodes it into
+// a vector.
 func DecodeVector(encodedValue string) ([]float32, error) {
+
+	// We first decode the encoded string into a byte array.
 	decodedString, err := base64.StdEncoding.DecodeString(encodedValue)
 	if err != nil {
-		fmt.Println("Error decoding string:", err)
 		return nil, err
 	}
 
+	// The array is expected to be divisible by 4 because each float32
+	// should occupy 4 bytes
+	if len(decodedString)%4 != 0 {
+		return nil, fmt.Errorf("Decoded byte array not divisible by 4")
+	}
 	dims := int(len(decodedString) / 4)
 	decodedVector := make([]float32, dims)
 
+	// We iterate through the array 4 bytes at a time and convert each of
+	// them to a float32 value by reading them in a little endian notation
 	for i := 0; i < dims; i++ {
 		bytes := decodedString[i*4 : (i+1)*4]
 		decodedVector[i] = math.Float32frombits(binary.LittleEndian.Uint32(bytes))

--- a/document/field_vector_base64_test.go
+++ b/document/field_vector_base64_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build vectors
+// +build vectors
+
 package document
 
 import (

--- a/document/field_vector_base64_test.go
+++ b/document/field_vector_base64_test.go
@@ -1,0 +1,110 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package document
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func TestDecodeVector(t *testing.T) {
+	vec := make([]float32, 2048)
+	for i := range vec {
+		vec[i] = rand.Float32()
+	}
+
+	vecBytes := bytifyVec(vec)
+	encodedVec := base64.StdEncoding.EncodeToString(vecBytes)
+
+	decodedVec, err := DecodeVector(encodedVec)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(decodedVec) != len(vec) {
+		t.Errorf("Decoded vector dimensions not same as original vector dimensions")
+	}
+
+	for i := range vec {
+		if vec[i] != decodedVec[i] {
+			t.Errorf("Decoded vector not the same as original vector")
+		}
+	}
+}
+
+func BenchmarkDecodeVector128(b *testing.B) {
+	vec := make([]float32, 128)
+	for i := range vec {
+		vec[i] = rand.Float32()
+	}
+
+	vecBytes := bytifyVec(vec)
+	encodedVec := base64.StdEncoding.EncodeToString(vecBytes)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = DecodeVector(encodedVec)
+	}
+}
+
+func BenchmarkDecodeVector784(b *testing.B) {
+	vec := make([]float32, 784)
+	for i := range vec {
+		vec[i] = rand.Float32()
+	}
+
+	vecBytes := bytifyVec(vec)
+	encodedVec := base64.StdEncoding.EncodeToString(vecBytes)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = DecodeVector(encodedVec)
+	}
+}
+
+func BenchmarkDecodeVector1536(b *testing.B) {
+	vec := make([]float32, 1536)
+	for i := range vec {
+		vec[i] = rand.Float32()
+	}
+
+	vecBytes := bytifyVec(vec)
+	encodedVec := base64.StdEncoding.EncodeToString(vecBytes)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = DecodeVector(encodedVec)
+	}
+}
+
+func bytifyVec(vec []float32) []byte {
+
+	buf := new(bytes.Buffer)
+
+	for _, v := range vec {
+		err := binary.Write(buf, binary.LittleEndian, v)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	return buf.Bytes()
+}

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -443,6 +443,8 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 					fieldMapping.processGeoShape(property, pathString, path, indexes, context)
 				} else if fieldMapping.Type == "geopoint" {
 					fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
+				} else if fieldMapping.Type == "vector-base64" {
+					fieldMapping.processVectorBase64(property, pathString, path, indexes, context)
 				} else {
 					fieldMapping.processString(propertyValueString, pathString, path, indexes, context)
 				}

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -443,7 +443,7 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 					fieldMapping.processGeoShape(property, pathString, path, indexes, context)
 				} else if fieldMapping.Type == "geopoint" {
 					fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
-				} else if fieldMapping.Type == "vector-base64" {
+				} else if fieldMapping.Type == "vector_base64" {
 					fieldMapping.processVectorBase64(property, pathString, path, indexes, context)
 				} else {
 					fieldMapping.processString(propertyValueString, pathString, path, indexes, context)

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -320,6 +320,7 @@ func (im *IndexMappingImpl) determineType(data interface{}) string {
 
 	return im.DefaultType
 }
+
 func (im *IndexMappingImpl) MapDocument(doc *document.Document, data interface{}) error {
 	docType := im.determineType(data)
 	docMapping := im.mappingForType(docType)

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -320,7 +320,6 @@ func (im *IndexMappingImpl) determineType(data interface{}) string {
 
 	return im.DefaultType
 }
-
 func (im *IndexMappingImpl) MapDocument(doc *document.Document, data interface{}) error {
 	docType := im.determineType(data)
 	docMapping := im.mappingForType(docType)

--- a/mapping/mapping_no_vectors.go
+++ b/mapping/mapping_no_vectors.go
@@ -21,9 +21,18 @@ func NewVectorFieldMapping() *FieldMapping {
 	return nil
 }
 
+func NewVectorBase64FieldMapping() *FieldMapping {
+	return nil
+}
+
 func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 	pathString string, path []string, indexes []uint64, context *walkContext) bool {
 	return false
+}
+
+func (fm *FieldMapping) processVectorBase64(propertyMightBeVector interface{},
+	pathString string, path []string, indexes []uint64, context *walkContext) {
+
 }
 
 // -----------------------------------------------------------------------------

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -18,6 +18,8 @@
 package mapping
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -35,6 +37,17 @@ const (
 func NewVectorFieldMapping() *FieldMapping {
 	return &FieldMapping{
 		Type:         "vector",
+		Store:        false,
+		Index:        true,
+		IncludeInAll: false,
+		DocValues:    false,
+		SkipFreqNorm: true,
+	}
+}
+
+func NewVectorBase64FieldMapping() *FieldMapping {
+	return &FieldMapping{
+		Type:         "vector-base64",
 		Store:        false,
 		Index:        true,
 		IncludeInAll: false,
@@ -121,6 +134,27 @@ func processVector(vecI interface{}, dims int) ([]float32, bool) {
 	return rv, true
 }
 
+func processVectorBase64(vecBase64 interface{}) (interface{}, bool) {
+
+	vecEncoded, ok := vecBase64.(string)
+	if !ok {
+		return nil, false
+	}
+
+	vecData, err := base64.StdEncoding.DecodeString(vecEncoded)
+	if err != nil {
+		return nil, false
+	}
+
+	var vector interface{}
+	err = json.Unmarshal(vecData, &vector)
+	if err != nil {
+		return nil, false
+	}
+
+	return vector, true
+}
+
 func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 	pathString string, path []string, indexes []uint64, context *walkContext) bool {
 	vector, ok := processVector(propertyMightBeVector, fm.Dims)
@@ -140,13 +174,24 @@ func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 	return true
 }
 
+func (fm *FieldMapping) processVectorBase64(propertyMightBeVectorBase64 interface{},
+	pathString string, path []string, indexes []uint64, context *walkContext) {
+
+	propertyMightBeVector, ok := processVectorBase64(propertyMightBeVectorBase64)
+	if !ok {
+		return
+	}
+
+	fm.processVector(propertyMightBeVector, pathString, path, indexes, context)
+}
+
 // -----------------------------------------------------------------------------
 // document validation functions
 
 func validateFieldMapping(field *FieldMapping, parentName string,
 	fieldAliasCtx map[string]*FieldMapping) error {
 	switch field.Type {
-	case "vector":
+	case "vector", "vector-base64":
 		return validateVectorFieldAlias(field, parentName, fieldAliasCtx)
 	default: // non-vector field
 		return validateFieldType(field)

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -153,7 +153,6 @@ func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 
 func (fm *FieldMapping) processVectorBase64(propertyMightBeVectorBase64 interface{},
 	pathString string, path []string, indexes []uint64, context *walkContext) {
-
 	encodedString, ok := propertyMightBeVectorBase64.(string)
 	if !ok {
 		return

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -135,7 +135,6 @@ func processVector(vecI interface{}, dims int) ([]float32, bool) {
 }
 
 func processVectorBase64(vecBase64 interface{}) (interface{}, bool) {
-
 	vecEncoded, ok := vecBase64.(string)
 	if !ok {
 		return nil, false

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -47,7 +47,7 @@ func NewVectorFieldMapping() *FieldMapping {
 
 func NewVectorBase64FieldMapping() *FieldMapping {
 	return &FieldMapping{
-		Type:         "vector-base64",
+		Type:         "vector_base64",
 		Store:        false,
 		Index:        true,
 		IncludeInAll: false,
@@ -191,7 +191,7 @@ func (fm *FieldMapping) processVectorBase64(propertyMightBeVectorBase64 interfac
 func validateFieldMapping(field *FieldMapping, parentName string,
 	fieldAliasCtx map[string]*FieldMapping) error {
 	switch field.Type {
-	case "vector", "vector-base64":
+	case "vector", "vector_base64":
 		return validateVectorFieldAlias(field, parentName, fieldAliasCtx)
 	default: // non-vector field
 		return validateFieldType(field)

--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -175,7 +175,6 @@ func (fm *FieldMapping) processVector(propertyMightBeVector interface{},
 
 func (fm *FieldMapping) processVectorBase64(propertyMightBeVectorBase64 interface{},
 	pathString string, path []string, indexes []uint64, context *walkContext) {
-
 	propertyMightBeVector, ok := processVectorBase64(propertyMightBeVectorBase64)
 	if !ok {
 		return

--- a/mapping_vector.go
+++ b/mapping_vector.go
@@ -22,3 +22,7 @@ import "github.com/blevesearch/bleve/v2/mapping"
 func NewVectorFieldMapping() *mapping.FieldMapping {
 	return mapping.NewVectorFieldMapping()
 }
+
+func NewVectorBase64FieldMapping() *mapping.FieldMapping {
+	return mapping.NewVectorBase64FieldMapping()
+}

--- a/search_knn.go
+++ b/search_knn.go
@@ -67,10 +67,11 @@ type SearchRequest struct {
 	sortFunc func(sort.Interface)
 }
 
+// Vector takes precedence over vectorBase64 in case both fields are given
 type KNNRequest struct {
 	Field        string       `json:"field"`
 	Vector       []float32    `json:"vector"`
-	VectorBase64 string       `json:"vectorbase64"`
+	VectorBase64 string       `json:"vector_base64"`
 	K            int64        `json:"k"`
 	Boost        *query.Boost `json:"boost,omitempty"`
 }

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -19,6 +19,7 @@ package bleve
 
 import (
 	"archive/zip"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -397,6 +398,162 @@ func min(a, b int) int {
 	return b
 }
 
+func TestVectorBase64Index(t *testing.T) {
+
+	dataset, searchRequests, err := readDatasetAndQueries(testInputCompressedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	documents := makeDatasetIntoDocuments(dataset)
+
+	_, searchRequestsCopy, err := readDatasetAndQueries(testInputCompressedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = encodeVectors(documents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modifySearchRequests(searchRequestsCopy)
+
+	contentFM := NewTextFieldMapping()
+	contentFM.Analyzer = en.AnalyzerName
+
+	vecFML2 := mapping.NewVectorFieldMapping()
+	vecFML2.Dims = testDatasetDims
+	vecFML2.Similarity = index.EuclideanDistance
+
+	vecBFML2 := mapping.NewVectorBase64FieldMapping()
+	vecBFML2.Dims = testDatasetDims
+	vecBFML2.Similarity = index.EuclideanDistance
+
+	vecFMDot := mapping.NewVectorFieldMapping()
+	vecFMDot.Dims = testDatasetDims
+	vecFMDot.Similarity = index.CosineSimilarity
+
+	vecBFMDot := mapping.NewVectorBase64FieldMapping()
+	vecBFMDot.Dims = testDatasetDims
+	vecBFMDot.Similarity = index.CosineSimilarity
+
+	indexMappingL2 := NewIndexMapping()
+	indexMappingL2.DefaultMapping.AddFieldMappingsAt("content", contentFM)
+	indexMappingL2.DefaultMapping.AddFieldMappingsAt("vector", vecFML2)
+	indexMappingL2.DefaultMapping.AddFieldMappingsAt("vectorEncoded", vecBFML2)
+
+	indexMappingDot := NewIndexMapping()
+	indexMappingDot.DefaultMapping.AddFieldMappingsAt("content", contentFM)
+	indexMappingDot.DefaultMapping.AddFieldMappingsAt("vector", vecFMDot)
+	indexMappingDot.DefaultMapping.AddFieldMappingsAt("vectorEncoded", vecBFMDot)
+
+	tmpIndexPathL2 := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, tmpIndexPathL2)
+
+	tmpIndexPathDot := createTmpIndexPath(t)
+	defer cleanupTmpIndexPath(t, tmpIndexPathDot)
+
+	indexL2, err := New(tmpIndexPathL2, indexMappingL2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := indexL2.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	indexDot, err := New(tmpIndexPathDot, indexMappingDot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := indexDot.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	batchL2 := indexL2.NewBatch()
+	batchDot := indexDot.NewBatch()
+
+	for _, doc := range documents {
+		err = batchL2.Index(doc["id"].(string), doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = batchDot.Index(doc["id"].(string), doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = indexL2.Batch(batchL2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = indexDot.Batch(batchDot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, _ := range searchRequests {
+		for _, operator := range knnOperators {
+			controlQuery := searchRequests[i]
+			testQuery := searchRequestsCopy[i]
+
+			controlQuery.AddKNNOperator(operator)
+			testQuery.AddKNNOperator(operator)
+
+			controlResultL2, err := indexL2.Search(controlQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+			testResultL2, err := indexL2.Search(testQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if controlResultL2 != nil && testResultL2 != nil {
+				if len(controlResultL2.Hits) == len(testResultL2.Hits) {
+					for j, _ := range controlResultL2.Hits {
+						if controlResultL2.Hits[j].ID != testResultL2.Hits[j].ID {
+							t.Fatalf("testcase %d failed: expected hit id %s, got hit id %s", i, controlResultL2.Hits[j].ID, testResultL2.Hits[j].ID)
+						}
+					}
+				}
+			} else if (controlResultL2 == nil && testResultL2 != nil) ||
+				(controlResultL2 != nil && testResultL2 == nil) {
+				t.Fatalf("testcase %d failed: expected result %s, got result %s", i, controlResultL2, testResultL2)
+			}
+
+			controlResultDot, err := indexDot.Search(controlQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+			testResultDot, err := indexDot.Search(testQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if controlResultDot != nil && testResultDot != nil {
+				if len(controlResultDot.Hits) == len(testResultDot.Hits) {
+					for j, _ := range controlResultDot.Hits {
+						if controlResultDot.Hits[j].ID != testResultDot.Hits[j].ID {
+							t.Fatalf("testcase %d failed: expected hit id %s, got hit id %s", i, controlResultDot.Hits[j].ID, testResultDot.Hits[j].ID)
+						}
+					}
+				}
+			} else if (controlResultDot == nil && testResultDot != nil) ||
+				(controlResultDot != nil && testResultDot == nil) {
+				t.Fatalf("testcase %d failed: expected result %s, got result %s", i, controlResultDot, testResultDot)
+			}
+		}
+	}
+}
+
 type testDocument struct {
 	ID      string    `json:"id"`
 	Content string    `json:"content"`
@@ -432,6 +589,28 @@ func readDatasetAndQueries(fileName string) ([]testDocument, []*SearchRequest, e
 		}
 	}
 	return dataset, queries, nil
+}
+
+func encodeVectors(docs []map[string]interface{}) error {
+
+	for _, doc := range docs {
+		vec, err := json.Marshal(doc["vector"])
+		if err != nil {
+			return err
+		}
+		doc["vectorEncoded"] = base64.StdEncoding.EncodeToString(vec)
+	}
+
+	return nil
+}
+
+func modifySearchRequests(srs []*SearchRequest) {
+
+	for _, sr := range srs {
+		for _, kr := range sr.KNN {
+			kr.Field = "vectorEncoded"
+		}
+	}
 }
 
 func makeDatasetIntoDocuments(dataset []testDocument) []map[string]interface{} {


### PR DESCRIPTION
 - Added a new field type called vector_base64.
 - Acts similar to vector in most cases.
 - When a new document arrives in the bleve layer, during the parsing of all its fields in processProperty, if the field mapping type is vector-base64, then its value is decoded into a vector field and processed like a vector.
 - The standard golang base64 library is used for the decode operation.