### PR TITLE
MB-66295: avoid redundant calculation of bm25 metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,14 @@ toolchain go1.23.5
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.4.5
 	github.com/bits-and-blooms/bitset v1.22.0
-	github.com/blevesearch/bleve_index_api v1.2.7
+	github.com/blevesearch/bleve_index_api v1.2.8
 	github.com/blevesearch/geo v0.1.20
 	github.com/blevesearch/go-faiss v1.0.25
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1
 	github.com/blevesearch/gtreap v0.1.1
-	github.com/blevesearch/scorch_segment_api/v2 v2.3.9
+	github.com/blevesearch/scorch_segment_api/v2 v2.3.10
 	github.com/blevesearch/segment v0.9.1
 	github.com/blevesearch/snowball v0.6.1
 	github.com/blevesearch/snowballstem v0.9.0
@@ -26,7 +26,7 @@ require (
 	github.com/blevesearch/zapx/v13 v13.4.1
 	github.com/blevesearch/zapx/v14 v14.4.1
 	github.com/blevesearch/zapx/v15 v15.4.1
-	github.com/blevesearch/zapx/v16 v16.2.2
+	github.com/blevesearch/zapx/v16 v16.2.3
 	github.com/couchbase/moss v0.2.0
 	github.com/golang/protobuf v1.3.2
 	github.com/spf13/cobra v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,5 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 )
+
+replace github.com/blevesearch/bleve_index_api => /Users/thejas.orkombu/fts/blevesearch/bleve_index_api

--- a/go.mod
+++ b/go.mod
@@ -45,5 +45,3 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 )
-
-replace github.com/blevesearch/bleve_index_api => /Users/thejas.orkombu/fts/blevesearch/bleve_index_api

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/RoaringBitmap/roaring/v2 v2.4.5/go.mod h1:FiJcsfkGje/nZBZgCu0ZxCPOKD/
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.2.7 h1:c8r9vmbaYQroAMSGag7zq5gEVPiuXrUQDqfnj7uYZSY=
-github.com/blevesearch/bleve_index_api v1.2.7/go.mod h1:rKQDl4u51uwafZxFrPD1R7xFOwKnzZW7s/LSeK4lgo0=
+github.com/blevesearch/bleve_index_api v1.2.8 h1:Y98Pu5/MdlkRyLM0qDHostYo7i+Vv1cDNhqTeR4Sy6Y=
+github.com/blevesearch/bleve_index_api v1.2.8/go.mod h1:rKQDl4u51uwafZxFrPD1R7xFOwKnzZW7s/LSeK4lgo0=
 github.com/blevesearch/geo v0.1.20 h1:paaSpu2Ewh/tn5DKn/FB5SzvH0EWupxHEIwbCk/QPqM=
 github.com/blevesearch/geo v0.1.20/go.mod h1:DVG2QjwHNMFmjo+ZgzrIq2sfCh6rIHzy9d9d0B59I6w=
 github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=
@@ -20,8 +20,8 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
-github.com/blevesearch/scorch_segment_api/v2 v2.3.9 h1:X6nJXnNHl7nasXW+U6y2Ns2Aw8F9STszkYkyBfQ+p0o=
-github.com/blevesearch/scorch_segment_api/v2 v2.3.9/go.mod h1:IrzspZlVjhf4X29oJiEhBxEteTqOY9RlYlk1lCmYHr4=
+github.com/blevesearch/scorch_segment_api/v2 v2.3.10 h1:Yqk0XD1mE0fDZAJXTjawJ8If/85JxnLd8v5vG/jWE/s=
+github.com/blevesearch/scorch_segment_api/v2 v2.3.10/go.mod h1:Z3e6ChN3qyN35yaQpl00MfI5s8AxUJbpTR/DL8QOQ+8=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -44,8 +44,8 @@ github.com/blevesearch/zapx/v14 v14.4.1 h1:G47kGCshknBZzZAtjcnIAMn3oNx8XBLxp8DMq
 github.com/blevesearch/zapx/v14 v14.4.1/go.mod h1:O7sDxiaL2r2PnCXbhh1Bvm7b4sP+jp4unE9DDPWGoms=
 github.com/blevesearch/zapx/v15 v15.4.1 h1:B5IoTMUCEzFdc9FSQbhVOxAY+BO17c05866fNruiI7g=
 github.com/blevesearch/zapx/v15 v15.4.1/go.mod h1:b/MreHjYeQoLjyY2+UaM0hGZZUajEbE0xhnr1A2/Q6Y=
