### PR TITLE
MB-64883 - Avoid redundant computation of eligible IDs 

### DIFF
--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -124,13 +124,12 @@ func (o *OptimizeVR) Finish() error {
 								eligibleVectorInternalIDs.And(snapshotGlobalDocNums[index])
 							}
 
-							eligibleLocalDocNums := make([]uint64,
-								eligibleVectorInternalIDs.GetCardinality())
+							eligibleLocalDocNums := roaring.NewBitmap()
 							// get the (segment-)local document numbers
-							for i, docNum := range eligibleVectorInternalIDs.ToArray() {
+							for _, docNum := range eligibleVectorInternalIDs.ToArray() {
 								localDocNum := o.snapshot.localDocNumFromGlobal(index,
 									uint64(docNum))
-								eligibleLocalDocNums[i] = localDocNum
+								eligibleLocalDocNums.Add(uint32(localDocNum))
 							}
 
 							pl, err = vecIndex.SearchWithFilter(vr.vector, vr.k,

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -132,12 +132,12 @@ func (o *OptimizeVR) Finish() error {
 								eligibleVectorInternalIDsClone.And(snapshotGlobalDocNums[index])
 							}
 
-							eligibleLocalDocNums := roaring.NewBitmap()
+							eligibleLocalDocNums := make([]uint64, 0)
 							// get the (segment-)local document numbers
 							for _, docNum := range eligibleVectorInternalIDsClone.ToArray() {
 								localDocNum := o.snapshot.localDocNumFromGlobal(index,
 									uint64(docNum))
-								eligibleLocalDocNums.Add(uint32(localDocNum))
+								eligibleLocalDocNums = append(eligibleLocalDocNums, localDocNum)
 							}
 
 							pl, err = vecIndex.SearchWithFilter(vr.vector, vr.k,

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -67,10 +67,16 @@ func (o *OptimizeVR) Finish() error {
 
 	var snapshotGlobalDocNums map[int]*roaring.Bitmap
 	var eligibleDocIDsMap map[string]map[int]*roaring.Bitmap
+	fields := make([]string, len(o.vrs))
+	for field := range o.vrs {
+		fields = append(fields, field)
+	}
+
 	if o.requiresFiltering {
 		snapshotGlobalDocNums = o.snapshot.globalDocNums()
 		eligibleDocIDsMap = make(map[string]map[int]*roaring.Bitmap)
-		for field, vrs := range o.vrs {
+		for _, field := range fields {
+			vrs := o.vrs[field]
 			eligibleDocIDsMap[field] = make(map[int]*roaring.Bitmap)
 			for index, vr := range vrs {
 				if vr.eligibleDocIDs != nil && len(vr.eligibleDocIDs) > 0 {
@@ -94,7 +100,8 @@ func (o *OptimizeVR) Finish() error {
 					<-semaphore // Release the semaphore slot
 					wg.Done()
 				}()
-				for field, vrs := range o.vrs {
+				for _, field := range fields {
+					vrs := o.vrs[field]
 					vecIndex, err := segment.InterpretVectorIndex(field,
 						o.requiresFiltering, origSeg.deleted)
 					if err != nil {

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -124,16 +124,17 @@ func (o *OptimizeVR) Finish() error {
 						// Only applies to filtered kNN.
 						if vr.eligibleDocIDs != nil && len(vr.eligibleDocIDs) > 0 {
 							eligibleVectorInternalIDs := eligibleDocIDsMap[field][vrIdx]
+							eligibleVectorInternalIDsClone := eligibleVectorInternalIDs.Clone()
 							if snapshotGlobalDocNums != nil {
 								// Only the eligible documents belonging to this segment
 								// will get filtered out.
 								// There is no way to determine which doc belongs to which segment
-								eligibleVectorInternalIDs.And(snapshotGlobalDocNums[index])
+								eligibleVectorInternalIDsClone.And(snapshotGlobalDocNums[index])
 							}
 
 							eligibleLocalDocNums := roaring.NewBitmap()
 							// get the (segment-)local document numbers
-							for _, docNum := range eligibleVectorInternalIDs.ToArray() {
+							for _, docNum := range eligibleVectorInternalIDsClone.ToArray() {
 								localDocNum := o.snapshot.localDocNumFromGlobal(index,
 									uint64(docNum))
 								eligibleLocalDocNums.Add(uint32(localDocNum))


### PR DESCRIPTION
Currently, filter eligible hits, which aren't specific to a segment, are computed redundantly for each segment.  

This PR pre-computes the eligible segment IDs and re-uses these for each segment. 