### PR TITLE
MB-65473: [BP] Refactor and Optimize Pre-Filtered Vector Search (#2169)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,15 @@ go 1.21
 
 require (
 	github.com/RoaringBitmap/roaring v1.9.3
-	github.com/bits-and-blooms/bitset v1.12.0
-	github.com/blevesearch/bleve_index_api v1.1.12
+	github.com/bits-and-blooms/bitset v1.22.0
+	github.com/blevesearch/bleve_index_api v1.2.1-0.20250407171239-fd7f57705029
 	github.com/blevesearch/geo v0.1.20
 	github.com/blevesearch/go-faiss v1.0.25
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1
 	github.com/blevesearch/gtreap v0.1.1
-	github.com/blevesearch/scorch_segment_api/v2 v2.2.16
+	github.com/blevesearch/scorch_segment_api/v2 v2.2.17-0.20250407171917-6fe0debd32b2
 	github.com/blevesearch/segment v0.9.1
 	github.com/blevesearch/snowball v0.6.1
 	github.com/blevesearch/snowballstem v0.9.0
@@ -24,7 +24,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.3.10
 	github.com/blevesearch/zapx/v14 v14.3.10
 	github.com/blevesearch/zapx/v15 v15.3.16
-	github.com/blevesearch/zapx/v16 v16.1.9-0.20241217210638-a0519e7caf3b
+	github.com/blevesearch/zapx/v16 v16.1.9-0.20250407172450-d7e1abd94198
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.12.0
 	github.com/blevesearch/bleve_index_api v1.1.12
 	github.com/blevesearch/geo v0.1.20
-	github.com/blevesearch/go-faiss v1.0.24
+	github.com/blevesearch/go-faiss v1.0.25
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+
 github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/geo v0.1.20 h1:paaSpu2Ewh/tn5DKn/FB5SzvH0EWupxHEIwbCk/QPqM=
 github.com/blevesearch/geo v0.1.20/go.mod h1:DVG2QjwHNMFmjo+ZgzrIq2sfCh6rIHzy9d9d0B59I6w=
-github.com/blevesearch/go-faiss v1.0.24 h1:K79IvKjoKHdi7FdiXEsAhxpMuns0x4fM0BO93bW5jLI=
-github.com/blevesearch/go-faiss v1.0.24/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=
+github.com/blevesearch/go-faiss v1.0.25/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
 github.com/RoaringBitmap/roaring v1.9.3 h1:t4EbC5qQwnisr5PrP9nt0IRhRTb9gMUgQF4t4S2OByM=
 github.com/RoaringBitmap/roaring v1.9.3/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+5kexNy1RXfegY=
-github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
+github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
+github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/blevesearch/bleve_index_api v1.2.1-0.20250407171239-fd7f57705029 h1:q7C4qHL4Y+yqNAXH5YnjUraYAJizaS53nZRNbGQi7WA=
+github.com/blevesearch/bleve_index_api v1.2.1-0.20250407171239-fd7f57705029/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/geo v0.1.20 h1:paaSpu2Ewh/tn5DKn/FB5SzvH0EWupxHEIwbCk/QPqM=
 github.com/blevesearch/geo v0.1.20/go.mod h1:DVG2QjwHNMFmjo+ZgzrIq2sfCh6rIHzy9d9d0B59I6w=
 github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=
@@ -19,8 +20,8 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.16 h1:uGvKVvG7zvSxCwcm4/ehBa9cCEuZVE+/zvrSl57QUVY=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.16/go.mod h1:VF5oHVbIFTu+znY1v30GjSpT5+9YFs9dV2hjvuh34F0=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.17-0.20250407171917-6fe0debd32b2 h1:Je3/kw5BR/7yo7GXHc7+EmccIkotvQHOJe486mlrjXg=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.17-0.20250407171917-6fe0debd32b2/go.mod h1:BvCHhDleyDmfz/jAAFgFBw9j/cZF99cXrghUPtnbx1Q=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -43,8 +44,8 @@ github.com/blevesearch/zapx/v14 v14.3.10 h1:SG6xlsL+W6YjhX5N3aEiL/2tcWh3DO75Bnz7
 github.com/blevesearch/zapx/v14 v14.3.10/go.mod h1:qqyuR0u230jN1yMmE4FIAuCxmahRQEOehF78m6oTgns=
 github.com/blevesearch/zapx/v15 v15.3.16 h1:Ct3rv7FUJPfPk99TI/OofdC+Kpb4IdyfdMH48sb+FmE=
 github.com/blevesearch/zapx/v15 v15.3.16/go.mod h1:Turk/TNRKj9es7ZpKK95PS7f6D44Y7fAFy8F4LXQtGg=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241217210638-a0519e7caf3b h1:ju9Az5YgrzCeK3M1QwvZIpxYhChkXp7/L0RhDYsxXoE=
-github.com/blevesearch/zapx/v16 v16.1.9-0.20241217210638-a0519e7caf3b/go.mod h1:BlrYNpOu4BvVRslmIG+rLtKhmjIaRhIbG8sb9scGTwI=
+github.com/blevesearch/zapx/v16 v16.1.9-0.20250407172450-d7e1abd94198 h1:PtyZSL5ipLnr0HQGQV0ksAM8xuytMyMw8IDpVlmu+KU=
+github.com/blevesearch/zapx/v16 v16.1.9-0.20250407172450-d7e1abd94198/go.mod h1:tVFqkTyBZKEF+WCenFJZ+EfTCMO+uuWSqIpvVKZmf9o=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 	segment_api "github.com/blevesearch/scorch_segment_api/v2"
@@ -65,27 +64,6 @@ func (o *OptimizeVR) Finish() error {
 	var errorsM sync.Mutex
 	var errors []error
 
-	var snapshotGlobalDocNums map[int]*roaring.Bitmap
-	var eligibleDocIDsMap map[string]map[int]*roaring.Bitmap
-	fields := make([]string, len(o.vrs))
-	for field := range o.vrs {
-		fields = append(fields, field)
-	}
-
-	if o.requiresFiltering {
-		snapshotGlobalDocNums = o.snapshot.globalDocNums()
-		eligibleDocIDsMap = make(map[string]map[int]*roaring.Bitmap)
-		for _, field := range fields {
-			vrs := o.vrs[field]
-			eligibleDocIDsMap[field] = make(map[int]*roaring.Bitmap)
-			for index, vr := range vrs {
-				if vr.eligibleDocIDs != nil && len(vr.eligibleDocIDs) > 0 {
-					eligibleDocIDsMap[field][index] = vr.getEligibleDocIDs()
-				}
-			}
-		}
-	}
-
 	defer o.invokeSearcherEndCallback()
 
 	wg := sync.WaitGroup{}
@@ -100,8 +78,7 @@ func (o *OptimizeVR) Finish() error {
 					<-semaphore // Release the semaphore slot
 					wg.Done()
 				}()
-				for _, field := range fields {
-					vrs := o.vrs[field]
+				for field, vrs := range o.vrs {
 					vecIndex, err := segment.InterpretVectorIndex(field,
 						o.requiresFiltering, origSeg.deleted)
 					if err != nil {
@@ -114,34 +91,19 @@ func (o *OptimizeVR) Finish() error {
 					// update the vector index size as a meta value in the segment snapshot
 					vectorIndexSize := vecIndex.Size()
 					origSeg.cachedMeta.updateMeta(field, vectorIndexSize)
-					for vrIdx, vr := range vrs {
+					for _, vr := range vrs {
 						var pl segment_api.VecPostingsList
 						var err error
 
 						// for each VR, populate postings list and iterators
 						// by passing the obtained vector index and getting similar vectors.
 
-						// Only applies to filtered kNN.
-						if vr.eligibleDocIDs != nil && len(vr.eligibleDocIDs) > 0 {
-							eligibleVectorInternalIDs := eligibleDocIDsMap[field][vrIdx]
-							eligibleVectorInternalIDsClone := eligibleVectorInternalIDs.Clone()
-							if snapshotGlobalDocNums != nil {
-								// Only the eligible documents belonging to this segment
-								// will get filtered out.
-								// There is no way to determine which doc belongs to which segment
-								eligibleVectorInternalIDsClone.And(snapshotGlobalDocNums[index])
-							}
-
-							eligibleLocalDocNums := make([]uint64, 0)
-							// get the (segment-)local document numbers
-							for _, docNum := range eligibleVectorInternalIDsClone.ToArray() {
-								localDocNum := o.snapshot.localDocNumFromGlobal(index,
-									uint64(docNum))
-								eligibleLocalDocNums = append(eligibleLocalDocNums, localDocNum)
-							}
-
+						// check if the vector reader is configured to use a pre-filter
+						// to filter out ineligible documents before performing
+						// kNN search.
+						if vr.eligibleSelector != nil {
 							pl, err = vecIndex.SearchWithFilter(vr.vector, vr.k,
-								eligibleLocalDocNums, vr.searchParams)
+								vr.eligibleSelector.SegmentEligibleDocs(index), vr.searchParams)
 						} else {
 							pl, err = vecIndex.Search(vr.vector, vr.k, vr.searchParams)
 						}
@@ -195,7 +157,7 @@ func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,
 	}
 	o.ctx = ctx
 	if !o.requiresFiltering {
-		o.requiresFiltering = len(s.eligibleDocIDs) > 0
+		o.requiresFiltering = s.eligibleSelector != nil
 	}
 
 	if o.snapshot != s.snapshot {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -473,31 +473,7 @@ func (is *IndexSnapshot) segmentIndexAndLocalDocNumFromGlobal(docNum uint64) (in
 			return is.offsets[x] > docNum
 		}) - 1
 
-	localDocNum := is.localDocNumFromGlobal(segmentIndex, docNum)
-	return int(segmentIndex), localDocNum
-}
-
-// This function returns the local docnum, given the segment index and global docnum
-func (is *IndexSnapshot) localDocNumFromGlobal(segmentIndex int, docNum uint64) uint64 {
-	return docNum - is.offsets[segmentIndex]
-}
-
-// Function to return a mapping of the segment index to the live global	doc nums
-// in the segment of the specified index snapshot.
-func (is *IndexSnapshot) globalDocNums() map[int]*roaring.Bitmap {
-	if len(is.segment) == 0 {
-		return nil
-	}
-
-	segmentIndexGlobalDocNums := make(map[int]*roaring.Bitmap)
-
-	for i := range is.segment {
-		segmentIndexGlobalDocNums[i] = roaring.NewBitmap()
-		for _, localDocNum := range is.segment[i].DocNumbersLive().ToArray() {
-			segmentIndexGlobalDocNums[i].Add(localDocNum + uint32(is.offsets[i]))
-		}
-	}
-	return segmentIndexGlobalDocNums
+	return int(segmentIndex), docNum - is.offsets[segmentIndex]
 }
 
 func (is *IndexSnapshot) ExternalID(id index.IndexInternalID) (string, error) {
@@ -516,6 +492,15 @@ func (is *IndexSnapshot) ExternalID(id index.IndexInternalID) (string, error) {
 	}
 
 	return string(v), nil
+}
+
+func (is *IndexSnapshot) segmentIndexAndLocalDocNum(id index.IndexInternalID) (int, uint64, error) {
+	docNum, err := docInternalToNumber(id)
+	if err != nil {
+		return 0, 0, err
+	}
+	segIdx, localDocNum := is.segmentIndexAndLocalDocNumFromGlobal(docNum)
+	return segIdx, localDocNum, nil
 }
 
 func (is *IndexSnapshot) InternalID(id string) (rv index.IndexInternalID, err error) {

--- a/index/scorch/snapshot_index_vr.go
+++ b/index/scorch/snapshot_index_vr.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/blevesearch/bleve/v2/size"
 	index "github.com/blevesearch/bleve_index_api"
 	segment_api "github.com/blevesearch/scorch_segment_api/v2"
@@ -51,32 +50,8 @@ type IndexSnapshotVectorReader struct {
 	currID        index.IndexInternalID
 	ctx           context.Context
 
-	searchParams json.RawMessage
-
-	// The following fields are only applicable for vector readers which will
-	// process pre-filtered kNN queries.
-	eligibleDocIDs []index.IndexInternalID
-}
-
-// Function to convert the internal IDs of the eligible documents to a type suitable
-// for addition to a bitmap.
-// Useful to have the eligible doc IDs in a bitmap to leverage the fast intersection
-// (AND) operations. Eg. finding the eligible doc IDs present in a segment.
-func (i *IndexSnapshotVectorReader) getEligibleDocIDs() *roaring.Bitmap {
-	res := roaring.NewBitmap()
-	if len(i.eligibleDocIDs) > 0 {
-		internalDocIDs := make([]uint32, 0, len(i.eligibleDocIDs))
-		// converts the doc IDs to uint32 and returns
-		for _, eligibleDocInternalID := range i.eligibleDocIDs {
-			internalDocID, err := docInternalToNumber(index.IndexInternalID(eligibleDocInternalID))
-			if err != nil {
-				continue
-			}
-			internalDocIDs = append(internalDocIDs, uint32(internalDocID))
-		}
-		res.AddMany(internalDocIDs)
-	}
-	return res
+	searchParams     json.RawMessage
+	eligibleSelector index.EligibleDocumentSelector
 }
 
 func (i *IndexSnapshotVectorReader) Size() int {
@@ -134,17 +109,8 @@ func (i *IndexSnapshotVectorReader) Advance(ID index.IndexInternalID,
 	preAlloced *index.VectorDoc) (*index.VectorDoc, error) {
 
 	if i.currPosting != nil && bytes.Compare(i.currID, ID) >= 0 {
-		var i2 index.VectorReader
-		var err error
-
-		if len(i.eligibleDocIDs) > 0 {
-			i2, err = i.snapshot.VectorReaderWithFilter(i.ctx, i.vector, i.field,
-				i.k, i.searchParams, i.eligibleDocIDs)
-		} else {
-			i2, err = i.snapshot.VectorReader(i.ctx, i.vector, i.field, i.k,
-				i.searchParams)
-		}
-
+		i2, err := i.snapshot.VectorReader(i.ctx, i.vector, i.field, i.k,
+			i.searchParams, i.eligibleSelector)
 		if err != nil {
 			return nil, err
 		}

--- a/index/scorch/snapshot_vector_index.go
+++ b/index/scorch/snapshot_vector_index.go
@@ -20,21 +20,23 @@ package scorch
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	index "github.com/blevesearch/bleve_index_api"
 	segment_api "github.com/blevesearch/scorch_segment_api/v2"
 )
 
 func (is *IndexSnapshot) VectorReader(ctx context.Context, vector []float32,
-	field string, k int64, searchParams json.RawMessage) (
+	field string, k int64, searchParams json.RawMessage,
+	eligibleSelector index.EligibleDocumentSelector) (
 	index.VectorReader, error) {
-
 	rv := &IndexSnapshotVectorReader{
-		vector:       vector,
-		field:        field,
-		k:            k,
-		snapshot:     is,
-		searchParams: searchParams,
+		vector:           vector,
+		field:            field,
+		k:                k,
+		snapshot:         is,
+		searchParams:     searchParams,
+		eligibleSelector: eligibleSelector,
 	}
 
 	if rv.postings == nil {
@@ -43,34 +45,41 @@ func (is *IndexSnapshot) VectorReader(ctx context.Context, vector []float32,
 	if rv.iterators == nil {
 		rv.iterators = make([]segment_api.VecPostingsIterator, len(is.segment))
 	}
-
 	// initialize postings and iterators within the OptimizeVR's Finish()
-
 	return rv, nil
 }
 
-func (is *IndexSnapshot) VectorReaderWithFilter(ctx context.Context, vector []float32,
-	field string, k int64, searchParams json.RawMessage,
-	filterIDs []index.IndexInternalID) (
-	index.VectorReader, error) {
+// eligibleDocumentSelector is used to filter out documents that are eligible for
+// the KNN search from a pre-filter query.
+type eligibleDocumentSelector struct {
+	// segment ID -> segment local doc nums
+	eligibleDocNums map[int][]uint64
+	is              *IndexSnapshot
+}
 
-	rv := &IndexSnapshotVectorReader{
-		vector:         vector,
-		field:          field,
-		k:              k,
-		snapshot:       is,
-		searchParams:   searchParams,
-		eligibleDocIDs: filterIDs,
+// SegmentEligibleDocs returns the list of eligible local doc numbers for the given segment.
+func (eds *eligibleDocumentSelector) SegmentEligibleDocs(segmentID int) []uint64 {
+	return eds.eligibleDocNums[segmentID]
+}
+
+// AddEligibleDocumentMatch adds a document match to the list of eligible documents.
+func (eds *eligibleDocumentSelector) AddEligibleDocumentMatch(id index.IndexInternalID) error {
+	if eds.is == nil {
+		return fmt.Errorf("eligibleDocumentSelector is not initialized with IndexSnapshot")
 	}
-
-	if rv.postings == nil {
-		rv.postings = make([]segment_api.VecPostingsList, len(is.segment))
+	// Get the segment number and the local doc number for this document.
+	segIdx, docNum, err := eds.is.segmentIndexAndLocalDocNum(id)
+	if err != nil {
+		return err
 	}
-	if rv.iterators == nil {
-		rv.iterators = make([]segment_api.VecPostingsIterator, len(is.segment))
+	// Add the local doc number to the list of eligible doc numbers for this segment.
+	eds.eligibleDocNums[segIdx] = append(eds.eligibleDocNums[segIdx], docNum)
+	return nil
+}
+
+func (is *IndexSnapshot) NewEligibleDocumentSelector() index.EligibleDocumentSelector {
+	return &eligibleDocumentSelector{
+		eligibleDocNums: map[int][]uint64{},
+		is:              is,
 	}
-
-	// initialize postings and iterators within the OptimizeVR's Finish()
-
-	return rv, nil
 }

--- a/search.go
+++ b/search.go
@@ -589,3 +589,13 @@ func (r *SearchRequest) SortFunc() func(data sort.Interface) {
 
 	return sort.Sort
 }
+
+func isMatchNoneQuery(q query.Query) bool {
+	_, ok := q.(*query.MatchNoneQuery)
+	return ok
+}
+
+func isMatchAllQuery(q query.Query) bool {
+	_, ok := q.(*query.MatchAllQuery)
+	return ok
+}

--- a/search/query/knn.go
+++ b/search/query/knn.go
@@ -35,9 +35,11 @@ type KNNQuery struct {
 	BoostVal    *Boost    `json:"boost,omitempty"`
 
 	// see KNNRequest.Params for description
-	Params        json.RawMessage `json:"params"`
-	FilterQuery   Query           `json:"filter,omitempty"`
-	filterResults []index.IndexInternalID
+	Params      json.RawMessage `json:"params"`
+	FilterQuery Query           `json:"filter,omitempty"`
+	// elegibleSelector is used to filter out documents that are
+	// eligible for the KNN search from a pre-filter query.
+	elegibleSelector index.EligibleDocumentSelector
 }
 
 func NewKNNQuery(vector []float32) *KNNQuery {
@@ -69,12 +71,8 @@ func (q *KNNQuery) SetParams(params json.RawMessage) {
 	q.Params = params
 }
 
-func (q *KNNQuery) SetFilterQuery(f Query) {
-	q.FilterQuery = f
-}
-
-func (q *KNNQuery) SetFilterResults(results []index.IndexInternalID) {
-	q.filterResults = results
+func (q *KNNQuery) SetEligibleSelector(eligibleSelector index.EligibleDocumentSelector) {
+	q.elegibleSelector = eligibleSelector
 }
 
 func (q *KNNQuery) Searcher(ctx context.Context, i index.IndexReader,
@@ -94,5 +92,5 @@ func (q *KNNQuery) Searcher(ctx context.Context, i index.IndexReader,
 
 	return searcher.NewKNNSearcher(ctx, i, m, options, q.VectorField,
 		q.Vector, q.K, q.BoostVal.Value(), similarityMetric, q.Params,
-		q.filterResults)
+		q.elegibleSelector)
 }

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -1371,8 +1371,7 @@ func TestKNNOperator(t *testing.T) {
 
 	// Conjunction
 	searchRequest.AddKNNOperator(knnOperatorAnd)
-	requiresFiltering := make(map[int]bool)
-	conjunction, _, _, err := createKNNQuery(searchRequest, nil, requiresFiltering)
+	conjunction, _, _, err := createKNNQuery(searchRequest, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for AND knn operator")
 	}
@@ -1388,7 +1387,7 @@ func TestKNNOperator(t *testing.T) {
 
 	// Disjunction
 	searchRequest.AddKNNOperator(knnOperatorOr)
-	disjunction, _, _, err := createKNNQuery(searchRequest, nil, requiresFiltering)
+	disjunction, _, _, err := createKNNQuery(searchRequest, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for OR knn operator")
 	}
@@ -1404,7 +1403,7 @@ func TestKNNOperator(t *testing.T) {
 
 	// Incorrect operator.
 	searchRequest.AddKNNOperator("bs_op")
-	searchRequest.Query, _, _, err = createKNNQuery(searchRequest, nil, requiresFiltering)
+	searchRequest.Query, _, _, err = createKNNQuery(searchRequest, nil)
 	if err == nil {
 		t.Fatalf("expected error for incorrect knn operator")
 	}


### PR DESCRIPTION
- Refactor pre-filtered vector search to enhance performance and reduce memory footprint.
- Replace the current bitmap-based approach for calculating segment local document numbers with a more direct method, where the local document numbers are mapped directly to the segment ID during the execution of the eligible collector.
- Requires:
    - https://github.com/blevesearch/bleve_index_api/pull/67
    - https://github.com/blevesearch/zapx/pull/320
    - https://github.com/blevesearch/go-faiss/pull/41
    - https://github.com/blevesearch/faiss/pull/49

---------