### PR TITLE
Disable upside_down's boltdb tests on darwin arm64

### DIFF
--- a/index/upsidedown/store/boltdb/store_test.go
+++ b/index/upsidedown/store/boltdb/store_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !darwin || !arm64
+
 package boltdb
 
 import (


### PR DESCRIPTION
+ Test(s) in this file hang on my computer and it seems they've started hanging on the workflow jobs as well.