### PR TITLE
MB-61985: Add a Scorch event for Index()

### DIFF
--- a/index.go
+++ b/index.go
@@ -47,7 +47,7 @@ func (b *Batch) Index(id string, data interface{}) error {
 		return ErrorEmptyID
 	}
 	if eventIndex, ok := b.index.(index.EventIndex); ok {
-		eventIndex.FireEvent(index.EventKindIndex)
+		eventIndex.FireIndexEvent()
 	}
 	doc := document.NewDocument(id)
 	err := b.index.Mapping().MapDocument(doc, data)

--- a/index.go
+++ b/index.go
@@ -46,21 +46,11 @@ func (b *Batch) Index(id string, data interface{}) error {
 	if id == "" {
 		return ErrorEmptyID
 	}
-	// notify handlers, if defined, that an index operation is about to be performed
-	// and that it would require additional memory estimated to be equal to the size
-	// of the last document indexed.
-	intIndex, err := b.index.Advanced()
-	if err == nil {
-		if eventIndex, ok := intIndex.(index.EventIndex); ok {
-			eventIndex.OnIndexStart()
-			defer func() {
-				eventIndex.OnIndex()
-			}()
-		}
+	if eventIndex, ok := b.index.(index.EventIndex); ok {
+		eventIndex.FireEvent(index.EventKindIndex)
 	}
-
 	doc := document.NewDocument(id)
-	err = b.index.Mapping().MapDocument(doc, data)
+	err := b.index.Mapping().MapDocument(doc, data)
 	if err != nil {
 		return err
 	}

--- a/index.go
+++ b/index.go
@@ -46,8 +46,21 @@ func (b *Batch) Index(id string, data interface{}) error {
 	if id == "" {
 		return ErrorEmptyID
 	}
+	// notify handlers, if defined, that an index operation is about to be performed
+	// and that it would require additional memory estimated to be equal to the size
+	// of the last document indexed.
+	intIndex, err := b.index.Advanced()
+	if err == nil {
+		if eventIndex, ok := intIndex.(index.EventIndex); ok {
+			eventIndex.OnIndexStart()
+			defer func() {
+				eventIndex.OnIndex()
+			}()
+		}
+	}
+
 	doc := document.NewDocument(id)
-	err := b.index.Mapping().MapDocument(doc, data)
+	err = b.index.Mapping().MapDocument(doc, data)
 	if err != nil {
 		return err
 	}

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -67,3 +67,10 @@ var EventKindMergeTaskIntroduction = EventKind(8)
 // EventKindPreMergeCheck is fired before the merge begins to check if
 // the caller should proceed with the merge.
 var EventKindPreMergeCheck = EventKind(9)
+
+// EventKindIndexStart is fired when Index() is invoked which
+// creates a new Document object from an interface using the index mapping.
+var EventKindIndexStart = EventKind(10)
+
+// EventKindIndex is fired when Index() completes.
+var EventKindIndex = EventKind(11)

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -71,6 +71,3 @@ var EventKindPreMergeCheck = EventKind(9)
 // EventKindIndexStart is fired when Index() is invoked which
 // creates a new Document object from an interface using the index mapping.
 var EventKindIndexStart = EventKind(10)
-
-// EventKindIndex is fired when Index() completes.
-var EventKindIndex = EventKind(11)

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -880,6 +880,5 @@ func (s *Scorch) CopyReader() index.CopyReader {
 
 // external API to fire a scorch event (EventKindIndexStart) externally from bleve
 func (s *Scorch) FireIndexEvent() {
-	// switch on bleve the event kind and fire the corresponding scorch event
 	s.fireEvent(EventKindIndexStart, 0)
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -49,7 +49,7 @@ type Scorch struct {
 
 	unsafeBatch bool
 
-	rootLock             sync.RWMutex
+	rootLock sync.RWMutex
 
 	root                 *IndexSnapshot // holds 1 ref-count on the root
 	rootPersisted        []chan error   // closed when root is persisted
@@ -376,6 +376,8 @@ func (s *Scorch) Delete(id string) error {
 func (s *Scorch) Batch(batch *index.Batch) (err error) {
 	start := time.Now()
 
+	// notify handlers that we're about to introduce a segment
+	s.fireEvent(EventKindBatchIntroductionStart, 0)
 	defer func() {
 		s.fireEvent(EventKindBatchIntroduction, time.Since(start))
 	}()
@@ -433,9 +435,6 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 	atomic.AddUint64(&s.stats.TotAnalysisTime, uint64(time.Since(start)))
 
 	indexStart := time.Now()
-
-	// notify handlers that we're about to introduce a segment
-	s.fireEvent(EventKindBatchIntroductionStart, 0)
 
 	var newSegment segment.Segment
 	var bufBytes uint64
@@ -877,4 +876,12 @@ func (s *Scorch) CopyReader() index.CopyReader {
 	}
 	s.rootLock.Unlock()
 	return rv
+}
+
+func (s *Scorch) OnIndexStart() {
+	s.fireEvent(EventKindIndexStart, 0)
+}
+
+func (s *Scorch) OnIndex() {
+	s.fireEvent(EventKindIndex, 0)
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -878,16 +878,8 @@ func (s *Scorch) CopyReader() index.CopyReader {
 	return rv
 }
 
-// external API to fire a scorch event externally from bleve
-func (s *Scorch) FireEvent(eventKind index.EventKind) {
+// external API to fire a scorch event (EventKindIndexStart) externally from bleve
+func (s *Scorch) FireIndexEvent() {
 	// switch on bleve the event kind and fire the corresponding scorch event
-	switch eventKind {
-	case index.EventKindIndex:
-		// bleve is about to index a document using the Index() API
-		// fire the corresponding scorch event
-		s.fireEvent(EventKindIndexStart, 0)
-	default:
-		// do nothing
-		return
-	}
+	s.fireEvent(EventKindIndexStart, 0)
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -376,7 +376,7 @@ func (s *Scorch) Delete(id string) error {
 func (s *Scorch) Batch(batch *index.Batch) (err error) {
 	start := time.Now()
 
-	// notify handlers that we're about to introduce a segment
+	// notify handlers that we're about to index a batch of data
 	s.fireEvent(EventKindBatchIntroductionStart, 0)
 	defer func() {
 		s.fireEvent(EventKindBatchIntroduction, time.Since(start))

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -878,10 +878,16 @@ func (s *Scorch) CopyReader() index.CopyReader {
 	return rv
 }
 
-func (s *Scorch) OnIndexStart() {
-	s.fireEvent(EventKindIndexStart, 0)
-}
-
-func (s *Scorch) OnIndex() {
-	s.fireEvent(EventKindIndex, 0)
+// external API to fire a scorch event externally from bleve
+func (s *Scorch) FireEvent(eventKind index.EventKind) {
+	// switch on bleve the event kind and fire the corresponding scorch event
+	switch eventKind {
+	case index.EventKindIndex:
+		// bleve is about to index a document using the Index() API
+		// fire the corresponding scorch event
+		s.fireEvent(EventKindIndexStart, 0)
+	default:
+		// do nothing
+		return
+	}
 }

--- a/index_impl.go
+++ b/index_impl.go
@@ -256,6 +256,16 @@ func (i *indexImpl) Index(id string, data interface{}) (err error) {
 		return ErrorIndexClosed
 	}
 
+	// notify handlers, if defined, that an index operation is about to be performed
+	intIndex, err := i.Advanced()
+	if err == nil {
+		if eventIndex, ok := intIndex.(index.EventIndex); ok {
+			eventIndex.OnIndexStart()
+			defer func() {
+				eventIndex.OnIndex()
+			}()
+		}
+	}
 	doc := document.NewDocument(id)
 	err = i.m.MapDocument(doc, data)
 	if err != nil {

--- a/index_impl.go
+++ b/index_impl.go
@@ -1115,13 +1115,13 @@ func (f FileSystemDirectory) GetWriter(filePath string) (io.WriteCloser,
 
 func (i *indexImpl) FireIndexEvent() {
 	// get the internal index implementation
-	intIndex, err := i.Advanced()
+	internalIndex, err := i.Advanced()
 	if err != nil {
 		return
 	}
 	// check if the internal index implementation supports events
-	if eventInternalIndex, ok := intIndex.(index.EventIndex); ok {
-		// fire the event
-		eventInternalIndex.FireIndexEvent()
+	if internalEventIndex, ok := internalIndex.(index.EventIndex); ok {
+		// fire the Index() event
+		internalEventIndex.FireIndexEvent()
 	}
 }

--- a/index_impl.go
+++ b/index_impl.go
@@ -255,7 +255,9 @@ func (i *indexImpl) Index(id string, data interface{}) (err error) {
 	if !i.open {
 		return ErrorIndexClosed
 	}
+
 	i.FireIndexEvent()
+
 	doc := document.NewDocument(id)
 	err = i.m.MapDocument(doc, data)
 	if err != nil {

--- a/index_impl.go
+++ b/index_impl.go
@@ -255,7 +255,7 @@ func (i *indexImpl) Index(id string, data interface{}) (err error) {
 	if !i.open {
 		return ErrorIndexClosed
 	}
-	i.FireEvent(index.EventKindIndex)
+	i.FireIndexEvent()
 	doc := document.NewDocument(id)
 	err = i.m.MapDocument(doc, data)
 	if err != nil {
@@ -1113,15 +1113,15 @@ func (f FileSystemDirectory) GetWriter(filePath string) (io.WriteCloser,
 		os.O_RDWR|os.O_CREATE, 0600)
 }
 
-func (i *indexImpl) FireEvent(eventKind index.EventKind) {
+func (i *indexImpl) FireIndexEvent() {
 	// get the internal index implementation
 	intIndex, err := i.Advanced()
 	if err != nil {
 		return
 	}
 	// check if the internal index implementation supports events
-	if eventIntIndex, ok := intIndex.(index.EventIndex); ok {
+	if eventInternalIndex, ok := intIndex.(index.EventIndex); ok {
 		// fire the event
-		eventIntIndex.FireEvent(eventKind)
+		eventInternalIndex.FireIndexEvent()
 	}
 }


### PR DESCRIPTION
- Add a scorch event for notifying listeners, if available, that a document is about to get added to the index, using the Index() API.
- This event can be useful for halting indexing before the Index() operation is carried out - since Index() converts an interface into a Document object using the IndexMapping's MapDocument, which consumes some extra memory.
- Shifted the EventKindBatchIntroductionStart event to before the documents were analyzed as document analysis consumes extra memory.