### PR TITLE
Updating SingleSegmentMergePlanOptions with MaxSegmentFileSize

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -150,6 +150,7 @@ var DefaultMergePlanOptions = MergePlanOptions{
 var SingleSegmentMergePlanOptions = MergePlanOptions{
 	MaxSegmentsPerTier:   1,
 	MaxSegmentSize:       1 << 30,
+	MaxSegmentFileSize:   1 << 40,
 	TierGrowth:           1.0,
 	SegmentsPerMergeTask: 10,
 	FloorSegmentSize:     1 << 30,


### PR DESCRIPTION
There was a small oversight introduced in force merge paths, where `MaxSegmentFileSize` option was missing in the `SingleSegmentMergePlanOptions`. This lead to none of the segments being eligible for a force merge. (https://github.com/blevesearch/bleve/blob/0672efa5cc7e79a9534b11517a9b8808bd8a277a/index/scorch/mergeplan/merge_plan.go#L189)

Consequently I was observing that the force merge was a no op when I triggered the API. Currently, this value has been set to 1TB.