### PR TITLE
MB-60943: Bump up zapx/v16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.13
-	github.com/blevesearch/zapx/v16 v16.0.13-0.20240429191555-5a7981a7b6ef
+	github.com/blevesearch/zapx/v16 v16.0.13-0.20240430155854-6fe4e6b9f70a
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.13 h1:6EkfaZiPlAxqXz0neniq35my6S48QI94W/wyhnpDHHQ=
 github.com/blevesearch/zapx/v15 v15.3.13/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.0.13-0.20240429191555-5a7981a7b6ef h1:KHp9ldL7EAs57wMbFs4qgBCKiE+Pb/gGH3PGgkcAp+w=
-github.com/blevesearch/zapx/v16 v16.0.13-0.20240429191555-5a7981a7b6ef/go.mod h1:B5dln0aZM/CPMZQP+HlM0UGnZFvVVGmnR3nvKuoOZKU=
+github.com/blevesearch/zapx/v16 v16.0.13-0.20240430155854-6fe4e6b9f70a h1:nSNmMQt2X6GJL2p9t5UW1/FMnAKsZAwNOvWRZZkYTj0=
+github.com/blevesearch/zapx/v16 v16.0.13-0.20240430155854-6fe4e6b9f70a/go.mod h1:B5dln0aZM/CPMZQP+HlM0UGnZFvVVGmnR3nvKuoOZKU=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
Includes:
* 6fe4e6b Aditi Ahuja | MB-60943 - Reduce number of centroids for IVF indexes.
* 8de5651 Rahul Rampure | add map capacity