### PR TITLE
feat: expose all available terms

### DIFF
--- a/search/facets_builder.go
+++ b/search/facets_builder.go
@@ -133,6 +133,17 @@ func (tf *TermFacets) Terms() []*TermFacet {
 	return tf.termFacets
 }
 
+func (tf *TermFacets) AvailableTerms() []*TermFacet {
+	if tf == nil {
+		return []*TermFacet{}
+	}
+	terms := make([]*TermFacet, 0, len(tf.termLookup))
+	for _, term := range tf.termLookup {
+		terms = append(terms, term)
+	}
+	return terms
+}
+
 func (tf *TermFacets) TrimToTopN(n int) {
 	tf.termFacets = tf.termFacets[:n]
 }

--- a/search/facets_builder_test.go
+++ b/search/facets_builder_test.go
@@ -422,3 +422,28 @@ func TestDateFacetResultsMerge(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", expectedFrs, frs1)
 	}
 }
+
+func TestAvailableTerms(t *testing.T) {
+	tfs := &TermFacets{}
+	tfs.Add(
+		&TermFacet{
+			Term:  "term",
+			Count: 10,
+		},
+	)
+	tfs.Add(
+		&TermFacet{
+			Term:  "term",
+			Count: 20,
+		},
+	)
+
+	terms := tfs.AvailableTerms()
+	if len(terms) != 1 {
+		t.Errorf("expected 1 terms, got %d", len(terms))
+	}
+
+	if terms[0].Count != 30 {
+		t.Errorf("expected 60, got %d", terms[0].Count)
+	}
+}


### PR DESCRIPTION
The lookup contains all possible facets.  We would like to expose this to use this as a way to expose all available facets for showing filters.

You can see an example [here of what we are doing](https://github.com/grafana/grafana/pull/96130).  We used [reflection here](https://github.com/grafana/grafana/blob/166c0b8d8508ea70b77e98dc240f510af5287f37/pkg/storage/unified/resource/index.go#L521) for now, but would like to avoid that.