### PR TITLE
MB-19243: Detect fuzziness automatically based on term length

### DIFF
--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -24,6 +24,19 @@ import (
 
 var MaxFuzziness = 2
 
+// AutoFuzzinessHighThreshold is the threshold for the term length
+// above which the fuzziness is set to MaxFuzziness when the fuzziness
+// mode is set to AutoFuzziness.
+var AutoFuzzinessHighThreshold = 5
+
+// AutoFuzzinessLowThreshold is the threshold for the term length
+// below which the fuzziness is set to zero when the fuzziness mode
+// is set to AutoFuzziness.
+// For terms with length between AutoFuzzinessLowThreshold and
+// AutoFuzzinessHighThreshold, the fuzziness is set to
+// MaxFuzziness - 1.
+var AutoFuzzinessLowThreshold = 2
+
 func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term string,
 	prefix, fuzziness int, field string, boost float64,
 	options search.SearcherOptions) (search.Searcher, error) {
@@ -86,10 +99,10 @@ func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term s
 
 func getAutoFuzziness(term string) int {
 	termLength := len(term)
-	if termLength > 5 {
-		return 2
-	} else if termLength > 2 {
-		return 1
+	if termLength > AutoFuzzinessHighThreshold {
+		return MaxFuzziness
+	} else if termLength > AutoFuzzinessLowThreshold {
+		return MaxFuzziness - 1
 	}
 	return 0
 }

--- a/search/searcher/search_fuzzy.go
+++ b/search/searcher/search_fuzzy.go
@@ -71,6 +71,21 @@ func NewFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term s
 		boost, options, true)
 }
 
+func getAutoFuzziness(term string) int {
+	termLength := len(term)
+	if termLength > 5 {
+		return 2
+	} else if termLength > 2 {
+		return 1
+	}
+	return 0
+}
+
+func NewAutoFuzzySearcher(ctx context.Context, indexReader index.IndexReader, term string,
+	prefix int, field string, boost float64, options search.SearcherOptions) (search.Searcher, error) {
+	return NewFuzzySearcher(ctx, indexReader, term, prefix, getAutoFuzziness(term), field, boost, options)
+}
+
 type fuzzyCandidates struct {
 	candidates []string
 	bytesRead  uint64

--- a/search/searcher/search_phrase_test.go
+++ b/search/searcher/search_phrase_test.go
@@ -37,7 +37,7 @@ func TestPhraseSearch(t *testing.T) {
 	}()
 
 	soptions := search.SearcherOptions{Explain: true, IncludeTermVectors: true}
-	phraseSearcher, err := NewPhraseSearcher(nil, twoDocIndexReader, []string{"angst", "beer"}, 0, "desc", 1.0, soptions)
+	phraseSearcher, err := NewPhraseSearcher(nil, twoDocIndexReader, []string{"angst", "beer"}, 0, false, "desc", 1.0, soptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestMultiPhraseSearch(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		searcher, err := NewMultiPhraseSearcher(nil, reader, test.phrase, 0, "desc", 1.0, soptions)
+		searcher, err := NewMultiPhraseSearcher(nil, reader, test.phrase, 0, false, "desc", 1.0, soptions)
 		if err != nil {
 			t.Error(err)
 		}
@@ -207,7 +207,7 @@ func TestFuzzyMultiPhraseSearch(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		searcher, err := NewMultiPhraseSearcher(context.TODO(), reader, test.mphrase, test.fuzziness, "desc", 1.0, soptions)
+		searcher, err := NewMultiPhraseSearcher(context.TODO(), reader, test.mphrase, test.fuzziness, false, "desc", 1.0, soptions)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
- The following queries can now automatically detect fuzziness based on the length of the terms:
  - Match Query
  - Fuzzy Query
  - Match-Phrase Query
  - Multi-Phrase Query
  - Phrase Query
- In these queries, each term (whether in a multi-term query like Match or Phrase, or in a single-term query like Fuzzy can have its own edit distance based on its length. The edit distance is calculated as follows:
  - For terms with 1 or 2 characters: edit distance = 0 (exact match)
  - For terms with 3, 4, or 5 characters: edit distance = 1 (fuzzy match)
  - For terms with more than 5 characters: edit distance = 2 (fuzzy match)
- This feature can be enabled using the `<query>.SetAutoFuzziness(<bool>)` API.
- Additionally, we've extended the functionality to query JSON parsing. You can specify fuzziness as either "auto" or a static value in the JSON query. Both formats are valid:
1. With auto fuzziness:
```
{
  "match" : "lorem",
  "field" : "bleve"
  "fuzziness" : "auto"
}
```
2. With static fuzziness:
```
{
  "match" : "lorem",
  "field" : "bleve"
  "fuzziness" : 2
}
```
When unmarshalled, the query will correctly apply the chosen fuzziness method.
- Fixed a bug where the code incorrectly returned an error message saying `fuzziness exceeds maximum` when using a fuzzy searcher with `fuzziness = 0`. Instead, a term searcher is now returned in this case.