### PR TITLE
MB-62230 - Pre-filtering Optimisation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.16
-	github.com/blevesearch/zapx/v16 v16.1.8-0.20241104164502-f19d5f0cdbcb
+	github.com/blevesearch/zapx/v16 v16.1.8
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.16 h1:Ct3rv7FUJPfPk99TI/OofdC+Kpb4IdyfdMH48sb+FmE=
 github.com/blevesearch/zapx/v15 v15.3.16/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.1.8-0.20241104164502-f19d5f0cdbcb h1:+LkKIOe8vnyxmHLI8iOa8vpv9h46qYait5znwcl7Utg=
-github.com/blevesearch/zapx/v16 v16.1.8-0.20241104164502-f19d5f0cdbcb/go.mod h1:JqQlOqlRVaYDkpLIl3JnKql8u4zKTNlVEa3nLsi0Gn8=
+github.com/blevesearch/zapx/v16 v16.1.8 h1:Bxzpw6YQpFs7UjoCV1+RvDw6fmAT2GZxldwX8b3wVBM=
+github.com/blevesearch/zapx/v16 v16.1.8/go.mod h1:JqQlOqlRVaYDkpLIl3JnKql8u4zKTNlVEa3nLsi0Gn8=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/search/collector/eligible.go
+++ b/search/collector/eligible.go
@@ -47,16 +47,16 @@ func NewEligibleCollector(size int) *EligibleCollector {
 	return newEligibleCollector(size)
 }
 
-func getEligibleCollectorStore() *eligibleStore {
+func getEligibleCollectorStore(size int) *eligibleStore {
 	return &eligibleStore{
-		ids: make([]index.IndexInternalID, 0),
+		ids: make([]index.IndexInternalID, 0, size),
 	}
 }
 
 func newEligibleCollector(size int) *EligibleCollector {
 	// No sort order & skip always 0 since this is only to filter eligible docs.
 	ec := &EligibleCollector{size: size}
-	ec.store = getEligibleCollectorStore()
+	ec.store = getEligibleCollectorStore(size)
 	return ec
 }
 

--- a/search/collector/eligible.go
+++ b/search/collector/eligible.go
@@ -27,7 +27,7 @@ type eligibleStore struct {
 	ids []index.IndexInternalID
 }
 
-func (s *eligibleStore) AddID(doc *search.DocumentMatch) *search.DocumentMatch {
+func (s *eligibleStore) AddDocumentMatch(doc *search.DocumentMatch) *search.DocumentMatch {
 	copyOfID := make([]byte, len(doc.IndexInternalID))
 	copy(copyOfID, doc.IndexInternalID)
 	s.ids = append(s.ids, copyOfID)
@@ -67,8 +67,7 @@ func makeEligibleDocumentMatchHandler(ctx *search.SearchContext) (search.Documen
 				return nil
 			}
 
-			// No elements removed from the store here.
-			doc := ec.store.AddID(d)
+			doc := ec.store.AddDocumentMatch(d)
 			ctx.DocumentMatchPool.Put(doc)
 			return nil
 		}, nil

--- a/search/collector/eligible.go
+++ b/search/collector/eligible.go
@@ -54,7 +54,10 @@ func makeEligibleDocumentMatchHandler(ctx *search.SearchContext) (search.Documen
 			copyOfID := make([]byte, len(d.IndexInternalID))
 			copy(copyOfID, d.IndexInternalID)
 			ec.ids = append(ec.ids, copyOfID)
+
+			// recycle the DocumentMatch
 			ctx.DocumentMatchPool.Put(d)
+
 			return nil
 		}, nil
 	}

--- a/search/collector/heap.go
+++ b/search/collector/heap.go
@@ -34,11 +34,6 @@ func newStoreHeap(capacity int, compare collectorCompare) *collectStoreHeap {
 	return rv
 }
 
-func (c *collectStoreHeap) Add(doc *search.DocumentMatch) *search.DocumentMatch {
-	c.add(doc)
-	return nil
-}
-
 func (c *collectStoreHeap) AddNotExceedingSize(doc *search.DocumentMatch,
 	size int) *search.DocumentMatch {
 	c.add(doc)

--- a/search/collector/list.go
+++ b/search/collector/list.go
@@ -34,11 +34,6 @@ func newStoreList(capacity int, compare collectorCompare) *collectStoreList {
 	return rv
 }
 
-func (c *collectStoreList) Add(doc *search.DocumentMatch, size int) *search.DocumentMatch {
-	c.results.PushBack(doc)
-	return nil
-}
-
 func (c *collectStoreList) AddNotExceedingSize(doc *search.DocumentMatch, size int) *search.DocumentMatch {
 	c.add(doc)
 	if c.len() > size {

--- a/search/collector/slice.go
+++ b/search/collector/slice.go
@@ -26,14 +26,7 @@ type collectStoreSlice struct {
 	ids []index.IndexInternalID
 }
 
-func newStoreSlice(capacity int, compare collectorCompare, onlyIDs bool) *collectStoreSlice {
-	if onlyIDs {
-		rv := &collectStoreSlice{
-			ids:     make([]index.IndexInternalID, 0, capacity),
-			compare: compare,
-		}
-		return rv
-	}
+func newStoreSlice(capacity int, compare collectorCompare) *collectStoreSlice {
 	rv := &collectStoreSlice{
 		slice:   make(search.DocumentMatchCollection, 0, capacity),
 		compare: compare,

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -33,10 +33,6 @@ func init() {
 }
 
 type collectorStore interface {
-	// Adds a doc to the store without considering size.
-	// Returns nil if the doc was added successfully.
-	Add(doc *search.DocumentMatch) *search.DocumentMatch
-
 	// Add the document, and if the new store size exceeds the provided size
 	// the last element is removed and returned.  If the size has not been
 	// exceeded, nil is returned.

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -170,7 +170,7 @@ func getOptimalCollectorStore(size, skip int, comparator collectorCompare) colle
 	if size+skip > 10 {
 		return newStoreHeap(backingSize, comparator)
 	} else {
-		return newStoreSlice(backingSize, comparator)
+		return newStoreSlice(backingSize, comparator, false)
 	}
 }
 

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -170,7 +170,7 @@ func getOptimalCollectorStore(size, skip int, comparator collectorCompare) colle
 	if size+skip > 10 {
 		return newStoreHeap(backingSize, comparator)
 	} else {
-		return newStoreSlice(backingSize, comparator, false)
+		return newStoreSlice(backingSize, comparator)
 	}
 }
 

--- a/search_knn.go
+++ b/search_knn.go
@@ -404,12 +404,9 @@ func (i *indexImpl) runKnnCollector(ctx context.Context, req *SearchRequest, rea
 		if err != nil {
 			return nil, err
 		}
-		filterHits := filterColl.Results()
+		filterHits := filterColl.IDs()
 		if len(filterHits) > 0 {
-			filterHitsMap[idx] = make([]index.IndexInternalID, len(filterHits))
-			for i, docMatch := range filterHits {
-				filterHitsMap[idx][i] = docMatch.IndexInternalID
-			}
+			filterHitsMap[idx] = filterHits
 		}
 		// set requiresFiltering regardless of whether there're filtered hits or
 		// not to later decide whether to consider the knnQuery or not


### PR DESCRIPTION
This PR - 
1. Avoids creating document matches for the pre-filter phase, when IDs suffice. 
2. Re-uses document matches by adding them to the doc match pool after each hit.