### PR TITLE
Refactor BM25 context key usage

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -591,7 +591,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	var fts search.FieldTermSynonymMap
 	var skipSynonymCollector bool
 
-	var bm25Data *search.BM25Stats
+	var bm25Stats *search.BM25Stats
 	var ok bool
 	if req.PreSearchData != nil {
 		for k, v := range req.PreSearchData {
@@ -614,7 +614,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 				}
 			case search.BM25PreSearchDataKey:
 				if v != nil {
-					bm25Data, ok = v.(*search.BM25Stats)
+					bm25Stats, ok = v.(*search.BM25Stats)
 					if !ok {
 						return nil, fmt.Errorf("bm25 preSearchData must be of type *search.BM25Stats")
 					}
@@ -658,10 +658,10 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	ctx = context.WithValue(ctx, search.GetScoringModelCallbackKey,
 		search.GetScoringModelCallbackFn(scoringModelCallback))
 
-	// set the bm25 presearch data (stats important for consistent scoring) in
+	// set the bm25Stats (stats important for consistent scoring) in
 	// the context object
-	if bm25Data != nil {
-		ctx = context.WithValue(ctx, search.BM25StatsKey, bm25Data)
+	if bm25Stats != nil {
+		ctx = context.WithValue(ctx, search.BM25StatsKey, bm25Stats)
 	}
 
 	// This callback and variable handles the tracking of bytes read

--- a/index_impl.go
+++ b/index_impl.go
@@ -616,7 +616,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 				if v != nil {
 					bm25Data, ok = v.(*search.BM25Stats)
 					if !ok {
-						return nil, fmt.Errorf("bm25 preSearchData must be of type map[string]interface{}")
+						return nil, fmt.Errorf("bm25 preSearchData must be of type *search.BM25Stats")
 					}
 				}
 			}
@@ -661,7 +661,7 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	// set the bm25 presearch data (stats important for consistent scoring) in
 	// the context object
 	if bm25Data != nil {
-		ctx = context.WithValue(ctx, search.BM25PreSearchDataKey, bm25Data)
+		ctx = context.WithValue(ctx, search.BM25StatsKey, bm25Data)
 	}
 
 	// This callback and variable handles the tracking of bytes read

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -86,7 +86,7 @@ func bm25ScoreMetrics(ctx context.Context, field string,
 	var fieldCardinality int
 	var err error
 
-	bm25Stats, ok := ctx.Value(search.BM25PreSearchDataKey).(*search.BM25Stats)
+	bm25Stats, ok := ctx.Value(search.BM25StatsKey).(*search.BM25Stats)
 	if !ok {
 		count, err = indexReader.DocCount()
 		if err != nil {

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -122,9 +122,9 @@ func newTermSearcherFromReader(ctx context.Context, indexReader index.IndexReade
 
 	// as a fallback case we track certain stats for tf-idf scoring
 	if ctx != nil {
-		if similaritModelCallback, ok := ctx.Value(search.
+		if similarityModelCallback, ok := ctx.Value(search.
 			GetScoringModelCallbackKey).(search.GetScoringModelCallbackFn); ok {
-			similarityModel = similaritModelCallback()
+			similarityModel = similarityModelCallback()
 		}
 	}
 	switch similarityModel {

--- a/search/util.go
+++ b/search/util.go
@@ -148,6 +148,10 @@ const (
 	// FieldTermSynonymMapKey is used to store and transport the synonym definitions data
 	// to the actual search phase which would use the synonyms to perform the search.
 	FieldTermSynonymMapKey ContextKey = "_field_term_synonym_map_key"
+
+	// BM25StatsKey is used to store and transport the BM25 Data
+	// to the actual search phase which would use it to perform the search.
+	BM25StatsKey ContextKey = "_bm25_stats_key"
 )
 
 func RecordSearchCost(ctx context.Context,


### PR DESCRIPTION
- Separates the use of `BM25PreSearchDataKey` (for pre-search data) and introduces `BM25StatsKey` for passing BM25 stats via context, similar to the existing `SynonymPreSearchDataKey` vs. `FieldTermSynonymMapKey` pattern. This improves clarity and consistency in key usage.