### PR TITLE
MB-61009: Raise max supported dimensionality of vectors to 4096

### DIFF
--- a/mapping/mapping_vectors.go
+++ b/mapping/mapping_vectors.go
@@ -26,10 +26,11 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
-// Min and Max allowed dimensions for a vector field
-const (
+// Min and Max allowed dimensions for a vector field;
+// p.s must be set/updated at process init() _only_
+var (
 	MinVectorDims = 1
-	MaxVectorDims = 2048
+	MaxVectorDims = 4096
 )
 
 func NewVectorFieldMapping() *FieldMapping {


### PR DESCRIPTION
+ Allow calling application to change min/max.
+ Will require downstream changes to disallow any setting greater
  than 2048 in the event of a mixed version cluster.