### PR TITLE
Fix search cost unit test

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -403,7 +403,7 @@ func TestBytesRead(t *testing.T) {
 	prevBytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
 
 	expectedBytesRead := uint64(21639)
-	if BleveFeatureVectorSearch {
+	if supportForVectorSearch {
 		expectedBytesRead = 22049
 	}
 
@@ -561,7 +561,7 @@ func TestBytesReadStored(t *testing.T) {
 	bytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
 
 	expectedBytesRead := uint64(11501)
-	if BleveFeatureVectorSearch {
+	if supportForVectorSearch {
 		expectedBytesRead = 11911
 	}
 
@@ -638,7 +638,7 @@ func TestBytesReadStored(t *testing.T) {
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
 
 	expectedBytesRead = uint64(3687)
-	if BleveFeatureVectorSearch {
+	if supportForVectorSearch {
 		expectedBytesRead = 4097
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -401,9 +401,15 @@ func TestBytesRead(t *testing.T) {
 	}
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	prevBytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if prevBytesRead != 21639 && res.Cost == prevBytesRead {
-		t.Fatalf("expected bytes read for query string 21639, got %v",
-			prevBytesRead)
+
+	expectedBytesRead := uint64(21639)
+	if BleveFeatureVectorSearch {
+		expectedBytesRead = 22049
+	}
+
+	if prevBytesRead != expectedBytesRead && res.Cost == prevBytesRead {
+		t.Fatalf("expected bytes read for query string %v, got %v",
+			expectedBytesRead, prevBytesRead)
 	}
 
 	// subsequent queries on the same field results in lesser amount
@@ -553,8 +559,14 @@ func TestBytesReadStored(t *testing.T) {
 
 	stats, _ := idx.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ := stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead != 11501 && bytesRead == res.Cost {
-		t.Fatalf("expected the bytes read stat to be around 11501, got %v", bytesRead)
+
+	expectedBytesRead := uint64(11501)
+	if BleveFeatureVectorSearch {
+		expectedBytesRead = 11911
+	}
+
+	if bytesRead != expectedBytesRead && bytesRead == res.Cost {
+		t.Fatalf("expected the bytes read stat to be around %v, got %v", expectedBytesRead, bytesRead)
 	}
 	prevBytesRead := bytesRead
 
@@ -624,8 +636,14 @@ func TestBytesReadStored(t *testing.T) {
 
 	stats, _ = idx1.StatsMap()["index"].(map[string]interface{})
 	bytesRead, _ = stats["num_bytes_read_at_query_time"].(uint64)
-	if bytesRead != 3687 && bytesRead == res.Cost {
-		t.Fatalf("expected the bytes read stat to be around 3687, got %v", bytesRead)
+
+	expectedBytesRead = uint64(3687)
+	if BleveFeatureVectorSearch {
+		expectedBytesRead = 4097
+	}
+
+	if bytesRead != expectedBytesRead && bytesRead == res.Cost {
+		t.Fatalf("expected the bytes read stat to be around %v, got %v", expectedBytesRead, bytesRead)
 	}
 	prevBytesRead = bytesRead
 

--- a/search_knn.go
+++ b/search_knn.go
@@ -30,7 +30,7 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
-const BleveFeatureVectorSearch = true
+const supportForVectorSearch = true
 
 type knnOperator string
 

--- a/search_knn.go
+++ b/search_knn.go
@@ -30,6 +30,8 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
+const BleveFeatureVectorSearch = true
+
 type knnOperator string
 
 // Must be updated only at init

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -28,6 +28,8 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
+const BleveFeatureVectorSearch = false
+
 // A SearchRequest describes all the parameters
 // needed to search the index.
 // Query is required.

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -28,7 +28,7 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
-const BleveFeatureVectorSearch = false
+const supportForVectorSearch = false
 
 // A SearchRequest describes all the parameters
 // needed to search the index.


### PR DESCRIPTION
- Fix the BytesRead and BytesStored unit tests to pass when using the `vectors` tag. The following commands can be used to validate that all UTs now pass.
    - go test -tags=vectors -race ./...
    - go test -race ./...