### PR TITLE
MB-64636 - Modified Weight for KNN Scorer

### DIFF
--- a/search/scorer/scorer_knn.go
+++ b/search/scorer/scorer_knn.go
@@ -128,7 +128,7 @@ func (sqs *KNNQueryScorer) Score(ctx *search.SearchContext,
 }
 
 func (sqs *KNNQueryScorer) Weight() float64 {
-	return sqs.queryBoost * sqs.queryBoost
+	return 1.0
 }
 
 func (sqs *KNNQueryScorer) SetQueryNorm(qnorm float64) {


### PR DESCRIPTION
1. Changed weight of a kNN query to 1 to allow the boost value to kick in when computing query score.
Since the weight of only the kNN scorer is changed, this will not impact how boosting is calculated for other types of queries.

To reduce the kNN score relative to the FTS query score, set boost to <1.

2. Added a unit test which demonstrates boost increasing scores even for pure kNN queries(kNN + match none query).
