### PR TITLE
Fix issue in parsing datetime field

### DIFF
--- a/analysis/datetime/timestamp/microseconds/microseconds.go
+++ b/analysis/datetime/timestamp/microseconds/microseconds.go
@@ -40,7 +40,7 @@ func (p *DateTimeParser) ParseDateTime(input string) (time.Time, string, error) 
 	if timestamp < minBound || timestamp > maxBound {
 		return time.Time{}, "", analysis.ErrInvalidTimestampRange
 	}
-	return time.UnixMicro(timestamp), "", nil
+	return time.UnixMicro(timestamp), Name, nil
 }
 
 func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.DateTimeParser, error) {

--- a/analysis/datetime/timestamp/milliseconds/milliseconds.go
+++ b/analysis/datetime/timestamp/milliseconds/milliseconds.go
@@ -40,7 +40,7 @@ func (p *DateTimeParser) ParseDateTime(input string) (time.Time, string, error) 
 	if timestamp < minBound || timestamp > maxBound {
 		return time.Time{}, "", analysis.ErrInvalidTimestampRange
 	}
-	return time.UnixMilli(timestamp), "", nil
+	return time.UnixMilli(timestamp), Name, nil
 }
 
 func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.DateTimeParser, error) {

--- a/analysis/datetime/timestamp/nanoseconds/nanoseconds.go
+++ b/analysis/datetime/timestamp/nanoseconds/nanoseconds.go
@@ -40,7 +40,7 @@ func (p *DateTimeParser) ParseDateTime(input string) (time.Time, string, error) 
 	if timestamp < minBound || timestamp > maxBound {
 		return time.Time{}, "", analysis.ErrInvalidTimestampRange
 	}
-	return time.Unix(0, timestamp), "", nil
+	return time.Unix(0, timestamp), Name, nil
 }
 
 func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.DateTimeParser, error) {

--- a/analysis/datetime/timestamp/seconds/seconds.go
+++ b/analysis/datetime/timestamp/seconds/seconds.go
@@ -40,7 +40,7 @@ func (p *DateTimeParser) ParseDateTime(input string) (time.Time, string, error) 
 	if timestamp < minBound || timestamp > maxBound {
 		return time.Time{}, "", analysis.ErrInvalidTimestampRange
 	}
-	return time.Unix(timestamp, 0), "", nil
+	return time.Unix(timestamp, 0), Name, nil
 }
 
 func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Cache) (analysis.DateTimeParser, error) {

--- a/index_impl.go
+++ b/index_impl.go
@@ -25,6 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/microseconds"
+	"github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/milliseconds"
+	"github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/nanoseconds"
+	"github.com/blevesearch/bleve/v2/analysis/datetime/timestamp/seconds"
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
@@ -738,10 +742,28 @@ func LoadAndHighlightFields(hit *search.DocumentMatch, req *SearchRequest,
 								datetime, layout, err := docF.DateTime()
 								if err == nil {
 									if layout == "" {
-										// layout not set probably means it was indexed as a timestamp
-										value = strconv.FormatInt(datetime.UnixNano(), 10)
+										// missing layout means we fallback to
+										// the default layout which is RFC3339
+										value = datetime.Format(time.RFC3339)
 									} else {
-										value = datetime.Format(layout)
+										// the layout here can now either be representative
+										// of an actual datetime layout or a timestamp
+										switch layout {
+										case seconds.Name:
+											value = strconv.FormatInt(datetime.Unix(), 10)
+										case milliseconds.Name:
+											value = strconv.FormatInt(datetime.UnixMilli(), 10)
+										case microseconds.Name:
+											value = strconv.FormatInt(datetime.UnixMicro(), 10)
+										case nanoseconds.Name:
+											value = strconv.FormatInt(datetime.UnixNano(), 10)
+										default:
+											// the layout for formatting the date to a string
+											// is provided by a datetime parser which is not
+											// handling the timestamp case, hence the layout
+											// can be directly used to format the date
+											value = datetime.Format(layout)
+										}
 									}
 								}
 							case index.BooleanField:


### PR DESCRIPTION
Addresses https://github.com/blevesearch/bleve/issues/2027

In bleve v2.3.10, [a bug fix](https://github.com/blevesearch/bleve/pull/1868) was introduced where the value of a datetime field in the Fields part of a search hit was made to match the value actually present in the document.
- For example if a document A was indexed and had value of a datetime field X to be "2001/08/20 03:00:10", and ifA was returned as part of the search result, A's Fields will have a map which would look like
- Before Fix 
    - "X" : "2001-08-20T03:00:10Z"
- After fix 
    - "X" : "2001/08/20 03:00:10"

This would come to play in case of custom user defined date time parser, and we did this by storing the layout with which the time string was parsed with during indexing. With timestamp support being added at the same time, they did not really have a valid layout to store and hence stored nil. During queries, the layout extracted, if null, was always assumed to be for the timestamp case _but_ the case where an existing index from pre v2.3.10 (which would also return null layout) was not handled and it became a catchall case leading to the datetime string being always returned in a timestamp rather than the expected default RFC3339.