-github.com/blevesearch/zapx/v16 v16.2.2 h1:MifKJVRTEhMTgSlle2bDRTb39BGc9jXFRLPZc6r0Rzk=
-github.com/blevesearch/zapx/v16 v16.2.2/go.mod h1:B9Pk4G1CqtErgQV9DyCSA9Lb7WZe4olYfGw7fVDZ4sk=
+github.com/blevesearch/zapx/v16 v16.2.3 h1:7Y0r+a3diEvlazsncexq1qoFOcBd64xwMS7aDm4lo1s=
+github.com/blevesearch/zapx/v16 v16.2.3/go.mod h1:wVJ+GtURAaRG9KQAMNYyklq0egV+XJlGcXNCE0OFjjA=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/RoaringBitmap/roaring/v2 v2.4.5/go.mod h1:FiJcsfkGje/nZBZgCu0ZxCPOKD/
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.2.7 h1:c8r9vmbaYQroAMSGag7zq5gEVPiuXrUQDqfnj7uYZSY=
-github.com/blevesearch/bleve_index_api v1.2.7/go.mod h1:rKQDl4u51uwafZxFrPD1R7xFOwKnzZW7s/LSeK4lgo0=
 github.com/blevesearch/geo v0.1.20 h1:paaSpu2Ewh/tn5DKn/FB5SzvH0EWupxHEIwbCk/QPqM=
 github.com/blevesearch/geo v0.1.20/go.mod h1:DVG2QjwHNMFmjo+ZgzrIq2sfCh6rIHzy9d9d0B59I6w=
 github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/RoaringBitmap/roaring/v2 v2.4.5/go.mod h1:FiJcsfkGje/nZBZgCu0ZxCPOKD/
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
 github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/blevesearch/bleve_index_api v1.2.7 h1:c8r9vmbaYQroAMSGag7zq5gEVPiuXrUQDqfnj7uYZSY=
+github.com/blevesearch/bleve_index_api v1.2.7/go.mod h1:rKQDl4u51uwafZxFrPD1R7xFOwKnzZW7s/LSeK4lgo0=
 github.com/blevesearch/geo v0.1.20 h1:paaSpu2Ewh/tn5DKn/FB5SzvH0EWupxHEIwbCk/QPqM=
 github.com/blevesearch/geo v0.1.20/go.mod h1:DVG2QjwHNMFmjo+ZgzrIq2sfCh6rIHzy9d9d0B59I6w=
 github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -16,7 +16,6 @@ package upsidedown
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/blevesearch/bleve/v2/document"
@@ -43,11 +42,6 @@ func (i *IndexReader) TermFieldReader(ctx context.Context, term []byte, fieldNam
 		return newUpsideDownCouchTermFieldReader(i, term, uint16(fieldIndex), includeFreq, includeNorm, includeTermVectors)
 	}
 	return newUpsideDownCouchTermFieldReader(i, []byte{ByteSeparator}, ^uint16(0), includeFreq, includeNorm, includeTermVectors)
-}
-
-func (i *IndexReader) FieldCardinality(field string) (int, error) {
-	// no-op for now
-	return 0, fmt.Errorf("not implemented")
 }
 
 func (i *IndexReader) FieldDict(fieldName string) (index.FieldDict, error) {

--- a/index/upsidedown/index_reader.go
+++ b/index/upsidedown/index_reader.go
@@ -16,11 +16,12 @@ package upsidedown
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/blevesearch/bleve/v2/document"
 	index "github.com/blevesearch/bleve_index_api"
-	"github.com/blevesearch/upsidedown_store_api"
+	store "github.com/blevesearch/upsidedown_store_api"
 )
 
 var reflectStaticSizeIndexReader int
