### PR TITLE
MB-61716: Corrected Field Mapping for Path Logic

### DIFF
--- a/mapping/index.go
+++ b/mapping/index.go
@@ -437,24 +437,16 @@ func (im *IndexMappingImpl) FieldAnalyzer(field string) string {
 func (im *IndexMappingImpl) FieldMappingForPath(path string) FieldMapping {
 	if im.TypeMapping != nil {
 		for _, v := range im.TypeMapping {
-			for field, property := range v.Properties {
-				for _, v1 := range property.Fields {
-					if field == path {
-						// Return field mapping if the name matches the path param.
-						return *v1
-					}
-				}
+			fm := v.fieldDescribedByPath(path)
+			if fm != nil {
+				return *fm
 			}
 		}
 	}
 
-	for field, property := range im.DefaultMapping.Properties {
-		for _, v1 := range property.Fields {
-			if field == path {
-				// Return field mapping if the name matches the path param.
-				return *v1
-			}
-		}
+	fm := im.DefaultMapping.fieldDescribedByPath(path)
+	if fm != nil {
+		return *fm
 	}
 
 	return FieldMapping{}


### PR DESCRIPTION
The previous logic here only checked fields one level deep which means any nested fields were not being considered. I replaced these with existing functions to get back the correct field mapping.