### PR TITLE
Refactor registry components to return an error instead of panicking on duplicate component registration

### DIFF
--- a/analysis/analyzer/custom/custom.go
+++ b/analysis/analyzer/custom/custom.go
@@ -101,7 +101,10 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func getCharFilters(charFilterNames []string, cache *registry.Cache) ([]analysis.CharFilter, error) {

--- a/analysis/analyzer/keyword/keyword.go
+++ b/analysis/analyzer/keyword/keyword.go
@@ -34,5 +34,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/analyzer/simple/simple.go
+++ b/analysis/analyzer/simple/simple.go
@@ -42,5 +42,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/analyzer/standard/standard.go
+++ b/analysis/analyzer/standard/standard.go
@@ -48,5 +48,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/analyzer/web/web.go
+++ b/analysis/analyzer/web/web.go
@@ -48,5 +48,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(Name, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/char/asciifolding/asciifolding.go
+++ b/analysis/char/asciifolding/asciifolding.go
@@ -50,7 +50,10 @@ func AsciiFoldingFilterConstructor(config map[string]interface{}, cache *registr
 }
 
 func init() {
-	registry.RegisterCharFilter(Name, AsciiFoldingFilterConstructor)
+	err := registry.RegisterCharFilter(Name, AsciiFoldingFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Converts characters above ASCII to their ASCII equivalents.

--- a/analysis/char/html/html.go
+++ b/analysis/char/html/html.go
@@ -50,5 +50,8 @@ func CharFilterConstructor(config map[string]interface{}, cache *registry.Cache)
 }
 
 func init() {
-	registry.RegisterCharFilter(Name, CharFilterConstructor)
+	err := registry.RegisterCharFilter(Name, CharFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/char/regexp/regexp.go
+++ b/analysis/char/regexp/regexp.go
@@ -58,5 +58,8 @@ func CharFilterConstructor(config map[string]interface{}, cache *registry.Cache)
 }
 
 func init() {
-	registry.RegisterCharFilter(Name, CharFilterConstructor)
+	err := registry.RegisterCharFilter(Name, CharFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/char/zerowidthnonjoiner/zerowidthnonjoiner.go
+++ b/analysis/char/zerowidthnonjoiner/zerowidthnonjoiner.go
@@ -32,5 +32,8 @@ func CharFilterConstructor(config map[string]interface{}, cache *registry.Cache)
 }
 
 func init() {
-	registry.RegisterCharFilter(Name, CharFilterConstructor)
+	err := registry.RegisterCharFilter(Name, CharFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/flexible/flexible.go
+++ b/analysis/datetime/flexible/flexible.go
@@ -60,5 +60,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/iso/iso.go
+++ b/analysis/datetime/iso/iso.go
@@ -239,5 +239,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/optional/optional.go
+++ b/analysis/datetime/optional/optional.go
@@ -43,5 +43,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/percent/percent.go
+++ b/analysis/datetime/percent/percent.go
@@ -163,5 +163,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/sanitized/sanitized.go
+++ b/analysis/datetime/sanitized/sanitized.go
@@ -123,5 +123,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/timestamp/microseconds/microseconds.go
+++ b/analysis/datetime/timestamp/microseconds/microseconds.go
@@ -48,5 +48,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/timestamp/milliseconds/milliseconds.go
+++ b/analysis/datetime/timestamp/milliseconds/milliseconds.go
@@ -48,5 +48,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/timestamp/nanoseconds/nanoseconds.go
+++ b/analysis/datetime/timestamp/nanoseconds/nanoseconds.go
@@ -48,5 +48,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/datetime/timestamp/seconds/seconds.go
+++ b/analysis/datetime/timestamp/seconds/seconds.go
@@ -48,5 +48,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	err := registry.RegisterDateTimeParser(Name, DateTimeParserConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ar/analyzer_ar.go
+++ b/analysis/lang/ar/analyzer_ar.go
@@ -61,5 +61,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ar/arabic_normalize.go
+++ b/analysis/lang/ar/arabic_normalize.go
@@ -81,5 +81,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ar/stemmer_ar.go
+++ b/analysis/lang/ar/stemmer_ar.go
@@ -114,5 +114,8 @@ func StemmerFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ar/stop_filter_ar.go
+++ b/analysis/lang/ar/stop_filter_ar.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ar/stop_words_ar.go
+++ b/analysis/lang/ar/stop_words_ar.go
@@ -145,5 +145,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/bg/stop_filter_bg.go
+++ b/analysis/lang/bg/stop_filter_bg.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/bg/stop_words_bg.go
+++ b/analysis/lang/bg/stop_words_bg.go
@@ -213,5 +213,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ca/articles_ca.go
+++ b/analysis/lang/ca/articles_ca.go
@@ -26,5 +26,8 @@ func ArticlesTokenMapConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	err := registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ca/elision_ca.go
+++ b/analysis/lang/ca/elision_ca.go
@@ -33,5 +33,8 @@ func ElisionFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	err := registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ca/stop_filter_ca.go
+++ b/analysis/lang/ca/stop_filter_ca.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ca/stop_words_ca.go
+++ b/analysis/lang/ca/stop_words_ca.go
@@ -240,5 +240,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/cjk/analyzer_cjk.go
+++ b/analysis/lang/cjk/analyzer_cjk.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/cjk/cjk_bigram.go
+++ b/analysis/lang/cjk/cjk_bigram.go
@@ -199,5 +199,8 @@ func CJKBigramFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(BigramName, CJKBigramFilterConstructor)
+	err := registry.RegisterTokenFilter(BigramName, CJKBigramFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/cjk/cjk_width.go
+++ b/analysis/lang/cjk/cjk_width.go
@@ -97,5 +97,8 @@ func CJKWidthFilterConstructor(config map[string]interface{}, cache *registry.Ca
 }
 
 func init() {
-	registry.RegisterTokenFilter(WidthName, CJKWidthFilterConstructor)
+	err := registry.RegisterTokenFilter(WidthName, CJKWidthFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ckb/analyzer_ckb.go
+++ b/analysis/lang/ckb/analyzer_ckb.go
@@ -57,5 +57,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ckb/sorani_normalize.go
+++ b/analysis/lang/ckb/sorani_normalize.go
@@ -114,5 +114,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ckb/sorani_stemmer_filter.go
+++ b/analysis/lang/ckb/sorani_stemmer_filter.go
@@ -144,5 +144,8 @@ func StemmerFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ckb/stop_filter_ckb.go
+++ b/analysis/lang/ckb/stop_filter_ckb.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ckb/stop_words_ckb.go
+++ b/analysis/lang/ckb/stop_words_ckb.go
@@ -156,5 +156,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/cs/stop_filter_cs.go
+++ b/analysis/lang/cs/stop_filter_cs.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/cs/stop_words_cs.go
+++ b/analysis/lang/cs/stop_words_cs.go
@@ -192,5 +192,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/da/analyzer_da.go
+++ b/analysis/lang/da/analyzer_da.go
@@ -52,5 +52,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/da/stemmer_da.go
+++ b/analysis/lang/da/stemmer_da.go
@@ -45,5 +45,8 @@ func DanishStemmerFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, DanishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, DanishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/da/stop_filter_da.go
+++ b/analysis/lang/da/stop_filter_da.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/da/stop_words_da.go
+++ b/analysis/lang/da/stop_words_da.go
@@ -130,5 +130,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/analyzer_de.go
+++ b/analysis/lang/de/analyzer_de.go
@@ -57,5 +57,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/german_normalize.go
+++ b/analysis/lang/de/german_normalize.go
@@ -91,5 +91,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/light_stemmer_de.go
+++ b/analysis/lang/de/light_stemmer_de.go
@@ -112,5 +112,8 @@ func GermanLightStemmerFilterConstructor(config map[string]interface{}, cache *r
 }
 
 func init() {
-	registry.RegisterTokenFilter(LightStemmerName, GermanLightStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(LightStemmerName, GermanLightStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/stemmer_de_snowball.go
+++ b/analysis/lang/de/stemmer_de_snowball.go
@@ -45,5 +45,8 @@ func GermanStemmerFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, GermanStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, GermanStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/stop_filter_de.go
+++ b/analysis/lang/de/stop_filter_de.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/de/stop_words_de.go
+++ b/analysis/lang/de/stop_words_de.go
@@ -314,5 +314,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/el/stop_filter_el.go
+++ b/analysis/lang/el/stop_filter_el.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/el/stop_words_el.go
+++ b/analysis/lang/el/stop_words_el.go
@@ -98,5 +98,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/en/analyzer_en.go
+++ b/analysis/lang/en/analyzer_en.go
@@ -66,5 +66,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/en/plural_stemmer.go
+++ b/analysis/lang/en/plural_stemmer.go
@@ -63,7 +63,10 @@ func EnglishPluralStemmerFilterConstructor(config map[string]interface{}, cache 
 }
 
 func init() {
-	registry.RegisterTokenFilter(PluralStemmerName, EnglishPluralStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(PluralStemmerName, EnglishPluralStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/analysis/lang/en/possessive_filter_en.go
+++ b/analysis/lang/en/possessive_filter_en.go
@@ -63,5 +63,8 @@ func PossessiveFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(PossessiveName, PossessiveFilterConstructor)
+	err := registry.RegisterTokenFilter(PossessiveName, PossessiveFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/en/stemmer_en_snowball.go
+++ b/analysis/lang/en/stemmer_en_snowball.go
@@ -45,5 +45,8 @@ func EnglishStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, EnglishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, EnglishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/en/stop_filter_en.go
+++ b/analysis/lang/en/stop_filter_en.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/en/stop_words_en.go
+++ b/analysis/lang/en/stop_words_en.go
@@ -340,5 +340,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/analyzer_es.go
+++ b/analysis/lang/es/analyzer_es.go
@@ -59,5 +59,8 @@ func AnalyzerConstructor(config map[string]interface{},
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/light_stemmer_es.go
+++ b/analysis/lang/es/light_stemmer_es.go
@@ -71,6 +71,8 @@ func SpanishLightStemmerFilterConstructor(config map[string]interface{},
 }
 
 func init() {
-	registry.RegisterTokenFilter(LightStemmerName,
-		SpanishLightStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(LightStemmerName, SpanishLightStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/spanish_normalize.go
+++ b/analysis/lang/es/spanish_normalize.go
@@ -63,5 +63,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/stemmer_es_snowball.go
+++ b/analysis/lang/es/stemmer_es_snowball.go
@@ -45,5 +45,8 @@ func SpanishStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, SpanishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, SpanishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/stop_filter_es.go
+++ b/analysis/lang/es/stop_filter_es.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{},
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/es/stop_words_es.go
+++ b/analysis/lang/es/stop_words_es.go
@@ -376,5 +376,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/eu/stop_filter_eu.go
+++ b/analysis/lang/eu/stop_filter_eu.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/eu/stop_words_eu.go
+++ b/analysis/lang/eu/stop_words_eu.go
@@ -119,5 +119,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fa/analyzer_fa.go
+++ b/analysis/lang/fa/analyzer_fa.go
@@ -67,5 +67,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fa/persian_normalize.go
+++ b/analysis/lang/fa/persian_normalize.go
@@ -73,5 +73,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fa/stop_filter_fa.go
+++ b/analysis/lang/fa/stop_filter_fa.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fa/stop_words_fa.go
+++ b/analysis/lang/fa/stop_words_fa.go
@@ -333,5 +333,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fi/analyzer_fi.go
+++ b/analysis/lang/fi/analyzer_fi.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fi/stemmer_fi.go
+++ b/analysis/lang/fi/stemmer_fi.go
@@ -45,5 +45,8 @@ func FinnishStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, FinnishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, FinnishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fi/stop_filter_fi.go
+++ b/analysis/lang/fi/stop_filter_fi.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fi/stop_words_fi.go
+++ b/analysis/lang/fi/stop_words_fi.go
@@ -117,5 +117,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/analyzer_fr.go
+++ b/analysis/lang/fr/analyzer_fr.go
@@ -58,5 +58,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/articles_fr.go
+++ b/analysis/lang/fr/articles_fr.go
@@ -33,5 +33,8 @@ func ArticlesTokenMapConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	err := registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/elision_fr.go
+++ b/analysis/lang/fr/elision_fr.go
@@ -33,5 +33,8 @@ func ElisionFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	err := registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/light_stemmer_fr.go
+++ b/analysis/lang/fr/light_stemmer_fr.go
@@ -302,5 +302,8 @@ func FrenchLightStemmerFilterConstructor(config map[string]interface{}, cache *r
 }
 
 func init() {
-	registry.RegisterTokenFilter(LightStemmerName, FrenchLightStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(LightStemmerName, FrenchLightStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/minimal_stemmer_fr.go
+++ b/analysis/lang/fr/minimal_stemmer_fr.go
@@ -75,5 +75,8 @@ func FrenchMinimalStemmerFilterConstructor(config map[string]interface{}, cache 
 }
 
 func init() {
-	registry.RegisterTokenFilter(MinimalStemmerName, FrenchMinimalStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(MinimalStemmerName, FrenchMinimalStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/stemmer_fr_snowball.go
+++ b/analysis/lang/fr/stemmer_fr_snowball.go
@@ -45,5 +45,8 @@ func FrenchStemmerFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, FrenchStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, FrenchStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/stop_filter_fr.go
+++ b/analysis/lang/fr/stop_filter_fr.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/fr/stop_words_fr.go
+++ b/analysis/lang/fr/stop_words_fr.go
@@ -206,5 +206,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ga/articles_ga.go
+++ b/analysis/lang/ga/articles_ga.go
@@ -23,5 +23,8 @@ func ArticlesTokenMapConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	err := registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ga/elision_ga.go
+++ b/analysis/lang/ga/elision_ga.go
@@ -33,5 +33,8 @@ func ElisionFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	err := registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ga/stop_filter_ga.go
+++ b/analysis/lang/ga/stop_filter_ga.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ga/stop_words_ga.go
+++ b/analysis/lang/ga/stop_words_ga.go
@@ -130,5 +130,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/gl/stop_filter_gl.go
+++ b/analysis/lang/gl/stop_filter_gl.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/gl/stop_words_gl.go
+++ b/analysis/lang/gl/stop_words_gl.go
@@ -181,5 +181,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hi/analyzer_hi.go
+++ b/analysis/lang/hi/analyzer_hi.go
@@ -64,5 +64,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hi/hindi_normalize.go
+++ b/analysis/lang/hi/hindi_normalize.go
@@ -134,5 +134,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hi/hindi_stemmer_filter.go
+++ b/analysis/lang/hi/hindi_stemmer_filter.go
@@ -145,5 +145,8 @@ func StemmerFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(StemmerName, StemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hi/stop_filter_hi.go
+++ b/analysis/lang/hi/stop_filter_hi.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hi/stop_words_hi.go
+++ b/analysis/lang/hi/stop_words_hi.go
@@ -255,5 +255,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hr/analyzer_hr.go
+++ b/analysis/lang/hr/analyzer_hr.go
@@ -60,5 +60,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hr/stemmer_hr.go
+++ b/analysis/lang/hr/stemmer_hr.go
@@ -149,5 +149,8 @@ func CroatianStemmerFilterConstructor(config map[string]interface{}, cache *regi
 }
 
 func init() {
-	registry.RegisterTokenFilter(StemmerName, CroatianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(StemmerName, CroatianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hr/stop_filter_hr.go
+++ b/analysis/lang/hr/stop_filter_hr.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hr/stop_words_hr.go
+++ b/analysis/lang/hr/stop_words_hr.go
@@ -104,5 +104,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hr/suffix_transformation_hr.go
+++ b/analysis/lang/hr/suffix_transformation_hr.go
@@ -182,5 +182,8 @@ func SuffixTransformationFilterConstructor(config map[string]interface{}, cache 
 }
 
 func init() {
-	registry.RegisterTokenFilter(SuffixTransformationFilterName, SuffixTransformationFilterConstructor)
+	err := registry.RegisterTokenFilter(SuffixTransformationFilterName, SuffixTransformationFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hu/analyzer_hu.go
+++ b/analysis/lang/hu/analyzer_hu.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hu/stemmer_hu.go
+++ b/analysis/lang/hu/stemmer_hu.go
@@ -45,5 +45,8 @@ func HungarianStemmerFilterConstructor(config map[string]interface{}, cache *reg
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, HungarianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, HungarianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hu/stop_filter_hu.go
+++ b/analysis/lang/hu/stop_filter_hu.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hu/stop_words_hu.go
+++ b/analysis/lang/hu/stop_words_hu.go
@@ -231,5 +231,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hy/stop_filter_hy.go
+++ b/analysis/lang/hy/stop_filter_hy.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/hy/stop_words_hy.go
+++ b/analysis/lang/hy/stop_words_hy.go
@@ -66,5 +66,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/id/stop_filter_id.go
+++ b/analysis/lang/id/stop_filter_id.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/id/stop_words_id.go
+++ b/analysis/lang/id/stop_words_id.go
@@ -379,5 +379,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/in/indic_normalize.go
+++ b/analysis/lang/in/indic_normalize.go
@@ -44,5 +44,8 @@ func NormalizerFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	err := registry.RegisterTokenFilter(NormalizeName, NormalizerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/analyzer_it.go
+++ b/analysis/lang/it/analyzer_it.go
@@ -58,5 +58,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/articles_it.go
+++ b/analysis/lang/it/articles_it.go
@@ -41,5 +41,8 @@ func ArticlesTokenMapConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	err := registry.RegisterTokenMap(ArticlesName, ArticlesTokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/elision_it.go
+++ b/analysis/lang/it/elision_it.go
@@ -33,5 +33,8 @@ func ElisionFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	err := registry.RegisterTokenFilter(ElisionName, ElisionFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/light_stemmer_it.go
+++ b/analysis/lang/it/light_stemmer_it.go
@@ -97,5 +97,8 @@ func ItalianLightStemmerFilterConstructor(config map[string]interface{}, cache *
 }
 
 func init() {
-	registry.RegisterTokenFilter(LightStemmerName, ItalianLightStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(LightStemmerName, ItalianLightStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/stemmer_it_snowball.go
+++ b/analysis/lang/it/stemmer_it_snowball.go
@@ -45,5 +45,8 @@ func ItalianStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, ItalianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, ItalianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/stop_filter_it.go
+++ b/analysis/lang/it/stop_filter_it.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/it/stop_words_it.go
+++ b/analysis/lang/it/stop_words_it.go
@@ -323,5 +323,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/nl/analyzer_nl.go
+++ b/analysis/lang/nl/analyzer_nl.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/nl/stemmer_nl.go
+++ b/analysis/lang/nl/stemmer_nl.go
@@ -45,5 +45,8 @@ func DutchStemmerFilterConstructor(config map[string]interface{}, cache *registr
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, DutchStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, DutchStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/nl/stop_filter_nl.go
+++ b/analysis/lang/nl/stop_filter_nl.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/nl/stop_words_nl.go
+++ b/analysis/lang/nl/stop_words_nl.go
@@ -139,5 +139,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/no/analyzer_no.go
+++ b/analysis/lang/no/analyzer_no.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/no/stemmer_no.go
+++ b/analysis/lang/no/stemmer_no.go
@@ -45,5 +45,8 @@ func NorwegianStemmerFilterConstructor(config map[string]interface{}, cache *reg
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, NorwegianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, NorwegianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/no/stop_filter_no.go
+++ b/analysis/lang/no/stop_filter_no.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/no/stop_words_no.go
+++ b/analysis/lang/no/stop_words_no.go
@@ -214,5 +214,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pl/analyzer_pl.go
+++ b/analysis/lang/pl/analyzer_pl.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pl/stemmer_pl.go
+++ b/analysis/lang/pl/stemmer_pl.go
@@ -51,5 +51,8 @@ func PolishStemmerFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, PolishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, PolishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pl/stop_filter_pl.go
+++ b/analysis/lang/pl/stop_filter_pl.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pl/stop_words_pl.go
+++ b/analysis/lang/pl/stop_words_pl.go
@@ -361,5 +361,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pt/analyzer_pt.go
+++ b/analysis/lang/pt/analyzer_pt.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pt/light_stemmer_pt.go
+++ b/analysis/lang/pt/light_stemmer_pt.go
@@ -191,5 +191,8 @@ func PortugueseLightStemmerFilterConstructor(config map[string]interface{}, cach
 }
 
 func init() {
-	registry.RegisterTokenFilter(LightStemmerName, PortugueseLightStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(LightStemmerName, PortugueseLightStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pt/stop_filter_pt.go
+++ b/analysis/lang/pt/stop_filter_pt.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/pt/stop_words_pt.go
+++ b/analysis/lang/pt/stop_words_pt.go
@@ -273,5 +273,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ro/analyzer_ro.go
+++ b/analysis/lang/ro/analyzer_ro.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ro/stemmer_ro.go
+++ b/analysis/lang/ro/stemmer_ro.go
@@ -45,5 +45,8 @@ func RomanianStemmerFilterConstructor(config map[string]interface{}, cache *regi
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, RomanianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, RomanianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ro/stop_filter_ro.go
+++ b/analysis/lang/ro/stop_filter_ro.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ro/stop_words_ro.go
+++ b/analysis/lang/ro/stop_words_ro.go
@@ -253,5 +253,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ru/analyzer_ru.go
+++ b/analysis/lang/ru/analyzer_ru.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ru/stemmer_ru.go
+++ b/analysis/lang/ru/stemmer_ru.go
@@ -45,5 +45,8 @@ func RussianStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, RussianStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, RussianStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ru/stop_filter_ru.go
+++ b/analysis/lang/ru/stop_filter_ru.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/ru/stop_words_ru.go
+++ b/analysis/lang/ru/stop_words_ru.go
@@ -263,5 +263,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/sv/analyzer_sv.go
+++ b/analysis/lang/sv/analyzer_sv.go
@@ -53,5 +53,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/sv/stemmer_sv.go
+++ b/analysis/lang/sv/stemmer_sv.go
@@ -45,5 +45,8 @@ func SwedishStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, SwedishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, SwedishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/sv/stop_filter_sv.go
+++ b/analysis/lang/sv/stop_filter_sv.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/sv/stop_words_sv.go
+++ b/analysis/lang/sv/stop_words_sv.go
@@ -153,5 +153,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/tr/analyzer_tr.go
+++ b/analysis/lang/tr/analyzer_tr.go
@@ -59,5 +59,8 @@ func AnalyzerConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	err := registry.RegisterAnalyzer(AnalyzerName, AnalyzerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/tr/stemmer_tr.go
+++ b/analysis/lang/tr/stemmer_tr.go
@@ -45,5 +45,8 @@ func TurkishStemmerFilterConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenFilter(SnowballStemmerName, TurkishStemmerFilterConstructor)
+	err := registry.RegisterTokenFilter(SnowballStemmerName, TurkishStemmerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/tr/stop_filter_tr.go
+++ b/analysis/lang/tr/stop_filter_tr.go
@@ -29,5 +29,8 @@ func StopTokenFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(StopName, StopTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/lang/tr/stop_words_tr.go
+++ b/analysis/lang/tr/stop_words_tr.go
@@ -232,5 +232,8 @@ func TokenMapConstructor(config map[string]interface{}, cache *registry.Cache) (
 }
 
 func init() {
-	registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	err := registry.RegisterTokenMap(StopName, TokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/apostrophe/apostrophe.go
+++ b/analysis/token/apostrophe/apostrophe.go
@@ -50,5 +50,8 @@ func ApostropheFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, ApostropheFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, ApostropheFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/camelcase/camelcase.go
+++ b/analysis/token/camelcase/camelcase.go
@@ -74,5 +74,8 @@ func CamelCaseFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, CamelCaseFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, CamelCaseFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/compound/dict.go
+++ b/analysis/token/compound/dict.go
@@ -137,5 +137,8 @@ func DictionaryCompoundFilterConstructor(config map[string]interface{}, cache *r
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, DictionaryCompoundFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, DictionaryCompoundFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/edgengram/edgengram.go
+++ b/analysis/token/edgengram/edgengram.go
@@ -111,5 +111,8 @@ func EdgeNgramFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, EdgeNgramFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, EdgeNgramFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/elision/elision.go
+++ b/analysis/token/elision/elision.go
@@ -70,5 +70,8 @@ func ElisionFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, ElisionFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, ElisionFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/hierarchy/hierarchy.go
+++ b/analysis/token/hierarchy/hierarchy.go
@@ -88,5 +88,8 @@ func HierarchyFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, HierarchyFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, HierarchyFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/keyword/keyword.go
+++ b/analysis/token/keyword/keyword.go
@@ -57,5 +57,8 @@ func KeyWordMarkerFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, KeyWordMarkerFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, KeyWordMarkerFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/length/length.go
+++ b/analysis/token/length/length.go
@@ -73,5 +73,8 @@ func LengthFilterConstructor(config map[string]interface{}, cache *registry.Cach
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, LengthFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, LengthFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/lowercase/lowercase.go
+++ b/analysis/token/lowercase/lowercase.go
@@ -47,7 +47,10 @@ func LowerCaseFilterConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, LowerCaseFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, LowerCaseFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // toLowerDeferredCopy will function exactly like

--- a/analysis/token/ngram/ngram.go
+++ b/analysis/token/ngram/ngram.go
@@ -90,7 +90,10 @@ func NgramFilterConstructor(config map[string]interface{}, cache *registry.Cache
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, NgramFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, NgramFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Expects either an int or a flaot64 value

--- a/analysis/token/porter/porter.go
+++ b/analysis/token/porter/porter.go
@@ -49,5 +49,8 @@ func PorterStemmerConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, PorterStemmerConstructor)
+	err := registry.RegisterTokenFilter(Name, PorterStemmerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/reverse/reverse.go
+++ b/analysis/token/reverse/reverse.go
@@ -44,7 +44,10 @@ func ReverseFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, ReverseFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, ReverseFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // reverse(..) will generate a reversed version of the provided

--- a/analysis/token/shingle/shingle.go
+++ b/analysis/token/shingle/shingle.go
@@ -165,5 +165,8 @@ func ShingleFilterConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, ShingleFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, ShingleFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/snowball/snowball.go
+++ b/analysis/token/snowball/snowball.go
@@ -55,5 +55,8 @@ func SnowballStemmerConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, SnowballStemmerConstructor)
+	err := registry.RegisterTokenFilter(Name, SnowballStemmerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/stop/stop.go
+++ b/analysis/token/stop/stop.go
@@ -66,5 +66,8 @@ func StopTokensFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, StopTokensFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, StopTokensFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/truncate/truncate.go
+++ b/analysis/token/truncate/truncate.go
@@ -55,5 +55,8 @@ func TruncateTokenFilterConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, TruncateTokenFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, TruncateTokenFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/unicodenorm/unicodenorm.go
+++ b/analysis/token/unicodenorm/unicodenorm.go
@@ -75,5 +75,8 @@ func UnicodeNormalizeFilterConstructor(config map[string]interface{}, cache *reg
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, UnicodeNormalizeFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, UnicodeNormalizeFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/token/unique/unique.go
+++ b/analysis/token/unique/unique.go
@@ -49,5 +49,8 @@ func UniqueTermFilterConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenFilter(Name, UniqueTermFilterConstructor)
+	err := registry.RegisterTokenFilter(Name, UniqueTermFilterConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenizer/exception/exception.go
+++ b/analysis/tokenizer/exception/exception.go
@@ -137,5 +137,8 @@ func ExceptionsTokenizerConstructor(config map[string]interface{}, cache *regist
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, ExceptionsTokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, ExceptionsTokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenizer/letter/letter.go
+++ b/analysis/tokenizer/letter/letter.go
@@ -29,5 +29,8 @@ func TokenizerConstructor(config map[string]interface{}, cache *registry.Cache) 
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, TokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, TokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenizer/regexp/regexp.go
+++ b/analysis/tokenizer/regexp/regexp.go
@@ -69,7 +69,10 @@ func RegexpTokenizerConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, RegexpTokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, RegexpTokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func detectTokenType(termBytes []byte) analysis.TokenType {

--- a/analysis/tokenizer/single/single.go
+++ b/analysis/tokenizer/single/single.go
@@ -45,5 +45,8 @@ func SingleTokenTokenizerConstructor(config map[string]interface{}, cache *regis
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, SingleTokenTokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, SingleTokenTokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenizer/unicode/unicode.go
+++ b/analysis/tokenizer/unicode/unicode.go
@@ -115,7 +115,10 @@ func UnicodeTokenizerConstructor(config map[string]interface{}, cache *registry.
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, UnicodeTokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, UnicodeTokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func convertType(segmentWordType int) analysis.TokenType {

--- a/analysis/tokenizer/web/web.go
+++ b/analysis/tokenizer/web/web.go
@@ -43,5 +43,8 @@ func TokenizerConstructor(config map[string]interface{}, cache *registry.Cache) 
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, TokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, TokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenizer/whitespace/whitespace.go
+++ b/analysis/tokenizer/whitespace/whitespace.go
@@ -33,5 +33,8 @@ func notSpace(r rune) bool {
 }
 
 func init() {
-	registry.RegisterTokenizer(Name, TokenizerConstructor)
+	err := registry.RegisterTokenizer(Name, TokenizerConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/analysis/tokenmap/custom.go
+++ b/analysis/tokenmap/custom.go
@@ -58,5 +58,8 @@ func GenericTokenMapConstructor(config map[string]interface{}, cache *registry.C
 }
 
 func init() {
-	registry.RegisterTokenMap(Name, GenericTokenMapConstructor)
+	err := registry.RegisterTokenMap(Name, GenericTokenMapConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -772,7 +772,10 @@ func (s *Scorch) unmarkIneligibleForRemoval(filename string) {
 }
 
 func init() {
-	registry.RegisterIndexType(Name, NewScorch)
+	err := registry.RegisterIndexType(Name, NewScorch)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func parseToTimeDuration(i interface{}) (time.Duration, error) {

--- a/index/upsidedown/store/boltdb/store.go
+++ b/index/upsidedown/store/boltdb/store.go
@@ -177,5 +177,8 @@ func (bs *Store) Compact() error {
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/upsidedown/store/goleveldb/store.go
+++ b/index/upsidedown/store/goleveldb/store.go
@@ -145,5 +145,8 @@ func (ldbs *Store) Compact() error {
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/upsidedown/store/gtreap/store.go
+++ b/index/upsidedown/store/gtreap/store.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2/registry"
 	"github.com/blevesearch/gtreap"
-	"github.com/blevesearch/upsidedown_store_api"
+	store "github.com/blevesearch/upsidedown_store_api"
 )
 
 const Name = "gtreap"
@@ -78,5 +78,8 @@ func (s *Store) Writer() (store.KVWriter, error) {
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/upsidedown/store/metrics/store.go
+++ b/index/upsidedown/store/metrics/store.go
@@ -95,7 +95,10 @@ func New(mo store.MergeOperator, config map[string]interface{}) (store.KVStore, 
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (s *Store) Close() error {

--- a/index/upsidedown/store/moss/store.go
+++ b/index/upsidedown/store/moss/store.go
@@ -224,5 +224,8 @@ func (s *Store) Collection() moss.Collection {
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/upsidedown/store/null/null.go
+++ b/index/upsidedown/store/null/null.go
@@ -114,5 +114,8 @@ func (w *writer) Close() error {
 }
 
 func init() {
-	registry.RegisterKVStore(Name, New)
+	err := registry.RegisterKVStore(Name, New)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/index/upsidedown/upsidedown.go
+++ b/index/upsidedown/upsidedown.go
@@ -1042,7 +1042,10 @@ func (udc *UpsideDownCouch) fieldIndexOrNewRow(name string) (uint16, *FieldRow) 
 }
 
 func init() {
-	registry.RegisterIndexType(Name, NewUpsideDownCouch)
+	err := registry.RegisterIndexType(Name, NewUpsideDownCouch)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func backIndexRowForDoc(kvreader store.KVReader, docID index.IndexInternalID) (*BackIndexRow, error) {

--- a/mapping/synonym.go
+++ b/mapping/synonym.go
@@ -64,5 +64,8 @@ func SynonymSourceConstructor(config map[string]interface{}, cache *registry.Cac
 }
 
 func init() {
-	registry.RegisterSynonymSource(analysis.SynonymSourceType, SynonymSourceConstructor)
+	err := registry.RegisterSynonymSource(analysis.SynonymSourceType, SynonymSourceConstructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/registry/analyzer.go
+++ b/registry/analyzer.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterAnalyzer(name string, constructor AnalyzerConstructor) {
+func RegisterAnalyzer(name string, constructor AnalyzerConstructor) error {
 	_, exists := analyzers[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate analyzer named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate analyzer named '%s'", name)
 	}
 	analyzers[name] = constructor
+	return nil
 }
 
 type AnalyzerConstructor func(config map[string]interface{}, cache *Cache) (analysis.Analyzer, error)

--- a/registry/char_filter.go
+++ b/registry/char_filter.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterCharFilter(name string, constructor CharFilterConstructor) {
+func RegisterCharFilter(name string, constructor CharFilterConstructor) error {
 	_, exists := charFilters[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate char filter named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate char filter named '%s'", name)
 	}
 	charFilters[name] = constructor
+	return nil
 }
 
 type CharFilterConstructor func(config map[string]interface{}, cache *Cache) (analysis.CharFilter, error)

--- a/registry/datetime_parser.go
+++ b/registry/datetime_parser.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterDateTimeParser(name string, constructor DateTimeParserConstructor) {
+func RegisterDateTimeParser(name string, constructor DateTimeParserConstructor) error {
 	_, exists := dateTimeParsers[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate date time parser named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate date time parser named '%s'", name)
 	}
 	dateTimeParsers[name] = constructor
+	return nil
 }
 
 type DateTimeParserConstructor func(config map[string]interface{}, cache *Cache) (analysis.DateTimeParser, error)

--- a/registry/fragment_formatter.go
+++ b/registry/fragment_formatter.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/search/highlight"
 )
 
-func RegisterFragmentFormatter(name string, constructor FragmentFormatterConstructor) {
+func RegisterFragmentFormatter(name string, constructor FragmentFormatterConstructor) error {
 	_, exists := fragmentFormatters[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate fragment formatter named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate fragment formatter named '%s'", name)
 	}
 	fragmentFormatters[name] = constructor
+	return nil
 }
 
 type FragmentFormatterConstructor func(config map[string]interface{}, cache *Cache) (highlight.FragmentFormatter, error)

--- a/registry/fragmenter.go
+++ b/registry/fragmenter.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/search/highlight"
 )
 
-func RegisterFragmenter(name string, constructor FragmenterConstructor) {
+func RegisterFragmenter(name string, constructor FragmenterConstructor) error {
 	_, exists := fragmenters[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate fragmenter named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate fragmenter named '%s'", name)
 	}
 	fragmenters[name] = constructor
+	return nil
 }
 
 type FragmenterConstructor func(config map[string]interface{}, cache *Cache) (highlight.Fragmenter, error)

--- a/registry/highlighter.go
+++ b/registry/highlighter.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/search/highlight"
 )
 
-func RegisterHighlighter(name string, constructor HighlighterConstructor) {
+func RegisterHighlighter(name string, constructor HighlighterConstructor) error {
 	_, exists := highlighters[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate highlighter named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate highlighter named '%s'", name)
 	}
 	highlighters[name] = constructor
+	return nil
 }
 
 type HighlighterConstructor func(config map[string]interface{}, cache *Cache) (highlight.Highlighter, error)

--- a/registry/index_type.go
+++ b/registry/index_type.go
@@ -20,12 +20,13 @@ import (
 	index "github.com/blevesearch/bleve_index_api"
 )
 
-func RegisterIndexType(name string, constructor IndexTypeConstructor) {
+func RegisterIndexType(name string, constructor IndexTypeConstructor) error {
 	_, exists := indexTypes[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate index encoding named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate index encoding named '%s'", name)
 	}
 	indexTypes[name] = constructor
+	return nil
 }
 
 type IndexTypeConstructor func(storeName string, storeConfig map[string]interface{}, analysisQueue *index.AnalysisQueue) (index.Index, error)
@@ -38,7 +39,7 @@ func IndexTypeConstructorByName(name string) IndexTypeConstructor {
 func IndexTypesAndInstances() ([]string, []string) {
 	var types []string
 	var instances []string
-	for name := range stores {
+	for name := range indexTypes {
 		types = append(types, name)
 	}
 	return types, instances

--- a/registry/store.go
+++ b/registry/store.go
@@ -17,15 +17,16 @@ package registry
 import (
 	"fmt"
 
-	"github.com/blevesearch/upsidedown_store_api"
+	store "github.com/blevesearch/upsidedown_store_api"
 )
 
-func RegisterKVStore(name string, constructor KVStoreConstructor) {
+func RegisterKVStore(name string, constructor KVStoreConstructor) error {
 	_, exists := stores[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate store named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate store named '%s'", name)
 	}
 	stores[name] = constructor
+	return nil
 }
 
 // KVStoreConstructor is used to build a KVStore of a specific type when

--- a/registry/synonym_source.go
+++ b/registry/synonym_source.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterSynonymSource(typ string, constructor SynonymSourceConstructor) {
+func RegisterSynonymSource(typ string, constructor SynonymSourceConstructor) error {
 	_, exists := synonymSources[typ]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate synonym source with type '%s'", typ))
+		return fmt.Errorf("attempted to register duplicate synonym source with type '%s'", typ)
 	}
 	synonymSources[typ] = constructor
+	return nil
 }
 
 type SynonymSourceCache struct {

--- a/registry/token_filter.go
+++ b/registry/token_filter.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterTokenFilter(name string, constructor TokenFilterConstructor) {
+func RegisterTokenFilter(name string, constructor TokenFilterConstructor) error {
 	_, exists := tokenFilters[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate token filter named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate token filter named '%s'", name)
 	}
 	tokenFilters[name] = constructor
+	return nil
 }
 
 type TokenFilterConstructor func(config map[string]interface{}, cache *Cache) (analysis.TokenFilter, error)

--- a/registry/token_maps.go
+++ b/registry/token_maps.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterTokenMap(name string, constructor TokenMapConstructor) {
+func RegisterTokenMap(name string, constructor TokenMapConstructor) error {
 	_, exists := tokenMaps[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate token map named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate token map named '%s'", name)
 	}
 	tokenMaps[name] = constructor
+	return nil
 }
 
 type TokenMapConstructor func(config map[string]interface{}, cache *Cache) (analysis.TokenMap, error)

--- a/registry/tokenizer.go
+++ b/registry/tokenizer.go
@@ -20,12 +20,13 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func RegisterTokenizer(name string, constructor TokenizerConstructor) {
+func RegisterTokenizer(name string, constructor TokenizerConstructor) error {
 	_, exists := tokenizers[name]
 	if exists {
-		panic(fmt.Errorf("attempted to register duplicate tokenizer named '%s'", name))
+		return fmt.Errorf("attempted to register duplicate tokenizer named '%s'", name)
 	}
 	tokenizers[name] = constructor
+	return nil
 }
 
 type TokenizerConstructor func(config map[string]interface{}, cache *Cache) (analysis.Tokenizer, error)

--- a/search/highlight/format/ansi/ansi.go
+++ b/search/highlight/format/ansi/ansi.go
@@ -105,5 +105,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterFragmentFormatter(Name, Constructor)
+	err := registry.RegisterFragmentFormatter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/format/html/html.go
+++ b/search/highlight/format/html/html.go
@@ -87,5 +87,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterFragmentFormatter(Name, Constructor)
+	err := registry.RegisterFragmentFormatter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/format/plain/plain.go
+++ b/search/highlight/format/plain/plain.go
@@ -85,5 +85,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterFragmentFormatter(Name, Constructor)
+	err := registry.RegisterFragmentFormatter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/fragmenter/simple/simple.go
+++ b/search/highlight/fragmenter/simple/simple.go
@@ -149,5 +149,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterFragmenter(Name, Constructor)
+	err := registry.RegisterFragmenter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/highlighter/ansi/ansi.go
+++ b/search/highlight/highlighter/ansi/ansi.go
@@ -46,5 +46,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterHighlighter(Name, Constructor)
+	err := registry.RegisterHighlighter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/highlighter/html/html.go
+++ b/search/highlight/highlighter/html/html.go
@@ -46,5 +46,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterHighlighter(Name, Constructor)
+	err := registry.RegisterHighlighter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/search/highlight/highlighter/simple/highlighter_simple.go
+++ b/search/highlight/highlighter/simple/highlighter_simple.go
@@ -17,6 +17,7 @@ package simple
 import (
 	"container/heap"
 	"fmt"
+
 	index "github.com/blevesearch/bleve_index_api"
 
 	"github.com/blevesearch/bleve/v2/registry"
@@ -217,5 +218,8 @@ func Constructor(config map[string]interface{}, cache *registry.Cache) (highligh
 }
 
 func init() {
-	registry.RegisterHighlighter(Name, Constructor)
+	err := registry.RegisterHighlighter(Name, Constructor)
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
- The `registry` package currently `panics` or crashes `Bleve` when a duplicate component is registered. This behavior makes it difficult to handle duplicate registrations gracefully and requires using a recover statement to prevent the application from crashing.

- To improve error handling and maintainability, the newly refactored proposed API will involve changing `Register<registry-component>` to return an error  instead of panicking when a duplicate registration is detected. This change would allow developers to check if a `<registry-component>` is already registered and handle it accordingly without relying on recover.