### PR TITLE
Introduce a new stat which indicates a bleve index's convergence

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -658,6 +658,16 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_persister_nap_merger_break"] = m["TotPersisterMergerNapBreak"]
 	m["total_compaction_written_bytes"] = m["TotFileMergeWrittenBytes"]
 
+	// the bool stat `index_converging` indicates whether the background routines
+	// which causes the index to reach a steady state are still doing some work.
+	if rootEpoch, ok := m["CurRootEpoch"].(uint64); ok {
+		if lastMergedEpoch, ok := m["LastMergedEpoch"].(uint64); ok {
+			if lastPersistedEpoch, ok := m["LastPersistedEpoch"].(uint64); ok {
+				m["index_converging"] = !(lastMergedEpoch == rootEpoch && lastPersistedEpoch == rootEpoch)
+			}
+		}
+	}
+
 	// calculate the aggregate of all the segment's field stats
 	aggFieldStats := newFieldStats()
 	for _, segmentSnapshot := range indexSnapshot.Segments() {

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -658,12 +658,12 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_persister_nap_merger_break"] = m["TotPersisterMergerNapBreak"]
 	m["total_compaction_written_bytes"] = m["TotFileMergeWrittenBytes"]
 
-	// the bool stat `index_converging` indicates whether the background routines
+	// the bool stat `index_active` indicates whether the background routines
 	// which causes the index to reach a steady state are still doing some work.
 	if rootEpoch, ok := m["CurRootEpoch"].(uint64); ok {
 		if lastMergedEpoch, ok := m["LastMergedEpoch"].(uint64); ok {
 			if lastPersistedEpoch, ok := m["LastPersistedEpoch"].(uint64); ok {
-				m["index_converging"] = !(lastMergedEpoch == rootEpoch && lastPersistedEpoch == rootEpoch)
+				m["index_active"] = !(lastMergedEpoch == rootEpoch && lastPersistedEpoch == rootEpoch)
 			}
 		}
 	}

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -658,12 +658,13 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 	m["num_persister_nap_merger_break"] = m["TotPersisterMergerNapBreak"]
 	m["total_compaction_written_bytes"] = m["TotFileMergeWrittenBytes"]
 
-	// the bool stat `index_active` indicates whether the background routines
-	// which causes the index to reach a steady state are still doing some work.
+	// the bool stat `index_bgthreads_active` indicates whether the background routines
+	// (which are responsible for the index to attain a steady state) are still
+	// doing some work.
 	if rootEpoch, ok := m["CurRootEpoch"].(uint64); ok {
 		if lastMergedEpoch, ok := m["LastMergedEpoch"].(uint64); ok {
 			if lastPersistedEpoch, ok := m["LastPersistedEpoch"].(uint64); ok {
-				m["index_active"] = !(lastMergedEpoch == rootEpoch && lastPersistedEpoch == rootEpoch)
+				m["index_bgthreads_active"] = !(lastMergedEpoch == rootEpoch && lastPersistedEpoch == rootEpoch)
 			}
 		}
 	}


### PR DESCRIPTION
`index_bgthreads_active` indicates whether the background routines that maintain the index are busy doing some work. This means that the index hasn't converged to a steady state and there could be potential file segment merges or in-memory segment flushes still remaining. 
This stat is beneficial for the application layer to get better insight as to whether the index is doing some background work (which can have implications on the system's resource utilisation) or not.