### PR TITLE
Refactor error handling in collectors to use user-friendly error messages

### DIFF
--- a/search/collector/eligible.go
+++ b/search/collector/eligible.go
@@ -93,7 +93,7 @@ func (ec *EligibleCollector) Collect(ctx context.Context, searcher search.Search
 	select {
 	case <-ctx.Done():
 		search.RecordSearchCost(ctx, search.AbortM, 0)
-		return ctx.Err()
+		return search.ContextError(ctx)
 	default:
 		next, err = searcher.Next(searchContext)
 	}
@@ -102,7 +102,7 @@ func (ec *EligibleCollector) Collect(ctx context.Context, searcher search.Search
 			select {
 			case <-ctx.Done():
 				search.RecordSearchCost(ctx, search.AbortM, 0)
-				return ctx.Err()
+				return search.ContextError(ctx)
 			default:
 			}
 		}

--- a/search/collector/knn.go
+++ b/search/collector/knn.go
@@ -176,7 +176,7 @@ func (hc *KNNCollector) Collect(ctx context.Context, searcher search.Searcher, r
 	select {
 	case <-ctx.Done():
 		search.RecordSearchCost(ctx, search.AbortM, 0)
-		return ctx.Err()
+		return search.ContextError(ctx)
 	default:
 		next, err = searcher.Next(searchContext)
 	}
@@ -185,7 +185,7 @@ func (hc *KNNCollector) Collect(ctx context.Context, searcher search.Searcher, r
 			select {
 			case <-ctx.Done():
 				search.RecordSearchCost(ctx, search.AbortM, 0)
-				return ctx.Err()
+				return search.ContextError(ctx)
 			default:
 			}
 		}

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -233,7 +233,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 	select {
 	case <-ctx.Done():
 		search.RecordSearchCost(ctx, search.AbortM, 0)
-		return ctx.Err()
+		return search.ContextError(ctx)
 	default:
 		next, err = searcher.Next(searchContext)
 	}
@@ -242,7 +242,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, searcher search.Searcher, 
 			select {
 			case <-ctx.Done():
 				search.RecordSearchCost(ctx, search.AbortM, 0)
-				return ctx.Err()
+				return search.ContextError(ctx)
 			default:
 			}
 		}

--- a/search/util.go
+++ b/search/util.go
@@ -16,6 +16,7 @@ package search
 
 import (
 	"context"
+	"errors"
 
 	"github.com/blevesearch/geo/s2"
 )
@@ -205,4 +206,21 @@ var BM25_b float64 = 0.75
 type BM25Stats struct {
 	DocCount         float64        `json:"doc_count"`
 	FieldCardinality map[string]int `json:"field_cardinality"`
+}
+
+// Human-readable errors for query timeout and cancellation,
+// used instead of the generic context errors.
+var ErrorQueryReqTimeout = errors.New("query request timeout")
+var ErrorQueryReqCanceled = errors.New("query request canceled")
+
+// ContextError maps context errors to human-readable query errors.
+func ContextError(ctx context.Context) error {
+	switch ctx.Err() {
+	case context.DeadlineExceeded:
+		return ErrorQueryReqTimeout
+	case context.Canceled:
+		return ErrorQueryReqCanceled
+	default:
+		return ctx.Err()
+	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -331,7 +331,7 @@ func TestUnmarshalingSearchResult(t *testing.T) {
       "failed":1,
       "successful":0,
       "errors":{
-        "default_index_362ce020b3d62b13_348f5c3c":"context deadline exceeded"
+        "default_index_362ce020b3d62b13_348f5c3c":"query request timeout"
       }
     },
     "request":{


### PR DESCRIPTION
- When a request times out, Bleve currently returns the Go-specific error "context deadline exceeded", which can be confusing or unclear to end users.
- To improve clarity, introduce an alias error with a more descriptive message such as "query request timeout".