### PR TITLE
Make CopyTo use copyLock instead of the rootLock

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1132,6 +1132,7 @@ func (s *Scorch) removeOldZapFiles() error {
 	}
 
 	s.rootLock.RLock()
+	s.copyLock.RLock()
 
 	for _, f := range files {
 		fname := f.Name()
@@ -1145,6 +1146,7 @@ func (s *Scorch) removeOldZapFiles() error {
 		}
 	}
 
+	s.copyLock.RUnlock()
 	s.rootLock.RUnlock()
 
 	return nil

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -908,7 +908,7 @@ func (is *IndexSnapshot) GetSpatialAnalyzerPlugin(typ string) (
 
 func (is *IndexSnapshot) CloseCopyReader() error {
 	// first unmark the segments that were marked for backup by this index snapshot
-	is.parent.rootLock.Lock()
+	is.parent.copyLock.Lock()
 	for _, seg := range is.segment {
 		var fileName string
 		if perSeg, ok := seg.segment.(segment.PersistedSegment); ok {
@@ -924,7 +924,7 @@ func (is *IndexSnapshot) CloseCopyReader() error {
 			delete(is.parent.copyScheduled, fileName)
 		}
 	}
-	is.parent.rootLock.Unlock()
+	is.parent.copyLock.Unlock()
 	// close the index snapshot normally
 	return is.Close()
 }


### PR DESCRIPTION
- Acquiring a write lock over the rootLock within copyTo might be detrimental since it can cause the CloseCopyReader() to be a blocking operation over the whole scorch environment. We can benefit by having a separate lock for CopyTo to use which would make the CopyReader and its close method mutually exclusive with only the cleanup routine and nothing else, as copyScheduled is only used in those areas.