### PR TITLE
Validate scorch routine options when creating or opening a Bleve Index.

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -160,13 +160,14 @@ func NewScorch(storeName string,
 	if ok {
 		rv.onAsyncError = RegistryAsyncErrorCallbacks[aecbName]
 	}
-	// validate any custom persistor/merger planner options
-	// to prevent an async error in the background routines.
+	// validate any custom persistor options to
+	// prevent an async error in the persistor routine
 	_, err = rv.parsePersisterOptions()
 	if err != nil {
 		return nil, err
 	}
-
+	// validate any custom merge planner options to
+	// prevent an async error in the merger routine
 	_, err = rv.parseMergePlannerOptions()
 	if err != nil {
 		return nil, err

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -160,6 +160,17 @@ func NewScorch(storeName string,
 	if ok {
 		rv.onAsyncError = RegistryAsyncErrorCallbacks[aecbName]
 	}
+	// validate any custom persistor/merger planner options
+	// to prevent an async error in the background routines.
+	_, err = rv.parsePersisterOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = rv.parseMergePlannerOptions()
+	if err != nil {
+		return nil, err
+	}
 
 	return rv, nil
 }


### PR DESCRIPTION
- If a malformed setting is used in the persistor/merger options, an async error is thrown leading to a crash loop in a live system.
- This PR adds a validation step to ensure that the options are valid before creating/opening the index.