### PR TITLE
MB-64360 - Fix for no eligible filter hits in a segment

### DIFF
--- a/index/scorch/empty_vec.go
+++ b/index/scorch/empty_vec.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build vectors
 // +build vectors
 

--- a/index/scorch/empty_vec.go
+++ b/index/scorch/empty_vec.go
@@ -1,0 +1,30 @@
+//go:build vectors
+// +build vectors
+
+package scorch
+
+import segment "github.com/blevesearch/scorch_segment_api/v2"
+
+type emptyVecPostingsIterator struct{}
+
+func (e *emptyVecPostingsIterator) Next() (segment.VecPosting, error) {
+	return nil, nil
+}
+
+func (e *emptyVecPostingsIterator) Advance(uint64) (segment.VecPosting, error) {
+	return nil, nil
+}
+
+func (e *emptyVecPostingsIterator) Size() int {
+	return 0
+}
+
+func (e *emptyVecPostingsIterator) BytesRead() uint64 {
+	return 0
+}
+
+func (e *emptyVecPostingsIterator) ResetBytesRead(uint64) {}
+
+func (e *emptyVecPostingsIterator) BytesWritten() uint64 { return 0 }
+
+var anemptyVecPostingsIterator = &emptyVecPostingsIterator{}

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -145,12 +145,8 @@ func (o *OptimizeVR) Finish() error {
 						atomic.AddUint64(&o.snapshot.parent.stats.TotKNNSearches, uint64(1))
 
 						if pl != nil && pl.Count() > 0 {
-							// postings and iterators are already alloc'ed when
-							// IndexSnapshotVectorReader is created
 							vr.postings[index] = pl
 							vr.iterators[index] = pl.Iterator(vr.iterators[index])
-						} else {
-							vr.iterators[index] = &emptyVecPostingsIterator{}
 						}
 					}
 					go vecIndex.Close()

--- a/index/scorch/snapshot_vector_index.go
+++ b/index/scorch/snapshot_vector_index.go
@@ -65,9 +65,13 @@ func (is *IndexSnapshot) VectorReaderWithFilter(ctx context.Context, vector []fl
 
 	if rv.postings == nil {
 		rv.postings = make([]segment_api.VecPostingsList, len(is.segment))
+
 	}
 	if rv.iterators == nil {
 		rv.iterators = make([]segment_api.VecPostingsIterator, len(is.segment))
+		for index := 0; index < len(is.segment); index++ {
+			rv.iterators[index] = anemptyVecPostingsIterator
+		}
 	}
 
 	// initialize postings and iterators within the OptimizeVR's Finish()


### PR DESCRIPTION
In pre-filtering, as opposed to regular kNN, there might be cases where some segments do not have any eligible filter hits and hence, should not be searched further. 
Since Next() calls fetch hits segment-by-segment, it is important to initialise the iterators of such segments with empty vec iterators.