### PR TITLE
MB-62182: Making the merge planner aware of segment file size

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -231,7 +231,7 @@ func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 		return nil, err
 	}
 
-	mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMerge)
+	mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMergePerWorker)
 
 	return &mergePlannerOptions, nil
 }

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -209,6 +209,17 @@ func (s *Scorch) ForceMerge(ctx context.Context,
 func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 	error) {
 	mergePlannerOptions := mergeplan.DefaultMergePlanOptions
+
+	po, err := s.parsePersisterOptions()
+	if err != nil {
+		return nil, err
+	}
+	// by default use the MaxSizeInMemoryMergePerWorker from the persister option
+	// as the FloorSegmentFileSize for the merge planner which would be the
+	// first tier size in the planning. If the value is 0, then we don't use the
+	// file size in the planning.
+	mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMergePerWorker)
+
 	if v, ok := s.config["scorchMergePlanOptions"]; ok {
 		b, err := util.MarshalJSON(v)
 		if err != nil {
@@ -225,16 +236,6 @@ func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 			return nil, err
 		}
 	}
-
-	if mergePlannerOptions.FloorSegmentFileSize == 0 {
-		po, err := s.parsePersisterOptions()
-		if err != nil {
-			return nil, err
-		}
-
-		mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMergePerWorker)
-	}
-
 	return &mergePlannerOptions, nil
 }
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -225,6 +225,14 @@ func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 			return nil, err
 		}
 	}
+
+	po, err := s.parsePersisterOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMerge)
+
 	return &mergePlannerOptions, nil
 }
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -226,12 +226,14 @@ func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 		}
 	}
 
-	po, err := s.parsePersisterOptions()
-	if err != nil {
-		return nil, err
-	}
+	if mergePlannerOptions.FloorSegmentFileSize == 0 {
+		po, err := s.parsePersisterOptions()
+		if err != nil {
+			return nil, err
+		}
 
-	mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMergePerWorker)
+		mergePlannerOptions.FloorSegmentFileSize = int64(po.MaxSizeInMemoryMergePerWorker)
+	}
 
 	return &mergePlannerOptions, nil
 }


### PR DESCRIPTION
This PR introduces a new option of `FloorSegmentFileSize` into the merge planner's algorithm which is used in the budget calculation. The budget calculation drives the merge planner to keep the actual number of file segments within a `budget`.

Currently the budget calculation is dependent on the number of documents however this doesn't translate well in terms of resource utilization when the per doc size - which directly translates to the segment file size, varies significantly across use-cases. The scoring mechanism is kept the same for now - this is because the factors involved in scoring a set of segments end up canceling out the per doc size factor. For eg the [nonDelRatio's](https://github.com/blevesearch/bleve/blob/deb523009e0232993086c00942b0eec08ad1c4e4/index/scorch/mergeplan/merge_plan.go#L360) totAfterSize and totBeforeSize would be computed as `numLiveDocs * perDocSize / totalDocs * perDocSize` which ends up cancelling out anyways. Similar thought is applicable for other scoring factors as well, however this can be subjected to future experimentation. 

A single persister worker tries to merge the `MaxSizeInMemoryMergePerWorker` worth of data and the corresponding file would also be roughly that size. On the merger side, the `FloorSegmentFileSize` is like the lowest value on the logarithmic staircase (the first tier size) and using which we come up with the ideal number of segments. So, the idea over here is to set first tier size to be equal to the max size of a fresh file that's been flushed out - which approximately equals to `MaxSizeInMemoryMergePerWorker`. This makes the merger more aware of much data is being flushed out to disk and make its decision accordingly.