@@ -42,6 +43,11 @@ func (i *IndexReader) TermFieldReader(ctx context.Context, term []byte, fieldNam
 		return newUpsideDownCouchTermFieldReader(i, term, uint16(fieldIndex), includeFreq, includeNorm, includeTermVectors)
 	}
 	return newUpsideDownCouchTermFieldReader(i, []byte{ByteSeparator}, ^uint16(0), includeFreq, includeNorm, includeTermVectors)
+}
+
+func (i *IndexReader) FieldCardinality(field string) (int, error) {
+	// no-op for now
+	return 0, fmt.Errorf("not implemented")
 }
 
 func (i *IndexReader) FieldDict(fieldName string) (index.FieldDict, error) {

--- a/index_impl.go
+++ b/index_impl.go
@@ -509,9 +509,11 @@ func (i *indexImpl) preSearch(ctx context.Context, req *SearchRequest, reader in
 				return nil, err
 			}
 			for field := range fs {
-				fieldCardinality[field], err = reader.FieldCardinality(field)
-				if err != nil {
-					return nil, err
+				if bm25Reader, ok := reader.(index.BM25Reader); ok {
+					fieldCardinality[field], err = bm25Reader.FieldCardinality(field)
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}

--- a/index_impl.go
+++ b/index_impl.go
@@ -509,11 +509,10 @@ func (i *indexImpl) preSearch(ctx context.Context, req *SearchRequest, reader in
 				return nil, err
 			}
 			for field := range fs {
-				dict, err := reader.FieldDict(field)
+				fieldCardinality[field], err = reader.FieldCardinality(field)
 				if err != nil {
 					return nil, err
 				}
-				fieldCardinality[field] = dict.Cardinality()
 			}
 		}
 	}

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -114,10 +114,6 @@ func (sr *stubReader) DocIDReaderOnly(ids []string) (index.DocIDReader, error) {
 	return nil, nil
 }
 
-func (sr *stubReader) FieldCardinality(field string) (int, error) {
-	return 0, nil
-}
-
 func (sr *stubReader) FieldDict(field string) (index.FieldDict, error) {
 	return nil, nil
 }

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -114,6 +114,10 @@ func (sr *stubReader) DocIDReaderOnly(ids []string) (index.DocIDReader, error) {
 	return nil, nil
 }
 
+func (sr *stubReader) FieldCardinality(field string) (int, error) {
+	return 0, nil
+}
+
 func (sr *stubReader) FieldDict(field string) (index.FieldDict, error) {
 	return nil, nil
 }

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -92,9 +92,11 @@ func bm25ScoreMetrics(ctx context.Context, field string,
 		if err != nil {
 			return 0, 0, err
 		}
-		fieldCardinality, err = indexReader.FieldCardinality(field)
-		if err != nil {
-			return 0, 0, err
+		if bm25Reader, ok := indexReader.(index.BM25Reader); ok {
+			fieldCardinality, err = bm25Reader.FieldCardinality(field)
+			if err != nil {
+				return 0, 0, err
+			}
 		}
 	} else {
 		count = uint64(bm25Stats.DocCount)

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -92,11 +92,10 @@ func bm25ScoreMetrics(ctx context.Context, field string,
 		if err != nil {
 			return 0, 0, err
 		}
-		dict, err := indexReader.FieldDict(field)
+		fieldCardinality, err = indexReader.FieldCardinality(field)
 		if err != nil {
 			return 0, 0, err
 		}
-		fieldCardinality = dict.Cardinality()
 	} else {
 		count = uint64(bm25Stats.DocCount)
 		fieldCardinality, ok = bm25Stats.FieldCardinality[field]


### PR DESCRIPTION
- cache a map which maps the field to its cardinality value so that we don't create the fieldDict everytime
- Furthermore in the case all the threads have a cache miss, use the write lock to make sure that we create the fieldDict only once to minimize garbage. 
- Use a separate mutex construct so that the contention is localised to the metrics gathering and doesn't affect the other threads' TFR generation.
- https://github.com/blevesearch/bleve_index_api/pull/68