### PR TITLE
fix: golangci-lint findings, fourth delivery

### DIFF
--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -137,8 +137,8 @@ func (o *OptimizeVR) Finish() error {
 }
 
 func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,
-	octx index.VectorOptimizableContext) (index.VectorOptimizableContext, error) {
-
+	octx index.VectorOptimizableContext,
+) (index.VectorOptimizableContext, error) {
 	if s.snapshot.parent.segPlugin.Version() < VectorSearchSupportedSegmentVersion {
 		return nil, fmt.Errorf("vector search not supported for this index, "+
 			"index's segment version %v, supported segment version for vector search %v",
@@ -146,8 +146,9 @@ func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,
 	}
 
 	if octx == nil {
-		octx = &OptimizeVR{snapshot: s.snapshot,
-			vrs: make(map[string][]*IndexSnapshotVectorReader),
+		octx = &OptimizeVR{
+			snapshot: s.snapshot,
+			vrs:      make(map[string][]*IndexSnapshotVectorReader),
 		}
 	}
 

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -724,7 +724,7 @@ func constructBM25PreSearchData(rv map[string]map[string]interface{}, sr *Search
 	bmStats := sr.BM25Stats
 	if bmStats != nil {
 		for _, index := range indexes {
-			rv[index.Name()][search.BM25PreSearchDataKey.String()] = &search.BM25Stats{
+			rv[index.Name()][search.BM25PreSearchDataKey] = &search.BM25Stats{
 				DocCount:         bmStats.DocCount,
 				FieldCardinality: bmStats.FieldCardinality,
 			}
@@ -866,9 +866,9 @@ func redistributePreSearchData(req *SearchRequest, indexes []Index) (map[string]
 		}
 	}
 
-	if bm25Data, ok := req.PreSearchData[search.BM25PreSearchDataKey.String()].(*search.BM25Stats); ok {
+	if bm25Data, ok := req.PreSearchData[search.BM25PreSearchDataKey].(*search.BM25Stats); ok {
 		for _, index := range indexes {
-			rv[index.Name()][search.BM25PreSearchDataKey.String()] = bm25Data
+			rv[index.Name()][search.BM25PreSearchDataKey] = bm25Data
 		}
 	}
 	return rv, nil

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -634,7 +634,7 @@ func preSearchRequired(ctx context.Context, req *SearchRequest, m mapping.IndexM
 func preSearch(ctx context.Context, req *SearchRequest, flags *preSearchFlags, indexes ...Index) (*SearchResult, error) {
 	// create a dummy request with a match none query
 	// since we only care about the preSearchData in PreSearch
-	var dummyQuery = req.Query
+	dummyQuery := req.Query
 	if !flags.bm25 && !flags.synonyms {
 		// create a dummy request with a match none query
 		// since we only care about the preSearchData in PreSearch
@@ -724,7 +724,7 @@ func constructBM25PreSearchData(rv map[string]map[string]interface{}, sr *Search
 	bmStats := sr.BM25Stats
 	if bmStats != nil {
 		for _, index := range indexes {
-			rv[index.Name()][search.BM25PreSearchDataKey] = &search.BM25Stats{
+			rv[index.Name()][search.BM25PreSearchDataKey.String()] = &search.BM25Stats{
 				DocCount:         bmStats.DocCount,
 				FieldCardinality: bmStats.FieldCardinality,
 			}
@@ -734,7 +734,8 @@ func constructBM25PreSearchData(rv map[string]map[string]interface{}, sr *Search
 }
 
 func constructPreSearchData(req *SearchRequest, flags *preSearchFlags,
-	preSearchResult *SearchResult, indexes []Index) (map[string]map[string]interface{}, error) {
+	preSearchResult *SearchResult, indexes []Index,
+) (map[string]map[string]interface{}, error) {
 	if flags == nil || preSearchResult == nil {
 		return nil, fmt.Errorf("invalid input, flags: %v, preSearchResult: %v", flags, preSearchResult)
 	}
@@ -762,7 +763,7 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, flags *preSear
 	asyncResults := make(chan *asyncSearchResult, len(indexes))
 	// run search on each index in separate go routine
 	var waitGroup sync.WaitGroup
-	var searchChildIndex = func(in Index, childReq *SearchRequest) {
+	searchChildIndex := func(in Index, childReq *SearchRequest) {
 		rv := asyncSearchResult{Name: in.Name()}
 		rv.Result, rv.Err = in.SearchInContext(ctx, childReq)
 		asyncResults <- &rv
@@ -865,9 +866,9 @@ func redistributePreSearchData(req *SearchRequest, indexes []Index) (map[string]
 		}
 	}
 
-	if bm25Data, ok := req.PreSearchData[search.BM25PreSearchDataKey].(*search.BM25Stats); ok {
+	if bm25Data, ok := req.PreSearchData[search.BM25PreSearchDataKey.String()].(*search.BM25Stats); ok {
 		for _, index := range indexes {
-			rv[index.Name()][search.BM25PreSearchDataKey] = bm25Data
+			rv[index.Name()][search.BM25PreSearchDataKey.String()] = bm25Data
 		}
 	}
 	return rv, nil
@@ -910,7 +911,6 @@ func hitsInCurrentPage(req *SearchRequest, hits []*search.DocumentMatch) []*sear
 // MultiSearch executes a SearchRequest across multiple Index objects,
 // then merges the results.  The indexes must honor any ctx deadline.
 func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[string]map[string]interface{}, indexes ...Index) (*SearchResult, error) {
-
 	searchStart := time.Now()
 	asyncResults := make(chan *asyncSearchResult, len(indexes))
 
@@ -925,7 +925,7 @@ func MultiSearch(ctx context.Context, req *SearchRequest, preSearchData map[stri
 	// run search on each index in separate go routine
 	var waitGroup sync.WaitGroup
 
-	var searchChildIndex = func(in Index, childReq *SearchRequest) {
+	searchChildIndex := func(in Index, childReq *SearchRequest) {
 		rv := asyncSearchResult{Name: in.Name()}
 		rv.Result, rv.Err = in.SearchInContext(ctx, childReq)
 		asyncResults <- &rv

--- a/index_impl.go
+++ b/index_impl.go
@@ -59,11 +59,21 @@ const storePath = "store"
 
 var mappingInternalKey = []byte("_mapping")
 
-const SearchQueryStartCallbackKey = "_search_query_start_callback_key"
-const SearchQueryEndCallbackKey = "_search_query_end_callback_key"
+type ContextKey string
 
-type SearchQueryStartCallbackFn func(size uint64) error
-type SearchQueryEndCallbackFn func(size uint64) error
+func (k ContextKey) String() string {
+	return string(k)
+}
+
+const (
+	SearchQueryStartCallbackKey ContextKey = "_search_query_start_callback_key"
+	SearchQueryEndCallbackKey   ContextKey = "_search_query_end_callback_key"
+)
+
+type (
+	SearchQueryStartCallbackFn func(size uint64) error
+	SearchQueryEndCallbackFn   func(size uint64) error
+)
 
 func indexStorePath(path string) string {
 	return path + string(os.PathSeparator) + storePath
@@ -412,10 +422,12 @@ func (i *indexImpl) Search(req *SearchRequest) (sr *SearchResult, err error) {
 	return i.SearchInContext(context.Background(), req)
 }
 
-var documentMatchEmptySize int
-var searchContextEmptySize int
-var facetResultEmptySize int
-var documentEmptySize int
+var (
+	documentMatchEmptySize int
+	searchContextEmptySize int
+	facetResultEmptySize   int
+	documentEmptySize      int
+)
 
 func init() {
 	var dm search.DocumentMatch
@@ -435,8 +447,8 @@ func init() {
 // needed to execute a search request.
 func memNeededForSearch(req *SearchRequest,
 	searcher search.Searcher,
-	topnCollector *collector.TopNCollector) uint64 {
-
+	topnCollector *collector.TopNCollector,
+) uint64 {
 	backingSize := req.Size + req.From + 1
 	if req.Size+req.From > collector.PreAllocSizeSkipCap {
 		backingSize = collector.PreAllocSizeSkipCap + 1
@@ -605,7 +617,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 					}
 					skipSynonymCollector = true
 				}
-			case search.BM25PreSearchDataKey:
+			case search.BM25PreSearchDataKey.String():
 				if v != nil {
 					bm25Data, ok = v.(*search.BM25Stats)
 					if !ok {
@@ -667,8 +679,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		totalSearchCost += bytesRead
 	}
 
-	ctx = context.WithValue(ctx, search.SearchIOStatsCallbackKey,
-		search.SearchIOStatsCallbackFunc(sendBytesRead))
+	ctx = context.WithValue(ctx, search.SearchIOStatsCallbackKey, search.SearchIOStatsCallbackFunc(sendBytesRead))
 
 	var bufPool *s2.GeoBufferPool
 	getBufferPool := func() *s2.GeoBufferPool {
@@ -679,8 +690,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		return bufPool
 	}
 
-	ctx = context.WithValue(ctx, search.GeoBufferPoolCallbackKey,
-		search.GeoBufferPoolCallbackFunc(getBufferPool))
+	ctx = context.WithValue(ctx, search.GeoBufferPoolCallbackKey, search.GeoBufferPoolCallbackFunc(getBufferPool))
 
 	searcher, err := req.Query.Searcher(ctx, indexReader, i.m, search.SearcherOptions{
 		Explain:            req.Explain,
@@ -847,7 +857,8 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 
 func LoadAndHighlightFields(hit *search.DocumentMatch, req *SearchRequest,
 	indexName string, r index.IndexReader,
-	highlighter highlight.Highlighter) (error, uint64) {
+	highlighter highlight.Highlighter,
+) (error, uint64) {
 	var totalStoredFieldsBytes uint64
 	if len(req.Fields) > 0 || highlighter != nil {
 		doc, err := r.Document(hit.ID)
@@ -1238,7 +1249,8 @@ func (i *indexImpl) CopyTo(d index.Directory) (err error) {
 }
 
 func (f FileSystemDirectory) GetWriter(filePath string) (io.WriteCloser,
-	error) {
+	error,
+) {
 	dir, file := filepath.Split(filePath)
 	if dir != "" {
 		err := os.MkdirAll(filepath.Join(string(f), dir), os.ModePerm)
@@ -1248,7 +1260,7 @@ func (f FileSystemDirectory) GetWriter(filePath string) (io.WriteCloser,
 	}
 
 	return os.OpenFile(filepath.Join(string(f), dir, file),
-		os.O_RDWR|os.O_CREATE, 0600)
+		os.O_RDWR|os.O_CREATE, 0o600)
 }
 
 func (i *indexImpl) FireIndexEvent() {

--- a/index_impl.go
+++ b/index_impl.go
@@ -59,6 +59,7 @@ const storePath = "store"
 
 var mappingInternalKey = []byte("_mapping")
 
+// ContextKey is used to identify the context key in the context.Context
 type ContextKey string
 
 func (k ContextKey) String() string {

--- a/index_impl.go
+++ b/index_impl.go
@@ -59,16 +59,9 @@ const storePath = "store"
 
 var mappingInternalKey = []byte("_mapping")
 
-// ContextKey is used to identify the context key in the context.Context
-type ContextKey string
-
-func (k ContextKey) String() string {
-	return string(k)
-}
-
 const (
-	SearchQueryStartCallbackKey ContextKey = "_search_query_start_callback_key"
-	SearchQueryEndCallbackKey   ContextKey = "_search_query_end_callback_key"
+	SearchQueryStartCallbackKey search.ContextKey = "_search_query_start_callback_key"
+	SearchQueryEndCallbackKey   search.ContextKey = "_search_query_end_callback_key"
 )
 
 type (
@@ -618,7 +611,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 					}
 					skipSynonymCollector = true
 				}
-			case search.BM25PreSearchDataKey.String():
+			case search.BM25PreSearchDataKey:
 				if v != nil {
 					bm25Data, ok = v.(*search.BM25Stats)
 					if !ok {

--- a/index_test.go
+++ b/index_test.go
@@ -2520,10 +2520,7 @@ func TestSearchQueryCallback(t *testing.T) {
 		return expErr
 	}
 
-	ctx := context.WithValue(
-		context.Background(),
-		SearchQueryStartCallbackKey,
-		SearchQueryStartCallbackFn(f))
+	ctx := context.WithValue(context.Background(), SearchQueryStartCallbackKey, SearchQueryStartCallbackFn(f))
 	_, err = index.SearchInContext(ctx, req)
 	if err != expErr {
 		t.Fatalf("Expected: %v, Got: %v", expErr, err)

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -105,7 +105,7 @@ func ParsePreSearchData(input []byte) (map[string]interface{}, error) {
 				rv = make(map[string]interface{})
 			}
 			rv[search.SynonymPreSearchDataKey] = value
-		case search.BM25PreSearchDataKey.String():
+		case search.BM25PreSearchDataKey:
 			var value *search.BM25Stats
 			if v != nil {
 				err := util.UnmarshalJSON(v, &value)
@@ -116,7 +116,7 @@ func ParsePreSearchData(input []byte) (map[string]interface{}, error) {
 			if rv == nil {
 				rv = make(map[string]interface{})
 			}
-			rv[search.BM25PreSearchDataKey.String()] = value
+			rv[search.BM25PreSearchDataKey] = value
 
 		}
 	}

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -105,7 +105,7 @@ func ParsePreSearchData(input []byte) (map[string]interface{}, error) {
 				rv = make(map[string]interface{})
 			}
 			rv[search.SynonymPreSearchDataKey] = value
-		case search.BM25PreSearchDataKey:
+		case search.BM25PreSearchDataKey.String():
 			var value *search.BM25Stats
 			if v != nil {
 				err := util.UnmarshalJSON(v, &value)
@@ -116,7 +116,7 @@ func ParsePreSearchData(input []byte) (map[string]interface{}, error) {
 			if rv == nil {
 				rv = make(map[string]interface{})
 			}
-			rv[search.BM25PreSearchDataKey] = value
+			rv[search.BM25PreSearchDataKey.String()] = value
 
 		}
 	}

--- a/search/util.go
+++ b/search/util.go
@@ -125,10 +125,6 @@ const (
 	// which scoring mechanism to use based on index mapping.
 	GetScoringModelCallbackKey ContextKey = "_get_scoring_model"
 
-	// BM25PreSearchDataKey is used to store the data gathered during the presearch
-	// phase which would be use in the actual search phase.
-	BM25PreSearchDataKey ContextKey = "_bm25_pre_search_data_key"
-
 	// SearchIOStatsCallbackKey is used to help the underlying searcher identify
 	SearchIOStatsCallbackKey ContextKey = "_search_io_stats_callback_key"
 
@@ -143,6 +139,15 @@ const (
 	// is performed, such that the scoring involved using these stats would be at a
 	// global level.
 	SearchTypeKey ContextKey = "_search_type_key"
+
+	// The following keys are used to invoke the callbacks at the start and end stages
+	// of optimizing the disjunction/conjunction searcher creation.
+	SearcherStartCallbackKey = "_searcher_start_callback_key"
+	SearcherEndCallbackKey   = "_searcher_end_callback_key"
+
+	// FieldTermSynonymMapKey is used to store and transport the synonym definitions data
+	// to the actual search phase which would use the synonyms to perform the search.
+	FieldTermSynonymMapKey ContextKey = "_field_term_synonym_map_key"
 )
 
 func RecordSearchCost(ctx context.Context,
@@ -178,18 +183,11 @@ type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
 const (
 	KnnPreSearchDataKey     = "_knn_pre_search_data_key"
 	SynonymPreSearchDataKey = "_synonym_pre_search_data_key"
-)
 
-// The following keys are used to invoke the callbacks at the start and end stages
-// of optimizing the disjunction/conjunction searcher creation.
-const (
-	SearcherStartCallbackKey = "_searcher_start_callback_key"
-	SearcherEndCallbackKey   = "_searcher_end_callback_key"
+	// BM25PreSearchDataKey is used to store the data gathered during the presearch
+	// phase which would be use in the actual search phase.
+	BM25PreSearchDataKey = "_bm25_pre_search_data_key"
 )
-
-// FieldTermSynonymMapKey is used to store and transport the synonym definitions data
-// to the actual search phase which would use the synonyms to perform the search.
-const FieldTermSynonymMapKey ContextKey = "_field_term_synonym_map_key"
 
 const GlobalScoring = "_global_scoring"
 

--- a/search/util.go
+++ b/search/util.go
@@ -142,8 +142,8 @@ const (
 
 	// The following keys are used to invoke the callbacks at the start and end stages
 	// of optimizing the disjunction/conjunction searcher creation.
-	SearcherStartCallbackKey = "_searcher_start_callback_key"
-	SearcherEndCallbackKey   = "_searcher_end_callback_key"
+	SearcherStartCallbackKey ContextKey = "_searcher_start_callback_key"
+	SearcherEndCallbackKey   ContextKey = "_searcher_end_callback_key"
 
 	// FieldTermSynonymMapKey is used to store and transport the synonym definitions data
 	// to the actual search phase which would use the synonyms to perform the search.
@@ -183,10 +183,7 @@ type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
 const (
 	KnnPreSearchDataKey     = "_knn_pre_search_data_key"
 	SynonymPreSearchDataKey = "_synonym_pre_search_data_key"
-
-	// BM25PreSearchDataKey is used to store the data gathered during the presearch
-	// phase which would be use in the actual search phase.
-	BM25PreSearchDataKey = "_bm25_pre_search_data_key"
+	BM25PreSearchDataKey    = "_bm25_pre_search_data_key"
 )
 
 const GlobalScoring = "_global_scoring"

--- a/search/util.go
+++ b/search/util.go
@@ -74,8 +74,6 @@ func MergeFieldTermLocations(dest []FieldTermLocation, matches []*DocumentMatch)
 	return dest
 }
 
-const SearchIOStatsCallbackKey = "_search_io_stats_callback_key"
-
 type SearchIOStatsCallbackFunc func(uint64)
 
 // Implementation of SearchIncrementalCostCallbackFn should handle the following messages
@@ -87,8 +85,11 @@ type SearchIOStatsCallbackFunc func(uint64)
 //     handled safely by the implementation.
 type SearchIncrementalCostCallbackFn func(SearchIncrementalCostCallbackMsg,
 	SearchQueryType, uint64)
-type SearchIncrementalCostCallbackMsg uint
-type SearchQueryType uint
+
+type (
+	SearchIncrementalCostCallbackMsg uint
+	SearchQueryType                  uint
+)
 
 const (
 	Term = SearchQueryType(1 << iota)
@@ -103,13 +104,50 @@ const (
 	DoneM
 )
 
-const SearchIncrementalCostKey = "_search_incremental_cost_key"
-const QueryTypeKey = "_query_type_key"
-const FuzzyMatchPhraseKey = "_fuzzy_match_phrase_key"
-const IncludeScoreBreakdownKey = "_include_score_breakdown_key"
+// ContextKey is used to identify the context key in the context.Context
+type ContextKey string
+
+func (c ContextKey) String() string {
+	return string(c)
+}
+
+const (
+	SearchIncrementalCostKey ContextKey = "_search_incremental_cost_key"
+	QueryTypeKey             ContextKey = "_query_type_key"
+	FuzzyMatchPhraseKey      ContextKey = "_fuzzy_match_phrase_key"
+	IncludeScoreBreakdownKey ContextKey = "_include_score_breakdown_key"
+
+	// PreSearchKey indicates whether to perform a preliminary search to gather necessary
+	// information which would be used in the actual search down the line.
+	PreSearchKey ContextKey = "_presearch_key"
+
+	// GetScoringModelCallbackKey is used to help the underlying searcher identify
+	// which scoring mechanism to use based on index mapping.
+	GetScoringModelCallbackKey ContextKey = "_get_scoring_model"
+
+	// BM25PreSearchDataKey is used to store the data gathered during the presearch
+	// phase which would be use in the actual search phase.
+	BM25PreSearchDataKey ContextKey = "_bm25_pre_search_data_key"
+
+	// SearchIOStatsCallbackKey is used to help the underlying searcher identify
+	SearchIOStatsCallbackKey ContextKey = "_search_io_stats_callback_key"
+
+	// GeoBufferPoolCallbackKey ContextKey is used to help the underlying searcher
+	GeoBufferPoolCallbackKey ContextKey = "_geo_buffer_pool_callback_key"
+
+	// SearchTypeKey is used to identify type of the search being performed.
+	//
+	// for consistent scoring in cases an index is partitioned/sharded (using an
+	// index alias), GlobalScoring helps in aggregating the necessary stats across
+	// all the child bleve indexes (shards/partitions) first before the actual search
+	// is performed, such that the scoring involved using these stats would be at a
+	// global level.
+	SearchTypeKey ContextKey = "_search_type_key"
+)
 
 func RecordSearchCost(ctx context.Context,
-	msg SearchIncrementalCostCallbackMsg, bytes uint64) {
+	msg SearchIncrementalCostCallbackMsg, bytes uint64,
+) {
 	if ctx != nil {
 		queryType, ok := ctx.Value(QueryTypeKey).(SearchQueryType)
 		if !ok {
@@ -125,52 +163,40 @@ func RecordSearchCost(ctx context.Context,
 	}
 }
 
-const GeoBufferPoolCallbackKey = "_geo_buffer_pool_callback_key"
-
 // Assigning the size of the largest buffer in the pool to 24KB and
 // the smallest buffer to 24 bytes. The pools are used to read a
 // sequence of vertices which are always 24 bytes each.
-const MaxGeoBufPoolSize = 24 * 1024
-const MinGeoBufPoolSize = 24
+const (
+	MaxGeoBufPoolSize = 24 * 1024
+	MinGeoBufPoolSize = 24
+)
 
 type GeoBufferPoolCallbackFunc func() *s2.GeoBufferPool
 
-// PreSearchKey indicates whether to perform a preliminary search to gather necessary
-// information which would be used in the actual search down the line.
-const PreSearchKey = "_presearch_key"
-
 // *PreSearchDataKey are used to store the data gathered during the presearch phase
 // which would be use in the actual search phase.
-const KnnPreSearchDataKey = "_knn_pre_search_data_key"
-const SynonymPreSearchDataKey = "_synonym_pre_search_data_key"
-const BM25PreSearchDataKey = "_bm25_pre_search_data_key"
-
-// SearchTypeKey is used to identify type of the search being performed.
-//
-// for consistent scoring in cases an index is partitioned/sharded (using an
-// index alias), GlobalScoring helps in aggregating the necessary stats across
-// all the child bleve indexes (shards/partitions) first before the actual search
-// is performed, such that the scoring involved using these stats would be at a
-// global level.
-const SearchTypeKey = "_search_type_key"
+const (
+	KnnPreSearchDataKey     = "_knn_pre_search_data_key"
+	SynonymPreSearchDataKey = "_synonym_pre_search_data_key"
+)
 
 // The following keys are used to invoke the callbacks at the start and end stages
 // of optimizing the disjunction/conjunction searcher creation.
-const SearcherStartCallbackKey = "_searcher_start_callback_key"
-const SearcherEndCallbackKey = "_searcher_end_callback_key"
+const (
+	SearcherStartCallbackKey = "_searcher_start_callback_key"
+	SearcherEndCallbackKey   = "_searcher_end_callback_key"
+)
 
 // FieldTermSynonymMapKey is used to store and transport the synonym definitions data
 // to the actual search phase which would use the synonyms to perform the search.
-const FieldTermSynonymMapKey = "_field_term_synonym_map_key"
+const FieldTermSynonymMapKey ContextKey = "_field_term_synonym_map_key"
 
 const GlobalScoring = "_global_scoring"
 
-// GetScoringModelCallbackKey is used to help the underlying searcher identify
-// which scoring mechanism to use based on index mapping.
-const GetScoringModelCallbackKey = "_get_scoring_model"
-
-type SearcherStartCallbackFn func(size uint64) error
-type SearcherEndCallbackFn func(size uint64) error
+type (
+	SearcherStartCallbackFn func(size uint64) error
+	SearcherEndCallbackFn   func(size uint64) error
+)
 
 type GetScoringModelCallbackFn func() string
 
@@ -199,8 +225,10 @@ func (f FieldTermSynonymMap) MergeWith(fts FieldTermSynonymMap) {
 // the default values are as per elastic search's implementation
 //   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-similarity.html#bm25
 //   - https://www.elastic.co/blog/practical-bm25-part-3-considerations-for-picking-b-and-k1-in-elasticsearch
-var BM25_k1 float64 = 1.2
-var BM25_b float64 = 0.75
+var (
+	BM25_k1 float64 = 1.2
+	BM25_b  float64 = 0.75
+)
 
 type BM25Stats struct {
 	DocCount         float64        `json:"doc_count"`


### PR DESCRIPTION
Since I started using this project on my production workloads, I would like to contribute to the project.

This fourth delivery is still fixing easy stuff like:

- minor formatting changes
- `golangci-lint run ./... | grep "SA1029"` 
  - index_impl.go:651:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_impl.go:642:32: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_impl.go:657:32: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_impl.go:676:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_impl.go:688:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_test.go:548:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_test.go:548:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - index_test.go:2525:3: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - search/query/disjunction.go:93:33: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - search/query/disjunction.go:93:33: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - search/query/geo_boundingbox.go:66:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
  - search/query/geo_boundingpolygon.go:64:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)

to fix this issue I created two custom types (enum) on the package `search`  and `bleve`

```go
...


type ContextKey string

func (c ContextKey) String() string {
	return string(c)
}

const (
	SearchQueryStartCallbackKey ContextKey = "_search_query_start_callback_key"
	SearchQueryEndCallbackKey   ContextKey = "_search_query_end_callback_key"
)

...
```

and then I grouped the `const` values used in the `context.WithValue` calls as part of the custom type (enum) created. 
