### PR TITLE
MB-60719: Do not `omit` score from document hits, even when empty

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -147,7 +147,7 @@ type DocumentMatch struct {
 	Index           string                `json:"index,omitempty"`
 	ID              string                `json:"id"`
 	IndexInternalID index.IndexInternalID `json:"-"`
-	Score           float64               `json:"score,omitempty"`
+	Score           float64               `json:"score"`
 	Expl            *Explanation          `json:"explanation,omitempty"`
 	Locations       FieldTermLocationMap  `json:"locations,omitempty"`
 	Fragments       FieldFragmentMap      `json:"fragments,omitempty"`


### PR DESCRIPTION
+ Omitting the score from the document hits when score:"none" causes an older SDK to panic that was expecting to see the attribute regardless.
+ This commit reverts a portion of what was proposed with https://github.com/blevesearch/bleve/pull/1930.