### PR TITLE
BugFix: Fixed Advance() API implementation in Optimized Composite Searchers

### DIFF
--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -393,5 +393,7 @@ func (i *IndexSnapshot) unadornedTermFieldReader(
 		includeNorm:        false,
 		includeTermVectors: false,
 		recycle:            false,
+		// signal downstream that this is a special unadorned termFieldReader
+		unadorned: true,
 	}
 }

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -50,6 +50,7 @@ type IndexSnapshotTermFieldReader struct {
 	recycle            bool
 	bytesRead          uint64
 	ctx                context.Context
+	unadorned          bool
 }
 
 func (i *IndexSnapshotTermFieldReader) incrementBytesRead(val uint64) {
@@ -146,14 +147,31 @@ func (i *IndexSnapshotTermFieldReader) Advance(ID index.IndexInternalID, preAllo
 	// FIXME do something better
 	// for now, if we need to seek backwards, then restart from the beginning
 	if i.currPosting != nil && bytes.Compare(i.currID, ID) >= 0 {
-		i2, err := i.snapshot.TermFieldReader(context.TODO(), i.term, i.field,
-			i.includeFreq, i.includeNorm, i.includeTermVectors)
-		if err != nil {
-			return nil, err
+		// Check if the TFR is a special unadorned composite optimization.
+		// Such a TFR will NOT have a valid `term` or `field` set, making it
+		// impossible for the TFR to replace itself with a new one.
+		if !i.unadorned {
+			i2, err := i.snapshot.TermFieldReader(context.TODO(), i.term, i.field,
+				i.includeFreq, i.includeNorm, i.includeTermVectors)
+			if err != nil {
+				return nil, err
+			}
+			// close the current term field reader before replacing it with a new one
+			_ = i.Close()
+			*i = *(i2.(*IndexSnapshotTermFieldReader))
+		} else {
+			// unadorned composite optimization
+			// we need to reset all the iterators
+			// back to the beginning, which effectively
+			// achives the same thing as the above
+			for _, iter := range i.iterators {
+				optimizedIterator, ok := iter.(*unadornedPostingsIteratorBitmap)
+				if !ok {
+					return nil, fmt.Errorf("unexpected iterator type %T", iter)
+				}
+				optimizedIterator.ResetIterator()
+			}
 		}
-		// close the current term field reader before replacing it with a new one
-		_ = i.Close()
-		*i = *(i2.(*IndexSnapshotTermFieldReader))
 	}
 	num, err := docInternalToNumber(ID)
 	if err != nil {

--- a/index/scorch/snapshot_index_tfr.go
+++ b/index/scorch/snapshot_index_tfr.go
@@ -165,11 +165,9 @@ func (i *IndexSnapshotTermFieldReader) Advance(ID index.IndexInternalID, preAllo
 			// back to the beginning, which effectively
 			// achives the same thing as the above
 			for _, iter := range i.iterators {
-				optimizedIterator, ok := iter.(*unadornedPostingsIteratorBitmap)
-				if !ok {
-					return nil, fmt.Errorf("unexpected iterator type %T", iter)
+				if optimizedIterator, ok := iter.(ResetablePostingsIterator); ok {
+					optimizedIterator.ResetIterator()
 				}
-				optimizedIterator.ResetIterator()
 			}
 		}
 	}

--- a/index/scorch/unadorned.go
+++ b/index/scorch/unadorned.go
@@ -165,6 +165,10 @@ func newUnadornedPostingsIteratorFrom1Hit(docNum1Hit uint64) segment.PostingsIte
 	}
 }
 
+type ResetablePostingsIterator interface {
+	ResetIterator()
+}
+
 type UnadornedPosting uint64
 
 func (p UnadornedPosting) Number() uint64 {

--- a/index/scorch/unadorned.go
+++ b/index/scorch/unadorned.go
@@ -112,7 +112,8 @@ func newUnadornedPostingsIteratorFromBitmap(bm *roaring.Bitmap) segment.Postings
 const docNum1HitFinished = math.MaxUint64
 
 type unadornedPostingsIterator1Hit struct {
-	docNum uint64
+	docNumOrig uint64 // original 1-hit docNum used to create this iterator
+	docNum     uint64 // current docNum
 }
 
 func (i *unadornedPostingsIterator1Hit) Next() (segment.Posting, error) {
@@ -159,9 +160,15 @@ func (i *unadornedPostingsIterator1Hit) BytesWritten() uint64 {
 
 func (i *unadornedPostingsIterator1Hit) ResetBytesRead(uint64) {}
 
+// ResetIterator resets the iterator to the original state.
+func (i *unadornedPostingsIterator1Hit) ResetIterator() {
+	i.docNum = i.docNumOrig
+}
+
 func newUnadornedPostingsIteratorFrom1Hit(docNum1Hit uint64) segment.PostingsIterator {
 	return &unadornedPostingsIterator1Hit{
-		docNum1Hit,
+		docNumOrig: docNum1Hit,
+		docNum:     docNum1Hit,
 	}
 }
 

--- a/index/scorch/unadorned.go
+++ b/index/scorch/unadorned.go
@@ -96,6 +96,12 @@ func (i *unadornedPostingsIteratorBitmap) ReplaceActual(actual *roaring.Bitmap) 
 	i.actual = actual.Iterator()
 }
 
+// Resets the iterator to the beginning of the postings list.
+// by resetting the actual iterator.
+func (i *unadornedPostingsIteratorBitmap) ResetIterator() {
+	i.actual = i.actualBM.Iterator()
+}
+
 func newUnadornedPostingsIteratorFromBitmap(bm *roaring.Bitmap) segment.PostingsIterator {
 	return &unadornedPostingsIteratorBitmap{
 		actualBM: bm,


### PR DESCRIPTION
- When using the `Advance()` API on an `IndexSnapshotTermFieldReader`, a special replacement mechanism is applied during a `Rewind`— when the requested document ID is behind the current document ID pointed to by the reader. In such cases, the object itself gets replaced.  
- However, this approach fails when the `IndexSnapshotTermFieldReader` is created by the `optimizeCompositeSearcher` method, which is used to construct optimized `conjunction` or `disjunction` searchers.  
- The issue arises because the `unadornedTermFieldReader` is initialized with the `term` set to `<optimization-type>` and `field` set to `*`. As a result, calling `Advance()` renders the entire `TFR` unusable, as it gets replaced by a dummy `TFR` that no longer functions.  
- This problem occurs specifically when calling `Advance()` on the `unadornedTermFieldReader` with an ID less than the current posting ID (triggering the rewind mechanism).  
- The issue is resolved by resetting the underlying `unadornedPostingsIteratorBitmap`, which effectively achieves the same result as the `TFR` replacement technique without rendering it unusable.
