### PR TITLE
MB-66271: Fix presearch result status on errors

### DIFF
--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -829,6 +829,11 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, flags *preSear
 			sr.Status.Total++
 			sr.Status.Failed++
 		}
+		// At this point, all errors have been recorded—either from the preSearch phase
+		// (via status.Merge) or from individual index search failures (indexErrors).
+		// Since partial results are not allowed, mark the entire request as failed.
+		sr.Status.Successful = 0
+		sr.Status.Failed = sr.Status.Total
 	} else {
 		prp.finalize(sr)
 	}

--- a/index_alias_impl.go
+++ b/index_alias_impl.go
@@ -827,7 +827,6 @@ func preSearchDataSearch(ctx context.Context, req *SearchRequest, flags *preSear
 		for indexName, indexErr := range indexErrors {
 			sr.Status.Errors[indexName] = indexErr
 			sr.Status.Total++
-			sr.Status.Failed++
 		}
 		// At this point, all errors have been recorded—either from the preSearch phase
 		// (via status.Merge) or from individual index search failures (indexErrors).


### PR DESCRIPTION
- If any index participating in a presearch returns an error, the entire presearch is considered failed, as partial results are not allowed for maintaining query consistency and accuracy.
- Previously, even though no hits were returned in such cases, the status could incorrectly indicate that some indexes succeeded—suggesting partial results existed when they didn't.
- This PR fixes the inconsistency by setting `status.Failed = status.Total` and `status.Successful = 0`, ensuring the status accurately reflects the absence of results.