### PR TITLE
fix: linter warnings on test files

### DIFF
--- a/geo/versus_test.go
+++ b/geo/versus_test.go
@@ -4145,16 +4145,12 @@ func TestDecodeGeoHashVersus(t *testing.T) {
 
 func compareLatitude(box []float64, v float64) bool {
 	avg := (box[0] + box[1]) / 2
-	if compareGeo(avg, v) != 0 {
-		return false
-	}
-	return true
+
+	return compareGeo(avg, v) == 0
 }
 
 func compareLogitude(box []float64, v float64) bool {
 	avg := (box[2] + box[3]) / 2
-	if compareGeo(avg, v) != 0 {
-		return false
-	}
-	return true
+
+	return compareGeo(avg, v) == 0
 }

--- a/index/scorch/mergeplan/merge_plan_test.go
+++ b/index/scorch/mergeplan/merge_plan_test.go
@@ -64,17 +64,24 @@ func TestSimplePlan(t *testing.T) {
 		ExpectPlan *MergePlan
 		ExpectErr  error
 	}{
-		{"nil segments",
-			nil, nil, nil, nil},
-		{"empty segments",
-			[]Segment{}, nil, nil, nil},
-		{"1 segment",
+		{
+			"nil segments",
+			nil, nil, nil, nil,
+		},
+		{
+			"empty segments",
+			[]Segment{},
+			nil, nil, nil,
+		},
+		{
+			"1 segment",
 			[]Segment{segs[1]},
 			nil,
 			nil,
 			nil,
 		},
-		{"2 segments",
+		{
+			"2 segments",
 			[]Segment{
 				segs[1],
 				segs[2],
@@ -82,7 +89,7 @@ func TestSimplePlan(t *testing.T) {
 			nil,
 			&MergePlan{
 				Tasks: []*MergeTask{
-					&MergeTask{
+					{
 						Segments: []Segment{
 							segs[2],
 							segs[1],
@@ -92,7 +99,8 @@ func TestSimplePlan(t *testing.T) {
 			},
 			nil,
 		},
-		{"3 segments",
+		{
+			"3 segments",
 			[]Segment{
 				segs[1],
 				segs[2],
@@ -101,7 +109,7 @@ func TestSimplePlan(t *testing.T) {
 			nil,
 			&MergePlan{
 				Tasks: []*MergeTask{
-					&MergeTask{
+					{
 						Segments: []Segment{
 							segs[9],
 							segs[2],
@@ -112,7 +120,8 @@ func TestSimplePlan(t *testing.T) {
 			},
 			nil,
 		},
-		{"many segments",
+		{
+			"many segments",
 			[]Segment{
 				segs[1],
 				segs[2],
@@ -130,7 +139,7 @@ func TestSimplePlan(t *testing.T) {
 			},
 			&MergePlan{
 				Tasks: []*MergeTask{
-					&MergeTask{
+					{
 						Segments: []Segment{
 							segs[6],
 							segs[5],
@@ -144,14 +153,18 @@ func TestSimplePlan(t *testing.T) {
 
 	for testi, test := range tests {
 		plan, err := Plan(test.Segments, test.Options)
+
 		if err != test.ExpectErr {
 			testj, _ := json.Marshal(&test)
-			t.Errorf("testi: %d, test: %s, got err: %v",
-				testi, testj, err)
+
+			t.Errorf("testi: %d, test: %s, got err: %v", testi, testj, err)
 		}
+
 		if !reflect.DeepEqual(plan, test.ExpectPlan) {
 			testj, _ := json.Marshal(&test)
+
 			planj, _ := json.Marshal(&plan)
+
 			t.Errorf("testi: %d, test: %s, got plan: %s",
 				testi, testj, planj)
 		}
@@ -184,7 +197,8 @@ func TestCalcBudget(t *testing.T) {
 		{0, 0, MergePlanOptions{}, 0},
 		{1, 0, MergePlanOptions{}, 1},
 		{9, 0, MergePlanOptions{}, 9},
-		{1, 1,
+		{
+			1, 1,
 			MergePlanOptions{
 				MaxSegmentsPerTier:   1,
 				MaxSegmentSize:       1000,
@@ -194,7 +208,8 @@ func TestCalcBudget(t *testing.T) {
 			},
 			1,
 		},
-		{21, 1,
+		{
+			21, 1,
 			MergePlanOptions{
 				MaxSegmentsPerTier:   1,
 				MaxSegmentSize:       1000,
@@ -204,7 +219,8 @@ func TestCalcBudget(t *testing.T) {
 			},
 			5,
 		},
-		{21, 1,
+		{
+			21, 1,
 			MergePlanOptions{
 				MaxSegmentsPerTier:   2,
 				MaxSegmentSize:       1000,
@@ -214,18 +230,30 @@ func TestCalcBudget(t *testing.T) {
 			},
 			7,
 		},
-		{1000, 2000, DefaultMergePlanOptions,
-			1},
-		{5000, 2000, DefaultMergePlanOptions,
-			3},
-		{10000, 2000, DefaultMergePlanOptions,
-			5},
-		{30000, 2000, DefaultMergePlanOptions,
-			11},
-		{1000000, 2000, DefaultMergePlanOptions,
-			24},
-		{1000000000, 2000, DefaultMergePlanOptions,
-			54},
+		{
+			1000, 2000, DefaultMergePlanOptions,
+			1,
+		},
+		{
+			5000, 2000, DefaultMergePlanOptions,
+			3,
+		},
+		{
+			10000, 2000, DefaultMergePlanOptions,
+			5,
+		},
+		{
+			30000, 2000, DefaultMergePlanOptions,
+			11,
+		},
+		{
+			1000000, 2000, DefaultMergePlanOptions,
+			24,
+		},
+		{
+			1000000000, 2000, DefaultMergePlanOptions,
+			54,
+		},
 	}
 
 	for testi, test := range tests {
@@ -492,7 +520,6 @@ func TestPlanMaxSegmentSizeLimit(t *testing.T) {
 			var totalLiveSize int64
 			for _, segs := range task.Segments {
 				totalLiveSize += segs.LiveSize()
-
 			}
 			if totalLiveSize >= o.MaxSegmentSize {
 				t.Errorf("merged segments size: %d exceeding the MaxSegmentSize"+
@@ -500,7 +527,6 @@ func TestPlanMaxSegmentSizeLimit(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 // ----------------------------------------

--- a/index/upsidedown/field_dict_test.go
+++ b/index/upsidedown/field_dict_test.go
@@ -47,14 +47,12 @@ func TestIndexFieldDict(t *testing.T) {
 		}
 	}()
 
-	var expectedCount uint64
 	doc := document.NewDocument("1")
 	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
 	err = idx.Update(doc)
 	if err != nil {
 		t.Errorf("Error updating index: %v", err)
 	}
-	expectedCount++
 
 	doc = document.NewDocument("2")
 	doc.AddField(document.NewTextFieldWithAnalyzer("name", []uint64{}, []byte("test test test"), testAnalyzer))
@@ -64,7 +62,6 @@ func TestIndexFieldDict(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error updating index: %v", err)
 	}
-	expectedCount++
 
 	indexReader, err := idx.Reader()
 	if err != nil {

--- a/index/upsidedown/reader_test.go
+++ b/index/upsidedown/reader_test.go
@@ -15,6 +15,7 @@
 package upsidedown
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -77,7 +78,7 @@ func TestIndexReader(t *testing.T) {
 	}()
 
 	// first look for a term that doesn't exist
-	reader, err := indexReader.TermFieldReader(nil, []byte("nope"), "name", true, true, true)
+	reader, err := indexReader.TermFieldReader(context.TODO(), []byte("nope"), "name", true, true, true)
 	if err != nil {
 		t.Errorf("Error accessing term field reader: %v", err)
 	}
@@ -90,12 +91,11 @@ func TestIndexReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reader, err = indexReader.TermFieldReader(nil, []byte("test"), "name", true, true, true)
+	reader, err = indexReader.TermFieldReader(context.TODO(), []byte("test"), "name", true, true, true)
 	if err != nil {
 		t.Errorf("Error accessing term field reader: %v", err)
 	}
 
-	expectedCount = 2
 	count = reader.Count()
 	if count != expectedCount {
 		t.Errorf("Expected doc count to be: %d got: %d", expectedCount, count)
@@ -128,7 +128,7 @@ func TestIndexReader(t *testing.T) {
 			},
 		},
 	}
-	tfr, err := indexReader.TermFieldReader(nil, []byte("rice"), "desc", true, true, true)
+	tfr, err := indexReader.TermFieldReader(context.TODO(), []byte("rice"), "desc", true, true, true)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	// now test usage of advance
-	reader, err = indexReader.TermFieldReader(nil, []byte("test"), "name", true, true, true)
+	reader, err = indexReader.TermFieldReader(context.TODO(), []byte("test"), "name", true, true, true)
 	if err != nil {
 		t.Errorf("Error accessing term field reader: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestIndexReader(t *testing.T) {
 	}
 
 	// now test creating a reader for a field that doesn't exist
-	reader, err = indexReader.TermFieldReader(nil, []byte("water"), "doesnotexist", true, true, true)
+	reader, err = indexReader.TermFieldReader(context.TODO(), []byte("water"), "doesnotexist", true, true, true)
 	if err != nil {
 		t.Errorf("Error accessing term field reader: %v", err)
 	}
@@ -195,7 +195,6 @@ func TestIndexReader(t *testing.T) {
 	if match != nil {
 		t.Errorf("expected nil, got %v", match)
 	}
-
 }
 
 func TestIndexDocIdReader(t *testing.T) {
@@ -264,10 +263,17 @@ func TestIndexDocIdReader(t *testing.T) {
 	}()
 
 	id, err := reader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	count := uint64(0)
 	for id != nil {
 		count++
 		id, err = reader.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if count != expectedCount {
 		t.Errorf("expected %d, got %d", expectedCount, count)
@@ -390,10 +396,17 @@ func TestIndexDocIdOnlyReader(t *testing.T) {
 	}()
 
 	id, err := reader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	count := uint64(0)
 	for id != nil {
 		count++
 		id, err = reader.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if count != 3 {
 		t.Errorf("expected 3, got %d", count)
@@ -441,10 +454,17 @@ func TestIndexDocIdOnlyReader(t *testing.T) {
 	}()
 
 	id, err = reader3.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	count = uint64(0)
 	for id != nil {
 		count++
 		id, err = reader3.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if count != 1 {
 		t.Errorf("expected 1, got %d", count)
@@ -525,5 +545,4 @@ func TestIndexDocIdOnlyReader(t *testing.T) {
 	if !id.Equals(index.IndexInternalID("9")) {
 		t.Errorf("expected to find id '9', got '%s'", id)
 	}
-
 }

--- a/index/upsidedown/store/metrics/metrics_test.go
+++ b/index/upsidedown/store/metrics/metrics_test.go
@@ -24,19 +24,19 @@ import (
 )
 
 func TestMetricsStore(t *testing.T) {
-	s, err := New(nil, map[string]interface{}{})
+	_, err := New(nil, map[string]interface{}{})
 	if err == nil {
 		t.Errorf("expected err when bad config")
 	}
 
-	s, err = New(nil, map[string]interface{}{
+	_, err = New(nil, map[string]interface{}{
 		"kvStoreName_actual": "some-invalid-kvstore-name",
 	})
 	if err == nil {
 		t.Errorf("expected err when unknown kvStoreName_actual")
 	}
 
-	s, err = New(nil, map[string]interface{}{
+	s, err := New(nil, map[string]interface{}{
 		"kvStoreName_actual": gtreap.Name,
 		"path":               "",
 	})

--- a/index/upsidedown/upsidedown_test.go
+++ b/index/upsidedown/upsidedown_test.go
@@ -15,6 +15,7 @@
 package upsidedown
 
 import (
+	"context"
 	"log"
 	"reflect"
 	"regexp"
@@ -970,6 +971,10 @@ func TestIndexInsertUpdateDeleteWithMultipleTypesStored(t *testing.T) {
 
 	// now delete the document
 	err = idx.Delete("1")
+	if err != nil {
+		t.Errorf("Error deleting entry from index: %v", err)
+	}
+
 	expectedCount--
 
 	// expected doc count shouldn't have changed
@@ -1047,7 +1052,6 @@ func TestIndexInsertFields(t *testing.T) {
 			t.Errorf("expected fields: %v, got %v", expectedFields, fields)
 		}
 	}
-
 }
 
 func TestIndexUpdateComposites(t *testing.T) {
@@ -1192,7 +1196,6 @@ func TestIndexFieldsMisc(t *testing.T) {
 	if fieldName3 != "" {
 		t.Errorf("expected field named '', got '%s'", fieldName3)
 	}
-
 }
 
 func TestIndexTermReaderCompositeFields(t *testing.T) {
@@ -1239,7 +1242,7 @@ func TestIndexTermReaderCompositeFields(t *testing.T) {
 		}
 	}()
 
-	termFieldReader, err := indexReader.TermFieldReader(nil, []byte("mister"), "_all", true, true, true)
+	termFieldReader, err := indexReader.TermFieldReader(context.TODO(), []byte("mister"), "_all", true, true, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1322,7 +1325,6 @@ func TestIndexDocValueReader(t *testing.T) {
 }
 
 func BenchmarkBatch(b *testing.B) {
-
 	cache := registry.NewCache()
 	analyzer, err := cache.AnalyzerNamed(standard.Name)
 	if err != nil {
@@ -1501,7 +1503,6 @@ func TestIndexBatchPersistedCallbackWithErrorUpsideDown(t *testing.T) {
 	if !callbackExecuted {
 		t.Fatal("expected callback to fire, it did not")
 	}
-
 }
 
 // fieldTerms contains the terms used by a document, keyed by field

--- a/index_alias_impl_test.go
+++ b/index_alias_impl_test.go
@@ -411,7 +411,8 @@ func TestIndexAliasMulti(t *testing.T) {
 				},
 			},
 			MaxScore: 1.0,
-		}}
+		},
+	}
 	ei2Count := uint64(8)
 	ei2 := &stubIndex{
 		err:            nil,
@@ -431,7 +432,8 @@ func TestIndexAliasMulti(t *testing.T) {
 				},
 			},
 			MaxScore: 2.0,
-		}}
+		},
+	}
 
 	alias := NewIndexAlias(ei1, ei2)
 
@@ -710,7 +712,6 @@ func TestMultiSearchSecondPage(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-
 }
 
 // TestMultiSearchTimeout tests simple timeout cases
@@ -748,7 +749,8 @@ func TestMultiSearchTimeout(t *testing.T) {
 				},
 			},
 			MaxScore: 1.0,
-		}}
+		},
+	}
 	ei2 := &stubIndex{
 		name: "ei2",
 		checkRequest: func(req *SearchRequest) error {
@@ -776,7 +778,8 @@ func TestMultiSearchTimeout(t *testing.T) {
 				},
 			},
 			MaxScore: 2.0,
-		}}
+		},
+	}
 
 	// first run with absurdly long time out, should succeed
 	var cancel context.CancelFunc
@@ -882,7 +885,8 @@ func TestMultiSearchTimeoutPartial(t *testing.T) {
 				},
 			},
 			MaxScore: 1.0,
-		}}
+		},
+	}
 	ei2 := &stubIndex{
 		name: "ei2",
 		err:  nil,
@@ -902,15 +906,14 @@ func TestMultiSearchTimeoutPartial(t *testing.T) {
 				},
 			},
 			MaxScore: 2.0,
-		}}
+		},
+	}
 
 	ei3 := &stubIndex{
 		name: "ei3",
 		checkRequest: func(req *SearchRequest) error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			<-ctx.Done()
+			return ctx.Err()
 		},
 		err: nil,
 		searchResult: &SearchResult{
@@ -929,7 +932,8 @@ func TestMultiSearchTimeoutPartial(t *testing.T) {
 				},
 			},
 			MaxScore: 3.0,
-		}}
+		},
+	}
 
 	// ei3 is set to take >50ms, so run search with timeout less than
 	// this, this should return partial results
@@ -1000,7 +1004,8 @@ func TestIndexAliasMultipleLayer(t *testing.T) {
 				},
 			},
 			MaxScore: 1.0,
-		}}
+		},
+	}
 	ei2 := &stubIndex{
 		name: "ei2",
 		checkRequest: func(req *SearchRequest) error {
@@ -1028,7 +1033,8 @@ func TestIndexAliasMultipleLayer(t *testing.T) {
 				},
 			},
 			MaxScore: 2.0,
-		}}
+		},
+	}
 
 	ei3 := &stubIndex{
 		name: "ei3",
@@ -1057,7 +1063,8 @@ func TestIndexAliasMultipleLayer(t *testing.T) {
 				},
 			},
 			MaxScore: 3.0,
-		}}
+		},
+	}
 
 	ei4 := &stubIndex{
 		name: "ei4",
@@ -1078,7 +1085,8 @@ func TestIndexAliasMultipleLayer(t *testing.T) {
 				},
 			},
 			MaxScore: 4.0,
-		}}
+		},
+	}
 
 	alias1 := NewIndexAlias(ei1, ei2)
 	alias2 := NewIndexAlias(ei3, ei4)

--- a/index_test.go
+++ b/index_test.go
@@ -241,7 +241,8 @@ func approxSame(actual, expected uint64) bool {
 }
 
 func checkStatsOnIndexedBatch(indexPath string, indexMapping mapping.IndexMapping,
-	expectedVal uint64) error {
+	expectedVal uint64,
+) error {
 	var wg sync.WaitGroup
 	var statValError error
 
@@ -557,7 +558,6 @@ func TestBM25GlobalScoring(t *testing.T) {
 				hit.Score, singlePartHits[i].Score)
 		}
 	}
-
 }
 
 func TestBytesRead(t *testing.T) {
@@ -926,7 +926,8 @@ func TestIndexCreateNewOverExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	index, err = New(tmpIndexPath, NewIndexMapping())
+
+	_, err = New(tmpIndexPath, NewIndexMapping())
 	if err != ErrorIndexPathExists {
 		t.Fatalf("expected error index path exists, got %v", err)
 	}
@@ -955,23 +956,23 @@ func TestIndexOpenMetaMissingOrCorrupt(t *testing.T) {
 	tmpIndexPathMeta := filepath.Join(tmpIndexPath, "index_meta.json")
 
 	// now intentionally change the storage type
-	err = os.WriteFile(tmpIndexPathMeta, []byte(`{"storage":"mystery"}`), 0666)
+	err = os.WriteFile(tmpIndexPathMeta, []byte(`{"storage":"mystery"}`), 0o666)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	index, err = Open(tmpIndexPath)
+	_, err = Open(tmpIndexPath)
 	if err == nil {
 		t.Fatalf("expected error for unknown storage type, got %v", err)
 	}
 
 	// now intentionally corrupt the metadata
-	err = os.WriteFile(tmpIndexPathMeta, []byte("corrupted"), 0666)
+	err = os.WriteFile(tmpIndexPathMeta, []byte("corrupted"), 0o666)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	index, err = Open(tmpIndexPath)
+	_, err = Open(tmpIndexPath)
 	if err != ErrorIndexMetaCorrupt {
 		t.Fatalf("expected error index metadata corrupted, got %v", err)
 	}
@@ -982,14 +983,13 @@ func TestIndexOpenMetaMissingOrCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	index, err = Open(tmpIndexPath)
+	_, err = Open(tmpIndexPath)
 	if err != ErrorIndexMetaMissing {
 		t.Fatalf("expected error index metadata missing, got %v", err)
 	}
 }
 
 func TestInMemIndex(t *testing.T) {
-
 	index, err := NewMemOnly(NewIndexMapping())
 	if err != nil {
 		t.Fatal(err)
@@ -1332,7 +1332,6 @@ func TestBatchString(t *testing.T) {
 	if !strings.Contains(batchStr, "DELETE INTERNAL - 'd'") {
 		t.Errorf("expected to contain DELETE INTERNAL - 'd', did not")
 	}
-
 }
 
 func TestIndexMetadataRaceBug198(t *testing.T) {
@@ -1353,6 +1352,7 @@ func TestIndexMetadataRaceBug198(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	done := make(chan struct{})
+	errChan := make(chan error, 1)
 	go func() {
 		for {
 			select {
@@ -1362,11 +1362,19 @@ func TestIndexMetadataRaceBug198(t *testing.T) {
 			default:
 				_, err2 := index.DocCount()
 				if err2 != nil {
-					t.Fatal(err2)
+					errChan <- err2
+					return
 				}
 			}
 		}
 	}()
+
+	// wait for any errors from the goroutine
+	select {
+	case err := <-errChan:
+		t.Fatal(err)
+	default:
+	}
 
 	for i := 0; i < 100; i++ {
 		batch := index.NewBatch()
@@ -1442,6 +1450,7 @@ func TestIndexCountMatchSearch(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	errChan := make(chan error, 1)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
@@ -1455,17 +1464,25 @@ func TestIndexCountMatchSearch(t *testing.T) {
 				}
 				err := b.Index(id, doc)
 				if err != nil {
-					t.Fatal(err)
+					errChan <- err
+					return
 				}
 			}
 			err := index.Batch(b)
 			if err != nil {
-				t.Fatal(err)
+				errChan <- err
 			}
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
+
+	// wait for any errors from the goroutines
+	select {
+	case err := <-errChan:
+		t.Fatal(err)
+	default:
+	}
 
 	// search for something that should match all documents
 	sr, err := index.Search(NewSearchRequest(NewMatchQuery("match")))
@@ -2276,7 +2293,6 @@ func TestOpenReadonlyMultiple(t *testing.T) {
 	index, err = OpenUsing(tmpIndexPath, map[string]interface{}{
 		"read_only": true,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2285,7 +2301,6 @@ func TestOpenReadonlyMultiple(t *testing.T) {
 	index2, err := OpenUsing(tmpIndexPath, map[string]interface{}{
 		"read_only": true,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2375,9 +2390,11 @@ func TestIndexAdvancedCountMatchSearch(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	errChan := make(chan error, 10)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
+			defer wg.Done()
 			b := index.NewBatch()
 			for j := 0; j < 200; j++ {
 				id := fmt.Sprintf("%d", (i*200)+j)
@@ -2388,17 +2405,25 @@ func TestIndexAdvancedCountMatchSearch(t *testing.T) {
 
 				err := b.IndexAdvanced(doc)
 				if err != nil {
-					t.Fatal(err)
+					errChan <- err
+					return
 				}
 			}
 			err := index.Batch(b)
 			if err != nil {
-				t.Fatal(err)
+				errChan <- err
+				return
 			}
-			wg.Done()
 		}(i)
 	}
 	wg.Wait()
+
+	close(errChan)
+	for err := range errChan {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	// search for something that should match all documents
 	sr, err := index.Search(NewSearchRequest(NewMatchQuery("match")))
@@ -2502,7 +2527,9 @@ func TestSearchQueryCallback(t *testing.T) {
 		return expErr
 	}
 
-	ctx := context.WithValue(context.Background(), SearchQueryStartCallbackKey,
+	ctx := context.WithValue(
+		context.Background(),
+		SearchQueryStartCallbackKey,
 		SearchQueryStartCallbackFn(f))
 	_, err = index.SearchInContext(ctx, req)
 	if err != expErr {
@@ -2656,7 +2683,6 @@ func TestBatchMerge(t *testing.T) {
 			t.Errorf("field %s is missing", ef)
 		}
 	}
-
 }
 
 func TestBug1096(t *testing.T) {

--- a/query_bench_test.go
+++ b/query_bench_test.go
@@ -249,8 +249,8 @@ func BenchmarkQueryDateRange(b *testing.B) {
 
 	inclusive := true
 	for i := 0; i < b.N; i++ {
-		start, _ := time.Parse("2006-01-02T12:00:00Z", members[i%(len(members)-2)])
-		end, _ := time.Parse("2006-01-02T12:00:00Z", members[(i+2)%(len(members)-2)])
+		start, _ := time.Parse("2006-01-02T15:04:05Z", members[i%(len(members)-2)])
+		end, _ := time.Parse("2006-01-02T15:04:05Z", members[(i+2)%(len(members)-2)])
 		q := NewDateRangeInclusiveQuery(start, end, &inclusive, &inclusive)
 		q.SetField("date")
 		req := NewSearchRequest(q)

--- a/search/query/query_string_parser_test.go
+++ b/search/query/query_string_parser_test.go
@@ -930,7 +930,6 @@ func TestQuerySyntaxParserInvalid(t *testing.T) {
 }
 
 func BenchmarkLexer(b *testing.B) {
-
 	for n := 0; n < b.N; n++ {
 		var tokenTypes []int
 		var tokens []yySymType
@@ -938,13 +937,18 @@ func BenchmarkLexer(b *testing.B) {
 		l := newQueryStringLex(r)
 		var lval yySymType
 		rv := l.Lex(&lval)
+
 		for rv > 0 {
 			tokenTypes = append(tokenTypes, rv)
 			tokens = append(tokens, lval)
+
+			// use the slice to silence the compiler warning
+			_ = tokenTypes
+			_ = tokens
+
 			lval.s = ""
 			lval.n = 0
 			rv = l.Lex(&lval)
 		}
 	}
-
 }

--- a/search/searcher/geoshape_contains_test.go
+++ b/search/searcher/geoshape_contains_test.go
@@ -24,14 +24,17 @@ import (
 
 var (
 	leftRectEdgeMultiPoint [][]float64   = [][]float64{{-1, 0.2}, {-0.9, 0.1}}
-	leftRectWithHole       [][][]float64 = [][][]float64{{{-1, 0}, {0, 0}, {0, 1}, {-1, 1}, {-1, 0}},
-		{{-0.75, 0.25}, {-0.75, -0.75}, {-0.25, 0.75}, {-0.25, 0.25}, {-0.74, 0.25}}}
+	leftRectWithHole       [][][]float64 = [][][]float64{
+		{{-1, 0}, {0, 0}, {0, 1}, {-1, 1}, {-1, 0}},
+		{{-0.75, 0.25}, {-0.75, -0.75}, {-0.25, 0.75}, {-0.25, 0.25}, {-0.74, 0.25}},
+	}
 	leftRectEdgePoint  []float64   = []float64{-1, 0.2}
 	leftRectMultiPoint [][]float64 = [][]float64{{0.5, 0.5}, {-0.9, 0.1}}
 )
 
 func testCaseSetup(t *testing.T, docShapeName, docShapeType string, docShapeVertices [][][][]float64,
-	i index.Index) (index.IndexReader, func() error, error) {
+	i index.Index,
+) (index.IndexReader, func() error, error) {
 	doc := document.NewDocument(docShapeName)
 	doc.AddField(document.NewGeoShapeFieldWithIndexingOptions("geometry", []uint64{},
 		docShapeVertices, docShapeType, document.DefaultGeoShapeIndexingOptions))
@@ -91,14 +94,14 @@ func TestPointPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -108,7 +111,7 @@ func TestPointPolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -154,14 +157,14 @@ func TestLinestringPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeLinestringQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for linestring: %+v",
@@ -171,7 +174,7 @@ func TestLinestringPolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -201,7 +204,7 @@ func TestEnvelopePointContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -218,7 +221,7 @@ func TestEnvelopePointContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -248,7 +251,7 @@ func TestEnvelopeLinestringContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -265,7 +268,7 @@ func TestEnvelopeLinestringContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -311,7 +314,7 @@ func TestEnvelopePolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -328,7 +331,7 @@ func TestEnvelopePolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -374,14 +377,14 @@ func TestPolygonPointContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -390,7 +393,7 @@ func TestPolygonPointContains(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -420,14 +423,14 @@ func TestPolygonLinestringContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -437,7 +440,7 @@ func TestPolygonLinestringContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -476,14 +479,14 @@ func TestPolygonEnvelopeContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "envelope",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -493,7 +496,7 @@ func TestPolygonEnvelopeContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -525,8 +528,10 @@ func TestMultiPointPolygonContains(t *testing.T) {
 		},
 		{
 			QueryShape: [][]float64{{0.3, 0.3}, {0.5, 0.5}},
-			DocShapeVertices: [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
-				{{0.2, 0.2}, {0.4, 0.2}, {0.4, 0.4}, {0.2, 0.4}, {0.2, 0.2}}},
+			DocShapeVertices: [][][]float64{
+				{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
+				{{0.2, 0.2}, {0.4, 0.2}, {0.4, 0.4}, {0.2, 0.4}, {0.2, 0.2}},
+			},
 			DocShapeName: "polygon1",
 			Expected:     nil, // returns nil since one of the points is within the hole
 			Desc:         "multi point inside polygon and hole",
@@ -540,14 +545,14 @@ func TestMultiPointPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipoint: %+v",
@@ -557,7 +562,7 @@ func TestMultiPointPolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -595,14 +600,14 @@ func TestMultiPointLinestringContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipoint: %+v",
@@ -612,7 +617,7 @@ func TestMultiPointLinestringContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -650,14 +655,14 @@ func TestMultiPointContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipoint: %+v",
@@ -667,7 +672,7 @@ func TestMultiPointContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -705,14 +710,14 @@ func TestPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -722,7 +727,7 @@ func TestPolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -768,14 +773,14 @@ func TestPolygonMultiPointContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -785,7 +790,7 @@ func TestPolygonMultiPointContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -823,14 +828,14 @@ func TestMultiPolygonPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiPolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -840,7 +845,7 @@ func TestMultiPolygonPolygonContains(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -877,14 +882,14 @@ func TestMultiLinestringMultiPolygonContains(t *testing.T) {
 	for _, test := range tests {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipolygon", test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiLinestringQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multilinestring: %+v",
@@ -893,7 +898,7 @@ func TestMultiLinestringMultiPolygonContains(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -925,14 +930,14 @@ func TestGeometryCollectionPolygonContains(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeGeometryCollectionRelationQuery(test.QueryType,
 				indexReader, test.QueryShape, test.QueryShapeTypes, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -941,7 +946,7 @@ func TestGeometryCollectionPolygonContains(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -982,14 +987,14 @@ func TestGeometryCollectionMultiPolygonContains(t *testing.T) {
 	for _, test := range tests {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipolygon", test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeGeometryCollectionRelationQuery(test.QueryType,
 				indexReader, test.QueryShape, test.QueryShapeTypes, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipolygon: %+v",
@@ -998,7 +1003,7 @@ func TestGeometryCollectionMultiPolygonContains(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }

--- a/search/searcher/geoshape_intersects_test.go
+++ b/search/searcher/geoshape_intersects_test.go
@@ -71,7 +71,7 @@ func TestPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		// indexing and searching independently for each case.
@@ -79,7 +79,7 @@ func TestPointIntersects(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -89,7 +89,7 @@ func TestPointIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -123,7 +123,7 @@ func TestPointMultiPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		// indexing and searching independently for each case.
@@ -131,7 +131,7 @@ func TestPointMultiPointIntersects(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -140,7 +140,7 @@ func TestPointMultiPointIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -183,14 +183,14 @@ func TestPointLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -200,7 +200,7 @@ func TestPointLinestringIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -243,14 +243,14 @@ func TestPointMultiLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -260,7 +260,7 @@ func TestPointMultiLinestringIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -296,8 +296,10 @@ func TestPointPolygonIntersects(t *testing.T) {
 		},
 		{
 			QueryShape: []float64{0.3, 0.3},
-			DocShapeVertices: [][][]float64{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			DocShapeVertices: [][][]float64{
+				{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			},
 			DocShapeName: "polygon1",
 			Desc:         "point inside hole inside polygon",
 			Expected:     nil,
@@ -310,14 +312,14 @@ func TestPointPolygonIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -326,7 +328,7 @@ func TestPointPolygonIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -355,16 +357,20 @@ func TestPointMultiPolygonIntersects(t *testing.T) {
 		},
 		{
 			QueryShape: []float64{1.5, 1.9},
-			DocShapeVertices: [][][][]float64{{{{1.0, 1.0}, {2.0, 2.0}, {0.0, 2.0}, {1.0, 1.0}}},
-				{{{1.5, 1.9}, {2.5, 2.9}, {0.5, 2.9}, {1.5, 1.9}}}},
+			DocShapeVertices: [][][][]float64{
+				{{{1.0, 1.0}, {2.0, 2.0}, {0.0, 2.0}, {1.0, 1.0}}},
+				{{{1.5, 1.9}, {2.5, 2.9}, {0.5, 2.9}, {1.5, 1.9}}},
+			},
 			DocShapeName: "multipolygon1",
 			Desc:         "point inside a polygon and on vertex of another polygon",
 			Expected:     []string{"multipolygon1"},
 		},
 		{
 			QueryShape: []float64{0.3, 0.3},
-			DocShapeVertices: [][][][]float64{{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}}},
+			DocShapeVertices: [][][][]float64{{
+				{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			}},
 			DocShapeName: "multipolygon1",
 			Desc:         "point inside hole inside one of the polygons",
 			Expected:     nil,
@@ -376,14 +382,14 @@ func TestPointMultiPolygonIntersects(t *testing.T) {
 	for _, test := range tests {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipolygon", test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -393,7 +399,7 @@ func TestPointMultiPolygonIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -431,7 +437,7 @@ func TestEnvelopePointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -448,7 +454,7 @@ func TestEnvelopePointIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -494,7 +500,7 @@ func TestEnvelopeLinestringIntersect(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -511,7 +517,7 @@ func TestEnvelopeLinestringIntersect(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -549,7 +555,7 @@ func TestEnvelopePolygonIntersect(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -566,7 +572,7 @@ func TestEnvelopePolygonIntersect(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -593,14 +599,14 @@ func TestMultiPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery("intersects",
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipoint: %+v",
@@ -609,7 +615,7 @@ func TestMultiPointIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -679,7 +685,7 @@ func TestLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -695,7 +701,7 @@ func TestLinestringIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -745,25 +751,31 @@ func TestLinestringPolygonIntersects(t *testing.T) {
 		},
 		{
 			QueryShape: [][]float64{{0.3, 0.3}, {0.35, 0.35}},
-			DocShapeVertices: [][][]float64{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			DocShapeVertices: [][][]float64{
+				{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			},
 			DocShapeName: "polygon1",
 			Desc:         "linestring does not intersect polygon when contained in the hole",
 			Expected:     nil,
 		},
 		{
 			QueryShape: [][]float64{{0.3, 0.3}, {0.5, 0.5}},
-			DocShapeVertices: [][][]float64{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			DocShapeVertices: [][][]float64{
+				{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			},
 			DocShapeName: "polygon1",
 			Desc:         "linestring intersects polygon in the hole",
 			Expected:     []string{"polygon1"},
 		},
 		{
 			QueryShape: [][]float64{{0.4, 0.3}, {0.6, 0.3}},
-			DocShapeVertices: [][][]float64{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
+			DocShapeVertices: [][][]float64{
+				{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}, {0.0, 0.0}},
 				{{0.3, 0.3}, {0.4, 0.2}, {0.5, 0.3}, {0.4, 0.4}, {0.3, 0.3}},
-				{{0.5, 0.3}, {0.6, 0.2}, {0.7, 0.3}, {0.6, 0.4}, {0.5, 0.3}}},
+				{{0.5, 0.3}, {0.6, 0.2}, {0.7, 0.3}, {0.6, 0.4}, {0.5, 0.3}},
+			},
 			DocShapeName: "polygon1",
 			Desc:         "linestring intersects polygon through touching holes",
 			Expected:     []string{"polygon1"},
@@ -776,7 +788,7 @@ func TestLinestringPolygonIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -792,7 +804,7 @@ func TestLinestringPolygonIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -855,7 +867,7 @@ func TestLinestringPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -871,7 +883,7 @@ func TestLinestringPointIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -906,7 +918,7 @@ func TestMultiLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -922,7 +934,7 @@ func TestMultiLinestringIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -957,7 +969,7 @@ func TestMultiLinestringMultiPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -973,7 +985,7 @@ func TestMultiLinestringMultiPointIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -987,54 +999,109 @@ func TestPolygonIntersects(t *testing.T) {
 		Expected         []string
 	}{
 		{
-			QueryShape: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
-			DocShapeVertices: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
+			QueryShape: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
+			DocShapeVertices: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
 			DocShapeName: "polygon1",
 			Desc:         "coincident polygons",
 			Expected:     []string{"polygon1"},
 		},
 		{
-			QueryShape: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
-			DocShapeVertices: [][][]float64{{{1.2, 1.2}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.2, 1.2}}},
+			QueryShape: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
+			DocShapeVertices: [][][]float64{{
+				{1.2, 1.2},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.2, 1.2},
+			}},
 			DocShapeName: "polygon1",
 			Desc:         "polygon and a window polygon",
 			Expected:     []string{"polygon1"},
 		},
 		{
-			QueryShape: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
-			DocShapeVertices: [][][]float64{{{1.1, 1.1}, {1.2, 1.1}, {1.2, 1.2},
-				{1.1, 1.2}, {1.1, 1.1}}},
+			QueryShape: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
+			DocShapeVertices: [][][]float64{{
+				{1.1, 1.1},
+				{1.2, 1.1},
+				{1.2, 1.2},
+				{1.1, 1.2},
+				{1.1, 1.1},
+			}},
 			DocShapeName: "polygon1",
 			Desc:         "nested polygons",
 			Expected:     []string{"polygon1"},
 		},
 		{
-			QueryShape: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
-			DocShapeVertices: [][][]float64{{{0.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{0.0, 2.0}, {0.0, 1.0}}},
+			QueryShape: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
+			DocShapeVertices: [][][]float64{{
+				{0.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{0.0, 2.0},
+				{0.0, 1.0},
+			}},
 			DocShapeName: "polygon1",
 			Desc:         "intersecting polygons",
 			Expected:     []string{"polygon1"},
 		},
 		{
-			QueryShape: [][][]float64{{{0, 0}, {5, 0}, {5, 5}, {0, 5}, {0, 0}}, {{1, 4}, {4, 4},
-				{4, 1}, {1, 1}, {1, 4}}},
+			QueryShape: [][][]float64{{{0, 0}, {5, 0}, {5, 5}, {0, 5}, {0, 0}}, {
+				{1, 4},
+				{4, 4},
+				{4, 1},
+				{1, 1},
+				{1, 4},
+			}},
 			DocShapeVertices: [][][]float64{{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}},
 			DocShapeName:     "polygon1",
 			Desc:             "polygon inside hole of a larger polygon",
 			Expected:         nil,
 		},
 		{
-			QueryShape: [][][]float64{{{1.0, 1.0}, {2.0, 1.0}, {2.0, 2.0},
-				{1.0, 2.0}, {1.0, 1.0}}},
-			DocShapeVertices: [][][]float64{{{3.0, 3.0}, {4.0, 3.0}, {4.0, 4.0},
-				{3.0, 4.0}, {3.0, 3.0}}},
+			QueryShape: [][][]float64{{
+				{1.0, 1.0},
+				{2.0, 1.0},
+				{2.0, 2.0},
+				{1.0, 2.0},
+				{1.0, 1.0},
+			}},
+			DocShapeVertices: [][][]float64{{
+				{3.0, 3.0},
+				{4.0, 3.0},
+				{4.0, 4.0},
+				{3.0, 4.0},
+				{3.0, 3.0},
+			}},
 			DocShapeName: "polygon1",
 			Desc:         "disjoint polygons",
 			Expected:     nil,
@@ -1046,7 +1113,7 @@ func TestPolygonIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1062,7 +1129,7 @@ func TestPolygonIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1118,7 +1185,7 @@ func TestPolygonLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1135,7 +1202,7 @@ func TestPolygonLinestringIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1191,7 +1258,7 @@ func TestPolygonMultiLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1208,7 +1275,7 @@ func TestPolygonMultiLinestringIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1243,7 +1310,7 @@ func TestPolygonPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1260,7 +1327,7 @@ func TestPolygonPointIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1274,19 +1341,39 @@ func TestMultiPolygonIntersects(t *testing.T) {
 		Expected         []string
 	}{
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20},
-				{5, 10}, {15, 5}}}, {{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
-			DocShapeVertices: [][][][]float64{{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0},
-				{0.0, 1.0}, {0.0, 0.0}}, {{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			QueryShape: [][][][]float64{{{
+				{15, 5},
+				{40, 10},
+				{10, 20},
+				{5, 10},
+				{15, 5},
+			}}, {{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			DocShapeVertices: [][][][]float64{{{
+				{0.0, 0.0},
+				{1.0, 0.0},
+				{1.0, 1.0},
+				{0.0, 1.0},
+				{0.0, 0.0},
+			}, {{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
 			DocShapeName: "multipolygon1",
 			Desc:         "intersecting multi polygons",
 			Expected:     []string{"multipolygon1"},
 		},
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20},
-				{5, 10}, {15, 5}}}, {{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
-			DocShapeVertices: [][][][]float64{{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0},
-				{0.0, 1.0}, {0.0, 0.0}}}},
+			QueryShape: [][][][]float64{{{
+				{15, 5},
+				{40, 10},
+				{10, 20},
+				{5, 10},
+				{15, 5},
+			}}, {{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			DocShapeVertices: [][][][]float64{{{
+				{0.0, 0.0},
+				{1.0, 0.0},
+				{1.0, 1.0},
+				{0.0, 1.0},
+				{0.0, 0.0},
+			}}},
 			DocShapeName: "multipolygon1",
 			Desc:         "non intersecting multi polygons",
 			Expected:     nil,
@@ -1298,7 +1385,7 @@ func TestMultiPolygonIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipolygon",
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1314,7 +1401,7 @@ func TestMultiPolygonIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1328,16 +1415,20 @@ func TestMultiPolygonMultiPointIntersects(t *testing.T) {
 		Expected         []string
 	}{
 		{
-			QueryShape: [][][][]float64{{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}},
-				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}}},
+			QueryShape: [][][][]float64{
+				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}},
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+			},
 			DocShapeVertices: [][]float64{{30, 20}, {30, 30}},
 			DocShapeName:     "multipoint1",
 			Desc:             "multipolygon intersects multipoint at the vertex",
 			Expected:         []string{"multipoint1"},
 		},
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
-				{{{30, 20}, {45, 50}, {10, 50}, {30, 20}}}},
+			QueryShape: [][][][]float64{
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+				{{{30, 20}, {45, 50}, {10, 50}, {30, 20}}},
+			},
 			DocShapeVertices: [][]float64{{30, -20}, {-30, 30}, {45, 66}},
 			DocShapeName:     "multipoint1",
 			Desc:             "multipolygon does not intersect multipoint",
@@ -1350,7 +1441,7 @@ func TestMultiPolygonMultiPointIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1367,7 +1458,7 @@ func TestMultiPolygonMultiPointIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1401,7 +1492,7 @@ func TestMultiPolygonMultiLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1417,7 +1508,7 @@ func TestMultiPolygonMultiLinestringIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1447,14 +1538,14 @@ func TestGeometryCollectionIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetupGeometryCollection(t, test.DocShapeName, test.Types,
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeGeometryCollectionRelationQuery("intersects",
 				indexReader, test.QueryShape, test.Types, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for geometry collection: %+v",
@@ -1464,7 +1555,7 @@ func TestGeometryCollectionIntersects(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1526,7 +1617,7 @@ func TestGeometryCollectionPointIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1564,7 +1655,7 @@ func TestGeometryCollectionLinestringIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1580,7 +1671,7 @@ func TestGeometryCollectionLinestringIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1618,7 +1709,7 @@ func TestGeometryCollectionPolygonIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1634,7 +1725,7 @@ func TestGeometryCollectionPolygonIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1672,7 +1763,7 @@ func TestPointGeometryCollectionIntersects(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetupGeometryCollection(t, test.DocShapeName, test.Types,
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1688,7 +1779,7 @@ func TestPointGeometryCollectionIntersects(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }

--- a/search/searcher/geoshape_within_test.go
+++ b/search/searcher/geoshape_within_test.go
@@ -31,7 +31,8 @@ var (
 )
 
 func testCaseSetupGeometryCollection(t *testing.T, docShapeName string, types []string, docShapeVertices [][][][][]float64,
-	i index.Index) (index.IndexReader, func() error, error) {
+	i index.Index,
+) (index.IndexReader, func() error, error) {
 	doc := document.NewDocument(docShapeName)
 	gcField := document.NewGeometryCollectionFieldWithIndexingOptions("geometry",
 		[]uint64{}, docShapeVertices, types, document.DefaultGeoShapeIndexingOptions)
@@ -44,7 +45,7 @@ func testCaseSetupGeometryCollection(t *testing.T, docShapeName string, types []
 	}
 	err := i.Update(doc)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	indexReader, err := i.Reader()
@@ -100,14 +101,14 @@ func TestPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -116,7 +117,7 @@ func TestPointWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -154,14 +155,14 @@ func TestMultiPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipoint: %+v",
@@ -171,7 +172,7 @@ func TestMultiPointWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -217,7 +218,7 @@ func TestEnvelopePointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -234,7 +235,7 @@ func TestEnvelopePointWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -280,7 +281,7 @@ func TestEnvelopeLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -297,7 +298,7 @@ func TestEnvelopeLinestringWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -343,7 +344,7 @@ func TestEnvelopePolygonWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -360,7 +361,7 @@ func TestEnvelopePolygonWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -398,14 +399,14 @@ func TestPointLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -414,7 +415,7 @@ func TestPointLinestringWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -453,14 +454,14 @@ func TestPointPolygonWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				false, indexReader, [][]float64{test.QueryShape}, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for point: %+v",
@@ -469,7 +470,7 @@ func TestPointPolygonWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -532,14 +533,14 @@ func TestLinestringPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeLinestringQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for linestring: %+v",
@@ -549,7 +550,7 @@ func TestLinestringPointWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -587,14 +588,14 @@ func TestMultiPointMultiLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePointRelationQuery(test.QueryType,
 				true, indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multilinestring: %+v",
@@ -603,7 +604,7 @@ func TestMultiPointMultiLinestringWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -640,14 +641,14 @@ func TestLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeLinestringQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for linestring: %+v",
@@ -657,7 +658,7 @@ func TestLinestringWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -689,7 +690,7 @@ func TestLinestringGeometryCollectionWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetupGeometryCollection(t, test.DocShapeName, test.Types,
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -705,7 +706,7 @@ func TestLinestringGeometryCollectionWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -736,8 +737,18 @@ func TestPolygonPointWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0},
-				{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			QueryShape: [][][]float64{{
+				{0, 0},
+				{1, 0},
+				{1, 1},
+				{0, 1},
+				{0, 0},
+				{0.2, 0.2},
+				{0.2, 0.4},
+				{0.4, 0.4},
+				{0.4, 0.2},
+				{0.2, 0.2},
+			}},
 			DocShapeVertices: []float64{0.3, 0.3},
 			DocShapeName:     "point1",
 			Expected:         nil,
@@ -794,14 +805,14 @@ func TestPolygonPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "point",
 			[][][][]float64{{{test.DocShapeVertices}}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -811,7 +822,7 @@ func TestPolygonPointWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -834,8 +845,10 @@ func TestPolygonLinestringWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			QueryShape: [][][]float64{
+				{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			},
 			DocShapeVertices: [][]float64{{0.3, 0.3}, {0.55, 0.55}},
 			DocShapeName:     "linestring1",
 			Expected:         nil,
@@ -843,8 +856,10 @@ func TestPolygonLinestringWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][]float64{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
-				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}}},
+			QueryShape: [][][]float64{
+				{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}},
+				{{0.2, 0.2}, {0.2, 0.4}, {0.4, 0.4}, {0.4, 0.2}, {0.2, 0.2}},
+			},
 			DocShapeVertices: [][]float64{{0.3, 0.3}, {4.0, 4.0}},
 			DocShapeName:     "linestring1",
 			Expected:         nil,
@@ -875,14 +890,14 @@ func TestPolygonLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "linestring",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -891,7 +906,7 @@ func TestPolygonLinestringWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -960,14 +975,14 @@ func TestPolygonWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "polygon",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapePolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -976,7 +991,7 @@ func TestPolygonWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -991,8 +1006,10 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 		QueryType        string
 	}{
 		{
-			QueryShape: [][][][]float64{{{{30, 25}, {45, 40}, {10, 40}, {30, 20}, {30, 25}}},
-				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}}},
+			QueryShape: [][][][]float64{
+				{{{30, 25}, {45, 40}, {10, 40}, {30, 20}, {30, 25}}},
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+			},
 			DocShapeVertices: [][]float64{{30, 20}, {15, 5}},
 			DocShapeName:     "multipoint1",
 			Expected:         []string{"multipoint1"},
@@ -1000,8 +1017,10 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
-				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			QueryShape: [][][][]float64{
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}},
+			},
 			DocShapeVertices: [][]float64{{30, 20}, {30, 30}, {45, 66}},
 			DocShapeName:     "multipoint1",
 			Expected:         nil,
@@ -1009,8 +1028,10 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][][]float64{{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
-				{{{1, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 0}}}},
+			QueryShape: [][][][]float64{
+				{{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
+				{{{1, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 0}}},
+			},
 			DocShapeVertices: [][]float64{{0.5, 0.5}, {1.5, 0.5}},
 			DocShapeName:     "multipoint1",
 			Expected:         []string{"multipoint1"},
@@ -1025,14 +1046,14 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipoint",
 			[][][][]float64{{test.DocShapeVertices}}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiPolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for polygon: %+v",
@@ -1042,7 +1063,7 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1072,14 +1093,14 @@ func TestMultiLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiLinestringQueryWithRelation("within",
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multilinestring: %+v",
@@ -1088,7 +1109,7 @@ func TestMultiLinestringWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1103,8 +1124,10 @@ func TestMultiPolygonMultiLinestringWithin(t *testing.T) {
 		QueryType        string
 	}{
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
-				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			QueryShape: [][][][]float64{
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}},
+			},
 			DocShapeVertices: [][][]float64{{{45, 40}, {10, 40}}, {{45, 40}, {10, 40}, {30, 20}}},
 			DocShapeName:     "multilinestring1",
 			Expected:         []string{"multilinestring1"},
@@ -1112,8 +1135,10 @@ func TestMultiPolygonMultiLinestringWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][][]float64{{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
-				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}}},
+			QueryShape: [][][][]float64{
+				{{{15, 5}, {40, 10}, {10, 20}, {5, 10}, {15, 5}}},
+				{{{30, 20}, {45, 40}, {10, 40}, {30, 20}}},
+			},
 			DocShapeVertices: [][][]float64{{{48, 40}, {8, 40}}, {{48, 40}, {8, 40}, {30, 12}}},
 			DocShapeName:     "multilinestring1",
 			Expected:         nil,
@@ -1127,14 +1152,14 @@ func TestMultiPolygonMultiLinestringWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multilinestring",
 			[][][][]float64{test.DocShapeVertices}, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiPolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipolygon: %+v",
@@ -1143,7 +1168,7 @@ func TestMultiPolygonMultiLinestringWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1158,8 +1183,10 @@ func TestMultiPolygonWithin(t *testing.T) {
 		QueryType        string
 	}{
 		{
-			QueryShape: [][][][]float64{{{{16, 6}, {41, 11}, {11, 21}, {6, 11}, {16, 6}}},
-				{{{31, 21}, {46, 41}, {11, 41}, {31, 21}}}},
+			QueryShape: [][][][]float64{
+				{{{16, 6}, {41, 11}, {11, 21}, {6, 11}, {16, 6}}},
+				{{{31, 21}, {46, 41}, {11, 41}, {31, 21}}},
+			},
 			DocShapeVertices: [][][][]float64{{{{31, 21}, {46, 41}, {11, 41}, {31, 21}}}},
 			DocShapeName:     "multipolygon1",
 			Expected:         []string{"multipolygon1"},
@@ -1167,8 +1194,10 @@ func TestMultiPolygonWithin(t *testing.T) {
 			QueryType:        "within",
 		},
 		{
-			QueryShape: [][][][]float64{{{{16, 6}, {41, 11}, {11, 21}, {6, 11}, {16, 6}}},
-				{{{31, 21}, {46, 41}, {11, 41}, {31, 21}}}},
+			QueryShape: [][][][]float64{
+				{{{16, 6}, {41, 11}, {11, 21}, {6, 11}, {16, 6}}},
+				{{{31, 21}, {46, 41}, {11, 41}, {31, 21}}},
+			},
 			DocShapeVertices: [][][][]float64{{{{31, 21}, {46, 41}, {16, 46}, {31, 21}}}},
 			DocShapeName:     "multipolygon1",
 			Expected:         nil,
@@ -1182,14 +1211,14 @@ func TestMultiPolygonWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetup(t, test.DocShapeName, "multipolygon",
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := runGeoShapeMultiPolygonQueryWithRelation(test.QueryType,
 				indexReader, test.QueryShape, "geometry")
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err.Error())
 			}
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Errorf("expected %v, got %v for multipolygon: %+v",
@@ -1198,7 +1227,7 @@ func TestMultiPolygonWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1252,7 +1281,7 @@ func TestGeometryCollectionWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetupGeometryCollection(t, test.DocShapeName, test.DocShapeTypes,
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1269,7 +1298,7 @@ func TestGeometryCollectionWithin(t *testing.T) {
 
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }
@@ -1301,7 +1330,7 @@ func TestGeometryCollectionPointWithin(t *testing.T) {
 		indexReader, closeFn, err := testCaseSetupGeometryCollection(t, test.DocShapeName, test.Types,
 			test.DocShapeVertices, i)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 
 		t.Run(test.Desc, func(t *testing.T) {
@@ -1317,7 +1346,7 @@ func TestGeometryCollectionPointWithin(t *testing.T) {
 		})
 		err = closeFn()
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err.Error())
 		}
 	}
 }

--- a/search/searcher/search_boolean_test.go
+++ b/search/searcher/search_boolean_test.go
@@ -15,6 +15,7 @@
 package searcher
 
 import (
+	"context"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/search"
@@ -22,7 +23,6 @@ import (
 )
 
 func TestBooleanSearch(t *testing.T) {
-
 	if twoDocIndex == nil {
 		t.Fatal("its null")
 	}
@@ -40,210 +40,213 @@ func TestBooleanSearch(t *testing.T) {
 	explainTrue := search.SearcherOptions{Explain: true}
 
 	// test 0
-	beerTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher}, explainTrue)
+	mustSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 1.0, explainTrue)
+	martyTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dustinTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
+	dustinTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	shouldSearcher, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher, dustinTermSearcher}, 0, explainTrue)
+	shouldSearcher, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{martyTermSearcher, dustinTermSearcher}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	steveTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher}, 0, explainTrue)
+	mustNotSearcher, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher, shouldSearcher, mustNotSearcher, explainTrue)
+	booleanSearcher, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher, shouldSearcher, mustNotSearcher, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 1
-	martyTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 1.0, explainTrue)
+	martyTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dustinTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
+	dustinTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	shouldSearcher2, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher2, dustinTermSearcher2}, 0, explainTrue)
+	shouldSearcher2, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{martyTermSearcher2, dustinTermSearcher2}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	steveTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher2, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher2}, 0, explainTrue)
+	mustNotSearcher2, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher2}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher2, err := NewBooleanSearcher(nil, twoDocIndexReader, nil, shouldSearcher2, mustNotSearcher2, explainTrue)
+	booleanSearcher2, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, nil, shouldSearcher2, mustNotSearcher2, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 2
-	steveTermSearcher3, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher3, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher3, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher3}, 0, explainTrue)
+	mustNotSearcher3, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher3}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher3, err := NewBooleanSearcher(nil, twoDocIndexReader, nil, nil, mustNotSearcher3, explainTrue)
+	booleanSearcher3, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, nil, nil, mustNotSearcher3, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 3
-	beerTermSearcher4, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher4, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher4, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher4}, explainTrue)
+	mustSearcher4, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher4}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	steveTermSearcher4, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher4, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher4, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher4}, 0, explainTrue)
+	mustNotSearcher4, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher4}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher4, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher4, nil, mustNotSearcher4, explainTrue)
+	booleanSearcher4, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher4, nil, mustNotSearcher4, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 4
-	beerTermSearcher5, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher5, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher5, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher5}, explainTrue)
+	mustSearcher5, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher5}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	steveTermSearcher5, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher5, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher5, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 1.0, explainTrue)
+	martyTermSearcher5, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher5, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher5, martyTermSearcher5}, 0, explainTrue)
+	mustNotSearcher5, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher5, martyTermSearcher5}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher5, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher5, nil, mustNotSearcher5, explainTrue)
+	booleanSearcher5, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher5, nil, mustNotSearcher5, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 5
-	beerTermSearcher6, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher6, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher6, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher6}, explainTrue)
+	mustSearcher6, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher6}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher6, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 1.0, explainTrue)
+	martyTermSearcher6, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dustinTermSearcher6, err := NewTermSearcher(nil, twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
+	dustinTermSearcher6, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	shouldSearcher6, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher6, dustinTermSearcher6}, 2, explainTrue)
+	shouldSearcher6, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{martyTermSearcher6, dustinTermSearcher6}, 2, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher6, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher6, shouldSearcher6, nil, explainTrue)
+	booleanSearcher6, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher6, shouldSearcher6, nil, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 6
-	beerTermSearcher7, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher7, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher7, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher7}, explainTrue)
+	mustSearcher7, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher7}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher7, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher7, nil, nil, explainTrue)
+	booleanSearcher7, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher7, nil, nil, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher7, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 5.0, explainTrue)
+	martyTermSearcher7, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	conjunctionSearcher7, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher7, booleanSearcher7}, explainTrue)
+	conjunctionSearcher7, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{martyTermSearcher7, booleanSearcher7}, explainTrue)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// test 7
-	beerTermSearcher8, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher8, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustSearcher8, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher8}, explainTrue)
+	mustSearcher8, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher8}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher8, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 1.0, explainTrue)
+	martyTermSearcher8, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dustinTermSearcher8, err := NewTermSearcher(nil, twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
+	dustinTermSearcher8, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "dustin", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	shouldSearcher8, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{martyTermSearcher8, dustinTermSearcher8}, 0, explainTrue)
+	shouldSearcher8, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{martyTermSearcher8, dustinTermSearcher8}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	steveTermSearcher8, err := NewTermSearcher(nil, twoDocIndexReader, "steve", "name", 1.0, explainTrue)
+	steveTermSearcher8, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "steve", "name", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustNotSearcher8, err := NewDisjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{steveTermSearcher8}, 0, explainTrue)
+	mustNotSearcher8, err := NewDisjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{steveTermSearcher8}, 0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	booleanSearcher8, err := NewBooleanSearcher(nil, twoDocIndexReader, mustSearcher8, shouldSearcher8, mustNotSearcher8, explainTrue)
+	booleanSearcher8, err := NewBooleanSearcher(context.TODO(), twoDocIndexReader, mustSearcher8, shouldSearcher8, mustNotSearcher8, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dustinTermSearcher8a, err := NewTermSearcher(nil, twoDocIndexReader, "dustin", "name", 5.0, explainTrue)
+	dustinTermSearcher8a, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "dustin", "name", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	conjunctionSearcher8, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{booleanSearcher8, dustinTermSearcher8a}, explainTrue)
+	conjunctionSearcher8, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{booleanSearcher8, dustinTermSearcher8a}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -15,6 +15,7 @@
 package searcher
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -39,93 +40,93 @@ func TestConjunctionSearch(t *testing.T) {
 	explainTrue := search.SearcherOptions{Explain: true}
 
 	// test 0
-	beerTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	martyTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "marty", "name", 5.0, explainTrue)
+	martyTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "marty", "name", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beerAndMartySearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher, martyTermSearcher}, explainTrue)
+	beerAndMartySearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher, martyTermSearcher}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 1
-	angstTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "angst", "desc", 1.0, explainTrue)
+	angstTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "angst", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beerTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	angstAndBeerSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{angstTermSearcher, beerTermSearcher2}, explainTrue)
+	angstAndBeerSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{angstTermSearcher, beerTermSearcher2}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 2
-	beerTermSearcher3, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher3, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	jackTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "jack", "name", 5.0, explainTrue)
+	jackTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "jack", "name", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beerAndJackSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher3, jackTermSearcher}, explainTrue)
+	beerAndJackSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher3, jackTermSearcher}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 3
-	beerTermSearcher4, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
+	beerTermSearcher4, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	misterTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "mister", "title", 5.0, explainTrue)
+	misterTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "mister", "title", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beerAndMisterSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher4, misterTermSearcher}, explainTrue)
+	beerAndMisterSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher4, misterTermSearcher}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 4
-	couchbaseTermSearcher, err := NewTermSearcher(nil, twoDocIndexReader, "couchbase", "street", 1.0, explainTrue)
+	couchbaseTermSearcher, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "couchbase", "street", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	misterTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "mister", "title", 5.0, explainTrue)
+	misterTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "mister", "title", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	couchbaseAndMisterSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{couchbaseTermSearcher, misterTermSearcher2}, explainTrue)
+	couchbaseAndMisterSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{couchbaseTermSearcher, misterTermSearcher2}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test 5
-	beerTermSearcher5, err := NewTermSearcher(nil, twoDocIndexReader, "beer", "desc", 5.0, explainTrue)
+	beerTermSearcher5, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "beer", "desc", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	couchbaseTermSearcher2, err := NewTermSearcher(nil, twoDocIndexReader, "couchbase", "street", 1.0, explainTrue)
+	couchbaseTermSearcher2, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "couchbase", "street", 1.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	misterTermSearcher3, err := NewTermSearcher(nil, twoDocIndexReader, "mister", "title", 5.0, explainTrue)
+	misterTermSearcher3, err := NewTermSearcher(context.TODO(), twoDocIndexReader, "mister", "title", 5.0, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	couchbaseAndMisterSearcher2, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{couchbaseTermSearcher2, misterTermSearcher3}, explainTrue)
+	couchbaseAndMisterSearcher2, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{couchbaseTermSearcher2, misterTermSearcher3}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	beerAndCouchbaseAndMisterSearcher, err := NewConjunctionSearcher(nil, twoDocIndexReader, []search.Searcher{beerTermSearcher5, couchbaseAndMisterSearcher2}, explainTrue)
+	beerAndCouchbaseAndMisterSearcher, err := NewConjunctionSearcher(context.TODO(), twoDocIndexReader, []search.Searcher{beerTermSearcher5, couchbaseAndMisterSearcher2}, explainTrue)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,29 +250,51 @@ func TestScorchCompositeSearchOptimizations(t *testing.T) {
 	}()
 
 	tests := []compositeSearchOptimizationTest{
-		{fieldTerms: []string{},
-			expectEmpty: "conjunction,disjunction"},
-		{fieldTerms: []string{"name:marty"},
-			expectEmpty: ""},
-		{fieldTerms: []string{"name:marty", "desc:beer"},
-			expectEmpty: ""},
-		{fieldTerms: []string{"name:marty", "name:marty"},
-			expectEmpty: ""},
-		{fieldTerms: []string{"name:marty", "desc:beer", "title:mister", "street:couchbase"},
-			expectEmpty: "conjunction"},
-		{fieldTerms: []string{"name:steve", "desc:beer", "title:mister", "street:couchbase"},
-			expectEmpty: ""},
+		{
+			fieldTerms:  []string{},
+			expectEmpty: "conjunction,disjunction",
+		},
+		{
+			fieldTerms:  []string{"name:marty"},
+			expectEmpty: "",
+		},
+		{
+			fieldTerms:  []string{"name:marty", "desc:beer"},
+			expectEmpty: "",
+		},
+		{
+			fieldTerms:  []string{"name:marty", "name:marty"},
+			expectEmpty: "",
+		},
+		{
+			fieldTerms:  []string{"name:marty", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: "conjunction",
+		},
+		{
+			fieldTerms:  []string{"name:steve", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: "",
+		},
 
-		{fieldTerms: []string{"name:NotARealName"},
-			expectEmpty: "conjunction,disjunction"},
-		{fieldTerms: []string{"name:NotARealName", "name:marty"},
-			expectEmpty: "conjunction"},
-		{fieldTerms: []string{"name:NotARealName", "name:marty", "desc:beer"},
-			expectEmpty: "conjunction"},
-		{fieldTerms: []string{"name:NotARealName", "name:marty", "name:marty"},
-			expectEmpty: "conjunction"},
-		{fieldTerms: []string{"name:NotARealName", "name:marty", "desc:beer", "title:mister", "street:couchbase"},
-			expectEmpty: "conjunction"},
+		{
+			fieldTerms:  []string{"name:NotARealName"},
+			expectEmpty: "conjunction,disjunction",
+		},
+		{
+			fieldTerms:  []string{"name:NotARealName", "name:marty"},
+			expectEmpty: "conjunction",
+		},
+		{
+			fieldTerms:  []string{"name:NotARealName", "name:marty", "desc:beer"},
+			expectEmpty: "conjunction",
+		},
+		{
+			fieldTerms:  []string{"name:NotARealName", "name:marty", "name:marty"},
+			expectEmpty: "conjunction",
+		},
+		{
+			fieldTerms:  []string{"name:NotARealName", "name:marty", "desc:beer", "title:mister", "street:couchbase"},
+			expectEmpty: "conjunction",
+		},
 	}
 
 	// The theme of this unit test is that given one of the above
@@ -281,14 +304,14 @@ func TestScorchCompositeSearchOptimizations(t *testing.T) {
 	// ID's from the search results from any of those combinations
 	// should be the same.
 	searcherOptionsToCompare := []search.SearcherOptions{
-		search.SearcherOptions{},
-		search.SearcherOptions{Explain: true},
-		search.SearcherOptions{IncludeTermVectors: true},
-		search.SearcherOptions{IncludeTermVectors: true, Explain: true},
-		search.SearcherOptions{Score: "none"},
-		search.SearcherOptions{Score: "none", IncludeTermVectors: true},
-		search.SearcherOptions{Score: "none", IncludeTermVectors: true, Explain: true},
-		search.SearcherOptions{Score: "none", Explain: true},
+		{},
+		{Explain: true},
+		{IncludeTermVectors: true},
+		{IncludeTermVectors: true, Explain: true},
+		{Score: "none"},
+		{Score: "none", IncludeTermVectors: true},
+		{Score: "none", IncludeTermVectors: true, Explain: true},
+		{Score: "none", Explain: true},
 	}
 
 	testScorchCompositeSearchOptimizations(t, twoDocIndexReader, tests,
@@ -301,7 +324,8 @@ func TestScorchCompositeSearchOptimizations(t *testing.T) {
 func testScorchCompositeSearchOptimizations(t *testing.T, indexReader index.IndexReader,
 	tests []compositeSearchOptimizationTest,
 	searcherOptionsToCompare []search.SearcherOptions,
-	compositeKind string) {
+	compositeKind string,
+) {
 	for testi := range tests {
 		resultsToCompare := map[string]bool{}
 
@@ -317,13 +341,13 @@ func testScorchCompositeSearchOptimizationsHelper(
 	t *testing.T, indexReader index.IndexReader,
 	tests []compositeSearchOptimizationTest, testi int,
 	searcherOptionsToCompare []search.SearcherOptions,
-	compositeKind string, allowOptimizations bool, resultsToCompare map[string]bool) {
+	compositeKind string, allowOptimizations bool, resultsToCompare map[string]bool,
+) {
 	// Save the global allowed optimization settings to restore later.
 	optimizeConjunction := scorch.OptimizeConjunction
 	optimizeConjunctionUnadorned := scorch.OptimizeConjunctionUnadorned
 	optimizeDisjunctionUnadorned := scorch.OptimizeDisjunctionUnadorned
-	optimizeDisjunctionUnadornedMinChildCardinality :=
-		scorch.OptimizeDisjunctionUnadornedMinChildCardinality
+	optimizeDisjunctionUnadornedMinChildCardinality := scorch.OptimizeDisjunctionUnadornedMinChildCardinality
 
 	scorch.OptimizeConjunction = allowOptimizations
 	scorch.OptimizeConjunctionUnadorned = allowOptimizations
@@ -337,8 +361,7 @@ func testScorchCompositeSearchOptimizationsHelper(
 		scorch.OptimizeConjunction = optimizeConjunction
 		scorch.OptimizeConjunctionUnadorned = optimizeConjunctionUnadorned
 		scorch.OptimizeDisjunctionUnadorned = optimizeDisjunctionUnadorned
-		scorch.OptimizeDisjunctionUnadornedMinChildCardinality =
-			optimizeDisjunctionUnadornedMinChildCardinality
+		scorch.OptimizeDisjunctionUnadornedMinChildCardinality = optimizeDisjunctionUnadornedMinChildCardinality
 	}()
 
 	test := tests[testi]
@@ -352,7 +375,7 @@ func testScorchCompositeSearchOptimizationsHelper(
 			field := ft[0]
 			term := ft[1]
 
-			searcher, err := NewTermSearcher(nil, indexReader, term, field, 1.0, searcherOptions)
+			searcher, err := NewTermSearcher(context.TODO(), indexReader, term, field, 1.0, searcherOptions)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -364,9 +387,9 @@ func testScorchCompositeSearchOptimizationsHelper(
 		var cs search.Searcher
 		var err error
 		if compositeKind == "conjunction" {
-			cs, err = NewConjunctionSearcher(nil, indexReader, searchers, searcherOptions)
+			cs, err = NewConjunctionSearcher(context.TODO(), indexReader, searchers, searcherOptions)
 		} else {
-			cs, err = NewDisjunctionSearcher(nil, indexReader, searchers, 0, searcherOptions)
+			cs, err = NewDisjunctionSearcher(context.TODO(), indexReader, searchers, 0, searcherOptions)
 		}
 		if err != nil {
 			t.Fatal(err)
@@ -393,6 +416,10 @@ func testScorchCompositeSearchOptimizationsHelper(
 			}
 
 			next, err = cs.Next(ctx)
+			if err != nil {
+				t.Fatalf("error iterating searcher: %v", err)
+			}
+
 			i++
 		}
 

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestTermRangeSearch(t *testing.T) {
-
 	twoDocIndexReader, err := twoDocIndex.Reader()
 	if err != nil {
 		t.Error(err)
@@ -200,7 +199,6 @@ func TestTermRangeSearch(t *testing.T) {
 		}
 
 	}
-
 }
 
 func TestTermRangeSearchTooManyTerms(t *testing.T) {
@@ -229,8 +227,8 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 		}
 	}()
 
-	var want = []string{"1", "3", "4", "5"}
-	var truth = true
+	want := []string{"1", "3", "4", "5"}
+	truth := true
 	searcher, err := NewTermRangeSearcher(nil, scorchReader, []byte("bobert"), []byte("ravi"),
 		&truth, &truth, "name", 1.0, search.SearcherOptions{Score: "none", IncludeTermVectors: false})
 	if err != nil {
@@ -252,6 +250,10 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 		got = append(got, extId)
 		ctx.DocumentMatchPool.Put(next)
 		next, err = searcher.Next(ctx)
+		if err != nil {
+			break
+		}
+
 		i++
 	}
 	if err != nil {

--- a/search_test.go
+++ b/search_test.go
@@ -87,23 +87,32 @@ func TestSortedFacetedQuery(t *testing.T) {
 		}
 	}()
 
-	index.Index("1", map[string]interface{}{
+	if err := index.Index("1", map[string]interface{}{
 		"country": "india",
 		"content": "k",
-	})
-	index.Index("2", map[string]interface{}{
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := index.Index("2", map[string]interface{}{
 		"country": "india",
 		"content": "l",
-	})
-	index.Index("3", map[string]interface{}{
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := index.Index("3", map[string]interface{}{
 		"country": "india",
 		"content": "k",
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := index.DocCount()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if d != 3 {
 		t.Errorf("expected 3, got %d", d)
 	}
@@ -156,18 +165,26 @@ func TestMatchAllScorer(t *testing.T) {
 		}
 	}()
 
-	index.Index("1", map[string]interface{}{
+	if err := index.Index("1", map[string]interface{}{
 		"country": "india",
 		"content": "k",
-	})
-	index.Index("2", map[string]interface{}{
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := index.Index("2", map[string]interface{}{
 		"country": "india",
 		"content": "l",
-	})
-	index.Index("3", map[string]interface{}{
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := index.Index("3", map[string]interface{}{
 		"country": "india",
 		"content": "k",
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := index.DocCount()
 	if err != nil {
@@ -196,7 +213,6 @@ func TestMatchAllScorer(t *testing.T) {
 }
 
 func TestSearchResultString(t *testing.T) {
-
 	tests := []struct {
 		result *SearchResult
 		str    string
@@ -309,7 +325,6 @@ func TestSearchResultMerge(t *testing.T) {
 }
 
 func TestUnmarshalingSearchResult(t *testing.T) {
-
 	searchResponse := []byte(`{
     "status":{
       "total":1,
@@ -356,11 +371,11 @@ func TestUnmarshalingSearchResult(t *testing.T) {
 }
 
 func TestFacetNumericDateRangeRequests(t *testing.T) {
-	var drMissingErr = fmt.Errorf("date range query must specify either start, end or both for range name 'testName'")
-	var nrMissingErr = fmt.Errorf("numeric range query must specify either min, max or both for range name 'testName'")
-	var drNrErr = fmt.Errorf("facet can only contain numeric ranges or date ranges, not both")
-	var drNameDupErr = fmt.Errorf("date ranges contains duplicate name 'testName'")
-	var nrNameDupErr = fmt.Errorf("numeric ranges contains duplicate name 'testName'")
+	drMissingErr := fmt.Errorf("date range query must specify either start, end or both for range name 'testName'")
+	nrMissingErr := fmt.Errorf("numeric range query must specify either min, max or both for range name 'testName'")
+	drNrErr := fmt.Errorf("facet can only contain numeric ranges or date ranges, not both")
+	drNameDupErr := fmt.Errorf("date ranges contains duplicate name 'testName'")
+	nrNameDupErr := fmt.Errorf("numeric ranges contains duplicate name 'testName'")
 	value := float64(5)
 
 	tests := []struct {
@@ -494,7 +509,6 @@ func TestFacetNumericDateRangeRequests(t *testing.T) {
 			t.Errorf("expected %#v, got %#v", test.result, result)
 		}
 	}
-
 }
 
 func TestSearchResultFacetsMerge(t *testing.T) {
@@ -1094,7 +1108,7 @@ func testBooleanMustNotSearcher(t *testing.T, indexName string) {
 	rhs := NewBooleanQuery()
 	rhs.AddMustNot(hasRole)
 
-	var compareLeftRightAndConjunction = func(idx Index, left, right query.Query) error {
+	compareLeftRightAndConjunction := func(idx Index, left, right query.Query) error {
 		// left
 		lr := NewSearchRequestOptions(left, 100, 0, false)
 		lres, err := idx.Search(lr)
@@ -2098,7 +2112,7 @@ func TestAnalyzerInheritance(t *testing.T) {
 	}
 
 	for i := range tests {
-		t.Run(fmt.Sprintf("%s", tests[i].name), func(t *testing.T) {
+		t.Run(tests[i].name, func(t *testing.T) {
 			idxMapping := NewIndexMapping()
 			if err := idxMapping.UnmarshalJSON([]byte(tests[i].mappingStr)); err != nil {
 				t.Fatal(err)
@@ -2495,9 +2509,9 @@ func TestCustomDateTimeParserLayoutValidation(t *testing.T) {
 			time.StampMilli,
 			time.StampMicro,
 			time.StampNano,
-			"2006-01-02 15:04:05", //time.DateTime
-			"2006-01-02",          //time.DateOnly
-			"15:04:05",            //time.TimeOnly
+			"2006-01-02 15:04:05", // time.DateTime
+			"2006-01-02",          // time.DateOnly
+			"15:04:05",            // time.TimeOnly
 
 			// Corrected layouts to the incorrect ones below.
 			"2006-01-02 03:04:05 -0700",
@@ -2590,7 +2604,6 @@ func TestDateRangeStringQuery(t *testing.T) {
 			"2006/01/02 3:04PM",
 		},
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2601,7 +2614,6 @@ func TestDateRangeStringQuery(t *testing.T) {
 			"02/01/2006 3:04PM",
 		},
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2873,6 +2885,7 @@ func TestDateRangeStringQuery(t *testing.T) {
 		}
 	}
 }
+
 func TestDateRangeFacetQueriesWithCustomDateTimeParser(t *testing.T) {
 	idxMapping := NewIndexMapping()
 
@@ -2883,7 +2896,6 @@ func TestDateRangeFacetQueriesWithCustomDateTimeParser(t *testing.T) {
 			"2006/01/02 3:04PM",
 		},
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2894,7 +2906,6 @@ func TestDateRangeFacetQueriesWithCustomDateTimeParser(t *testing.T) {
 			"02/01/2006 3:04PM",
 		},
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4019,118 +4030,118 @@ func TestSynonymSearchQueries(t *testing.T) {
 					He remains persistent even in the face of challenges.`,
 		},
 		"doc2": {
-			"text": `The tranquil surroundings of the retreat provide a perfect escape from the hustle and bustle of city life. 
-					Guests enjoy the peaceful atmosphere, which is perfect for relaxation and rejuvenation. 
-					The calm environment offers the ideal place to meditate and connect with nature. 
+			"text": `The tranquil surroundings of the retreat provide a perfect escape from the hustle and bustle of city life.
+					Guests enjoy the peaceful atmosphere, which is perfect for relaxation and rejuvenation.
+					The calm environment offers the ideal place to meditate and connect with nature.
 					Even the most stressed individuals find themselves feeling relaxed and at ease.`,
 		},
 		"doc3": {
-			"text": `The house was burned down, leaving only a charred shell behind. 
-					The intense heat of the flames caused the walls to warp and the roof to cave in. 
-					The seared remains of the furniture told the story of the blaze. 
+			"text": `The house was burned down, leaving only a charred shell behind.
+					The intense heat of the flames caused the walls to warp and the roof to cave in.
+					The seared remains of the furniture told the story of the blaze.
 					The incinerated remains left little more than ashes to remember what once was.`,
 		},
 		"doc4": {
-			"text": `The faithful dog followed its owner everywhere, always loyal and steadfast. 
-					It was devoted to protecting its family, and its reliable nature meant it could always be trusted. 
-					In the face of danger, the dog remained calm, knowing its role was to stay vigilant. 
+			"text": `The faithful dog followed its owner everywhere, always loyal and steadfast.
+					It was devoted to protecting its family, and its reliable nature meant it could always be trusted.
+					In the face of danger, the dog remained calm, knowing its role was to stay vigilant.
 					Its trustworthy companionship provided comfort and security.`,
 		},
 		"doc5": {
-			"text": `The lively market is bustling with activity from morning to night. 
-					The dynamic energy of the crowd fills the air as vendors sell their wares. 
-					Shoppers wander from stall to stall, captivated by the vibrant colors and energetic atmosphere. 
+			"text": `The lively market is bustling with activity from morning to night.
+					The dynamic energy of the crowd fills the air as vendors sell their wares.
+					Shoppers wander from stall to stall, captivated by the vibrant colors and energetic atmosphere.
 					This place is alive with movement and life.`,
 		},
 		"doc6": {
-			"text": `In moments of crisis, bravery shines through. 
-					It takes valor to step forward when others are afraid to act. 
-					Heroes are defined by their guts and nerve, taking risks to protect others. 
+			"text": `In moments of crisis, bravery shines through.
+					It takes valor to step forward when others are afraid to act.
+					Heroes are defined by their guts and nerve, taking risks to protect others.
 					Boldness in the face of danger is what sets them apart.`,
 		},
 		"doc7": {
-			"text": `Innovation is the driving force behind progress in every industry. 
-					The company fosters an environment of invention, encouraging creativity at every level. 
-					The focus on novelty and improvement means that ideas are always evolving. 
+			"text": `Innovation is the driving force behind progress in every industry.
+					The company fosters an environment of invention, encouraging creativity at every level.
+					The focus on novelty and improvement means that ideas are always evolving.
 					The development of new solutions is at the core of the company's mission.`,
 		},
 		"doc8": {
-			"text": `The blazing sunset cast a radiant glow over the horizon, painting the sky with hues of red and orange. 
-					The intense heat of the day gave way to a fiery display of color. 
-					As the sun set, the glowing light illuminated the landscape, creating a breathtaking scene. 
+			"text": `The blazing sunset cast a radiant glow over the horizon, painting the sky with hues of red and orange.
+					The intense heat of the day gave way to a fiery display of color.
+					As the sun set, the glowing light illuminated the landscape, creating a breathtaking scene.
 					The fiery sky was a sight to behold.`,
 		},
 		"doc9": {
-			"text": `The fertile soil of the valley makes it perfect for farming. 
-					The productive land yields abundant crops year after year. 
-					Farmers rely on the rich, fruitful ground to sustain their livelihoods. 
+			"text": `The fertile soil of the valley makes it perfect for farming.
+					The productive land yields abundant crops year after year.
+					Farmers rely on the rich, fruitful ground to sustain their livelihoods.
 					The area is known for its plentiful harvests, supporting both local communities and export markets.`,
 		},
 		"doc10": {
-			"text": `The arid desert is a vast, dry expanse with little water or vegetation. 
-					The barren landscape stretches as far as the eye can see, offering little respite from the scorching sun. 
-					The desolate environment is unforgiving to those who venture too far without preparation. 
+			"text": `The arid desert is a vast, dry expanse with little water or vegetation.
+					The barren landscape stretches as far as the eye can see, offering little respite from the scorching sun.
+					The desolate environment is unforgiving to those who venture too far without preparation.
 					The parched earth cracks under the heat, creating a harsh, unyielding terrain.`,
 		},
 		"doc11": {
-			"text": `The fox is known for its cunning and intelligence. 
-					As a predator, it relies on its sharp instincts to outwit its prey. 
-					Its vulpine nature makes it both mysterious and fascinating. 
+			"text": `The fox is known for its cunning and intelligence.
+					As a predator, it relies on its sharp instincts to outwit its prey.
+					Its vulpine nature makes it both mysterious and fascinating.
 					The fox's ability to hunt with precision and stealth is what makes it such a formidable hunter.`,
 		},
 		"doc12": {
-			"text": `The dog is often considered man's best friend due to its loyal nature. 
-					As a companion, the hound provides both protection and affection. 
-					The puppy quickly becomes a member of the family, always by your side. 
+			"text": `The dog is often considered man's best friend due to its loyal nature.
+					As a companion, the hound provides both protection and affection.
+					The puppy quickly becomes a member of the family, always by your side.
 					Its playful energy and unshakable loyalty make it a beloved pet.`,
 		},
 		"doc13": {
-			"text": `He worked tirelessly through the night, always persistent in his efforts. 
-					His industrious approach to problem-solving kept the project moving forward. 
-					No matter how difficult the task, he remained focused, always giving his best. 
+			"text": `He worked tirelessly through the night, always persistent in his efforts.
+					His industrious approach to problem-solving kept the project moving forward.
+					No matter how difficult the task, he remained focused, always giving his best.
 					His dedication paid off when the project was completed ahead of schedule.`,
 		},
 		"doc14": {
-			"text": `The river flowed calmly through the valley, its peaceful current offering a sense of tranquility. 
-					Fishermen relaxed by the banks, enjoying the calm waters that reflected the sky above. 
-					The tranquil nature of the river made it a perfect spot for meditation. 
+			"text": `The river flowed calmly through the valley, its peaceful current offering a sense of tranquility.
+					Fishermen relaxed by the banks, enjoying the calm waters that reflected the sky above.
+					The tranquil nature of the river made it a perfect spot for meditation.
 					As the day ended, the river's quiet flow brought a sense of peace.`,
 		},
 		"doc15": {
-			"text": `After the fire, all that was left was the charred remains of what once was. 
-					The seared walls of the house told a tragic story. 
-					The intensity of the blaze had burned everything in its path, leaving only the smoldering wreckage behind. 
+			"text": `After the fire, all that was left was the charred remains of what once was.
+					The seared walls of the house told a tragic story.
+					The intensity of the blaze had burned everything in its path, leaving only the smoldering wreckage behind.
 					The incinerated objects could not be salvaged, and the damage was beyond repair.`,
 		},
 		"doc16": {
-			"text": `The devoted employee always went above and beyond to complete his tasks. 
-					His steadfast commitment to the company made him a valuable team member. 
-					He was reliable, never failing to meet deadlines. 
+			"text": `The devoted employee always went above and beyond to complete his tasks.
+					His steadfast commitment to the company made him a valuable team member.
+					He was reliable, never failing to meet deadlines.
 					His trustworthiness earned him the respect of his colleagues, and was considered an
 					ingenious expert in his field.`,
 		},
 		"doc17": {
-			"text": `The city is vibrant, full of life and energy. 
-					The dynamic pace of the streets reflects the diverse culture of its inhabitants. 
-					People from all walks of life contribute to the energetic atmosphere. 
+			"text": `The city is vibrant, full of life and energy.
+					The dynamic pace of the streets reflects the diverse culture of its inhabitants.
+					People from all walks of life contribute to the energetic atmosphere.
 					The city's lively spirit can be felt in every corner, from the bustling markets to the lively festivals.`,
 		},
 		"doc18": {
-			"text": `In a moment of uncertainty, he made a bold decision that would change his life forever. 
-					It took courage and nerve to take the leap, but his bravery paid off. 
-					The guts to face the unknown allowed him to achieve something remarkable. 
+			"text": `In a moment of uncertainty, he made a bold decision that would change his life forever.
+					It took courage and nerve to take the leap, but his bravery paid off.
+					The guts to face the unknown allowed him to achieve something remarkable.
 					Being an bright scholar, the skill he demonstrated inspired those around him.`,
 		},
 		"doc19": {
-			"text": `Innovation is often born from necessity, and the lightbulb is a prime example. 
-					Thomas Edison's invention changed the world, offering a new way to see the night. 
-					The creativity involved in developing such a groundbreaking product sparked a wave of 
+			"text": `Innovation is often born from necessity, and the lightbulb is a prime example.
+					Thomas Edison's invention changed the world, offering a new way to see the night.
+					The creativity involved in developing such a groundbreaking product sparked a wave of
 					novelty in the scientific community. This improvement in technology continues to shape the modern world.
 					He was a clever academic and a smart researcher.`,
 		},
 		"doc20": {
-			"text": `The fiery volcano erupted with a force that shook the earth. Its radiant lava flowed down the sides, 
-					illuminating the night sky. The intense heat from the eruption could be felt miles away, as the 
+			"text": `The fiery volcano erupted with a force that shook the earth. Its radiant lava flowed down the sides,
+					illuminating the night sky. The intense heat from the eruption could be felt miles away, as the
 					glowing lava burned everything in its path. The fiery display was both terrifying and mesmerizing.`,
 		},
 	}
@@ -4211,7 +4222,7 @@ func TestSynonymSearchQueries(t *testing.T) {
 		return batches
 	}
 	// Create batches of 5 documents
-	var batchSize = 5
+	batchSize := 5
 	docBatches := createDocBatches(combinedDocIDs, batchSize)
 	if len(docBatches) == 0 {
 		t.Fatal("expected batches")
@@ -4389,11 +4400,16 @@ func TestSynonymSearchQueries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			cleanupTmpIndexPath(t, indexesPath[i])
 		}
 	}()
 	alias := NewIndexAlias(indexes...)
-	alias.SetIndexMapping(imap)
+
+	if err := alias.SetIndexMapping(imap); err != nil {
+		t.Fatal(err)
+	}
+
 	err = runTestQueries(alias)
 	if err != nil {
 		t.Fatal(err)
@@ -4425,7 +4441,11 @@ func TestSynonymSearchQueries(t *testing.T) {
 		aliases[numAliases-1].Add(indexes[numIndexes-1])
 	}
 	alias = NewIndexAlias()
-	alias.SetIndexMapping(imap)
+
+	if err := alias.SetIndexMapping(imap); err != nil {
+		t.Fatal(err)
+	}
+
 	for i := 0; i < numAliases; i++ {
 		alias.Add(aliases[i])
 	}
@@ -4491,7 +4511,9 @@ func TestGeoDistanceInSort(t *testing.T) {
 	}
 
 	for _, doc := range docs {
-		idx.Index(doc.id, map[string]interface{}{"geo": doc.point})
+		if err := idx.Index(doc.id, map[string]interface{}{"geo": doc.point}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	q := NewGeoDistanceQuery(qp[0], qp[1], "1000000m")

--- a/test/versus_score_test.go
+++ b/test/versus_score_test.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -44,11 +43,11 @@ func TestDisjunctionSearchScoreIndexWithCompositeFields(t *testing.T) {
 			"upsidedown: (%+v, %+v), scorch: (%+v, %+v)\n",
 			*upHits[0].Expl, *upHits[1].Expl, *scHits[0].Expl, *scHits[1].Expl)
 	}
-
 }
 
 func disjunctionQueryiOnIndexWithCompositeFields(indexName string,
-	t *testing.T) []*search.DocumentMatch {
+	t *testing.T,
+) []*search.DocumentMatch {
 	tmpIndexPath, err := os.MkdirTemp("", "bleve-testidx")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
@@ -134,8 +133,7 @@ func disjunctionQueryiOnIndexWithCompositeFields(indexName string,
 	}
 
 	if len(res.Hits) != 2 {
-		t.Errorf(fmt.Sprintf("indexType: %s Expected 2 hits, "+
-			"but got: %v", indexName, len(res.Hits)))
+		t.Errorf("indexType: %s Expected 2 hits, but got: %v", indexName, len(res.Hits))
 	}
 
 	return res.Hits

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/index/scorch"
@@ -400,7 +401,8 @@ func hitsById(res *bleve.SearchResult) map[string]*search.DocumentMatch {
 
 func (vt *VersusTest) run(indexTypeA, kvStoreA, indexTypeB, kvStoreB string,
 	cb func(versusTest *VersusTest, searchTemplates []string, idxA, idxB bleve.Index),
-	searchTemplates []string) {
+	searchTemplates []string,
+) {
 	if cb == nil {
 		cb = testVersusSearches
 	}
@@ -441,8 +443,6 @@ func (vt *VersusTest) run(indexTypeA, kvStoreA, indexTypeB, kvStoreB string,
 		vt.t.Fatalf("new using err: %v", err)
 	}
 	defer func() { _ = idxB.Close() }()
-
-	rand.Seed(0)
 
 	if vt.Bodies == nil {
 		vt.Bodies = vt.genBodies()
@@ -505,9 +505,11 @@ func (vt *VersusTest) genBodies() (rv [][]string) {
 }
 
 func (vt *VersusTest) genBody() (rv []string) {
-	m := rand.Intn(vt.MaxWordsPerDoc)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	m := rng.Intn(vt.MaxWordsPerDoc)
 	for j := 0; j < m; j++ {
-		rv = append(rv, vt.genWord(rand.Intn(vt.NumWords)))
+		rv = append(rv, vt.genWord(rng.Intn(vt.NumWords)))
 	}
 	return rv
 }


### PR DESCRIPTION
Since I started using this project on my production workloads, I would like to contribute to the project.

This first contribution is focused on the easy part of cleaning the code according to the common `golang linters`, like `golangci-lint` and `gopls`.  To impact the less possible in my contribution I started with `_test.go files`, I fixed some of the easy ones, there are too many and many of these linters warnings come from old go code.

I hope this contribution starts helping and standardizing the code according to the golang version used.
