### PR TITLE
MB-60971: update the bolt with the correct file segments

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -481,8 +481,9 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		return false, nil
 	}
 
-	// drains out (after merging in memory) the segments in the flushSet parallely
-	newSnapshot, newSegmentIDs, err := s.mergeSegmentBasesParallel(snapshot, flushSet)
+	// the newSnapshot at this point would contain the newly created file segments
+	// and updated with the root.
+	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet)
 	if err != nil {
 		return false, err
 	}
@@ -529,7 +530,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		}
 	}
 
-	// append to the equiv the new segment
+	// append to the equiv the newly merged segments
 	for _, segment := range newSnapshot.segment {
 		if _, ok := newMergedSegmentIDs[segment.id]; ok {
 			equiv.segment = append(equiv.segment, &SegmentSnapshot{

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -538,7 +538,6 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 				deleted: nil, // nil since merging handled deletions
 				stats:   nil,
 			})
-			break
 		}
 	}
 


### PR DESCRIPTION
- This is applicable to concurrent persister algorithm (introduced in v2.5.0) - which is not _ON_ by default.
- In cases where the persister creates new file segments, the bolt file is supposed to be updated with the complete set of file segments. 
- However currently, while loading the index from the bolt source, there can be data loss issues because a set of segments associated with the root snapshot weren't tracked in the bolt file and hence wouldn't be loaded from the disk.
- Note that the live index doesn't have issues because the root would track the live persisted segments and point to the corresponding files. 
- Also added some better code comments