### PR TITLE
Use v16.1.9 for zapx/v16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.16
-	github.com/blevesearch/zapx/v16 v16.1.9-0.20241202063052-60ebc9a97954
+	github.com/blevesearch/zapx/v16 v16.1.9
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.16 h1:Ct3rv7FUJPfPk99TI/OofdC+Kpb4IdyfdMH48sb+FmE=
 github.com/blevesearch/zapx/v15 v15.3.16/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241128100831-c85f4c5695fd h1:Es5x1U5ii+lM/zStrb4YCY4R1sKVEi0d6XAOZQ5Q0N4=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241128100831-c85f4c5695fd/go.mod h1:JqQlOqlRVaYDkpLIl3JnKql8u4zKTNlVEa3nLsi0Gn8=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241202063052-60ebc9a97954 h1:MiW4//cq4F/oxY41jSMJifeIdxq02tqAZQouFVeN+48=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241202063052-60ebc9a97954/go.mod h1:zuxVgVaLZ0g4lZvrv06xDc24N6nLCOzXYHVkXI7LMHM=
+github.com/blevesearch/zapx/v16 v16.1.9 h1:br5EgGntCF723cCecSpOACE0LnGAP4+HYrkcEfQkcBY=
+github.com/blevesearch/zapx/v16 v16.1.9/go.mod h1:zuxVgVaLZ0g4lZvrv06xDc24N6nLCOzXYHVkXI7LMHM=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=


### PR DESCRIPTION
To bring in:
* 60ebc9a Aditi Ahuja | Merge branch v16-trinity-couchbase (https://github.com/blevesearch/zapx/pulls/283)
    * c85f4c5 Aditi Ahuja | MB-64360 - Guardrail fix for missing vectors (https://github.com/blevesearch/zapx/pulls/282)