### PR TITLE
MB-63742 - Fix populating the filter hits map

### DIFF
--- a/search_knn.go
+++ b/search_knn.go
@@ -407,8 +407,8 @@ func (i *indexImpl) runKnnCollector(ctx context.Context, req *SearchRequest, rea
 		filterHits := filterColl.Results()
 		if len(filterHits) > 0 {
 			filterHitsMap[idx] = make([]index.IndexInternalID, len(filterHits))
-			for _, docMatch := range filterHits {
-				filterHitsMap[idx] = append(filterHitsMap[idx], docMatch.IndexInternalID)
+			for i, docMatch := range filterHits {
+				filterHitsMap[idx][i] = docMatch.IndexInternalID
 			}
 			requiresFiltering[idx] = true
 		}


### PR DESCRIPTION
Populates the initialised filter hits map using an index.