### PR TITLE
MB-66163: always protect the latest snapshot within bolt

### DIFF
--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -72,6 +72,6 @@ var EventKindPreMergeCheck = EventKind(9)
 // creates a new Document object from an interface using the index mapping.
 var EventKindIndexStart = EventKind(10)
 
-// EventKindPreMergeCheck is fired before the purge code is invoked and decides
-// whether to execute or not. For unit test puposes
+// EventKindPurgerCheck is fired before the purge code is invoked and decides
+// whether to execute or not. For unit test purposes
 var EventKindPurgerCheck = EventKind(11)

--- a/index/scorch/event.go
+++ b/index/scorch/event.go
@@ -71,3 +71,7 @@ var EventKindPreMergeCheck = EventKind(9)
 // EventKindIndexStart is fired when Index() is invoked which
 // creates a new Document object from an interface using the index mapping.
 var EventKindIndexStart = EventKind(10)
+
+// EventKindPreMergeCheck is fired before the purge code is invoked and decides
+// whether to execute or not. For unit test puposes
+var EventKindPurgerCheck = EventKind(11)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -81,6 +81,10 @@ OUTER:
 					// Retry instead of blocking/waiting here since a long wait
 					// can result in more segments introduced i.e. s.root will
 					// be updated.
+
+					// decrement the ref count since its no longer needed in this
+					// iteration
+					_ = ourSnapshot.DecRef()
 					continue OUTER
 				}
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -532,10 +532,10 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			// as an extra layer of security, mark this file as ineligible for removal
-			// this will be flipped back when the bolt is updated - which means,
-			// the bolt entry will go away if the snapshot is zero ref'd and the
-			// file will be cleaned if its eligible to be removed.
+			// to prevent accidental cleanup of this newly created file, mark it
+			// as ineligible for removal. this will be flipped back when the bolt
+			// is updated - which is valid, since the snapshot updated in bolt is
+			// cleaned up only if its zero ref'd (MB-66163 for more details)
 			s.markIneligibleForRemoval(filename)
 			newMergedSegmentIDs[id] = newSegmentID
 			newDocIDsSet[id] = newDocIDs

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -532,6 +532,11 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
+			// as an extra layer of security, mark this file as ineligible for removal
+			// this will be flipped back when the bolt is updated - which means,
+			// the bolt entry will go away if the snapshot is zero ref'd and the
+			// file will be cleaned if its eligible to be removed.
+			s.markIneligibleForRemoval(filename)
 			newMergedSegmentIDs[id] = newSegmentID
 			newDocIDsSet[id] = newDocIDs
 			newMergedSegments[id], err = s.segPlugin.Open(path)

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1113,7 +1113,10 @@ func getProtectedSnapshots(rollbackSamplingInterval time.Duration,
 	numSnapshotsToKeep int,
 	persistedSnapshots []*snapshotMetaData,
 ) map[uint64]time.Time {
-	lastPoint, protectedEpochs := getTimeSeriesSnapshots(numSnapshotsToKeep,
+	// keep numSnapshotsToKeep - 1 worth of time series snapshots, because we always
+	// must preserve the very latest snapshot in bolt as well to avoid accidental
+	// deletes of bolt entries and cleanups by the purger code.
+	lastPoint, protectedEpochs := getTimeSeriesSnapshots(numSnapshotsToKeep-1,
 		rollbackSamplingInterval, persistedSnapshots)
 	if len(protectedEpochs) < numSnapshotsToKeep {
 		numSnapshotsNeeded := numSnapshotsToKeep - len(protectedEpochs)

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -228,7 +228,9 @@ OUTER:
 		case s.introducerNotifier <- w:
 		}
 
-		s.removeOldData() // might as well cleanup while waiting
+		if ok := s.fireEvent(EventKindPurgerCheck, 0); ok {
+			s.removeOldData() // might as well cleanup while waiting
+		}
 
 		atomic.AddUint64(&s.stats.TotPersistLoopWait, 1)
 
@@ -296,7 +298,9 @@ func (s *Scorch) pausePersisterForMergerCatchUp(lastPersistedEpoch uint64,
 	// 1. Too many older snapshots awaiting the clean up.
 	// 2. The merger could be lagging behind on merging the disk files.
 	if numFilesOnDisk > uint64(po.PersisterNapUnderNumFiles) {
-		s.removeOldData()
+		if ok := s.fireEvent(EventKindPurgerCheck, 0); ok {
+			s.removeOldData()
+		}
 		numFilesOnDisk, _, _ = s.diskFileStats(nil)
 	}
 

--- a/index/scorch/rollback_test.go
+++ b/index/scorch/rollback_test.go
@@ -283,15 +283,14 @@ func TestGetProtectedSnapshots(t *testing.T) {
 				{epoch: 99, timeStamp: currentTimeStamp.Add(-(RollbackSamplingInterval / 12))},
 				{epoch: 88, timeStamp: currentTimeStamp.Add(-(RollbackSamplingInterval / 6))},
 				{epoch: 50, timeStamp: currentTimeStamp.Add(-(RollbackSamplingInterval))},
-				{epoch: 35, timeStamp: currentTimeStamp.Add(-(6 * RollbackSamplingInterval / 5))},
-				{epoch: 10, timeStamp: currentTimeStamp.Add(-(2 * RollbackSamplingInterval))},
 			},
 			numSnapshotsToKeep: 2,
 			expCount:           2,
-			expEpochs:          []uint64{50, 10},
+			expEpochs:          []uint64{100, 50},
 		},
 		{
-			title: "epochs that have timestamps approximated to the expected value",
+			title: "epochs that have timestamps approximated to the expected value, " +
+				"always retain the latest one",
 			metaData: []*snapshotMetaData{
 				{epoch: 100, timeStamp: currentTimeStamp},
 				{epoch: 99, timeStamp: currentTimeStamp.Add(-(RollbackSamplingInterval / 12))},
@@ -302,7 +301,7 @@ func TestGetProtectedSnapshots(t *testing.T) {
 			},
 			numSnapshotsToKeep: 3,
 			expCount:           3,
-			expEpochs:          []uint64{50, 35, 10},
+			expEpochs:          []uint64{100, 35, 10},
 		},
 		{
 			title: "protecting epochs when we don't have enough snapshots with RollbackSamplingInterval" +

--- a/index/scorch/rollback_test.go
+++ b/index/scorch/rollback_test.go
@@ -409,9 +409,7 @@ func TestLatestSnapshotProtected(t *testing.T) {
 
 	// disable merger and purger
 	RegistryEventCallbacks["test"] = func(e Event) bool {
-		if e.Kind == EventKindPreMergeCheck {
-			return false
-		} else if e.Kind == EventKindPurgerCheck {
+		if e.Kind == EventKindPreMergeCheck || e.Kind == EventKindPurgerCheck {
 			return false
 		}
 		return true
@@ -490,9 +488,7 @@ func TestBackupRacingWithPurge(t *testing.T) {
 
 	// disable merger and purger
 	RegistryEventCallbacks["test"] = func(e Event) bool {
-		if e.Kind == EventKindPreMergeCheck {
-			return false
-		} else if e.Kind == EventKindPurgerCheck {
+		if e.Kind == EventKindPreMergeCheck || e.Kind == EventKindPurgerCheck {
 			return false
 		}
 		return true


### PR DESCRIPTION
- Currently because of the time-series based checkpointing mechanism, there can be edge cases where we don't end up protecting the very latest snapshot that's there in the bolt file. 
- This can cause some serious issues along the persister path, where the newly created file segments that's part of the new snapshot written to bolt can potentially get cleaned up when the purge code `removeOldData` is invoked. If there were a backup operation `indexReader.CopyTo()` to be performed just after this purge operation, the latest root still has a pointer to the file segment but the underlying file itself would have been purged because its not part of `ineligibleForRemoval` structure and also the corresponding bolt entry would have been deleted.
- The issue highlighted has also been unit tested and is consistently reproducable.
  ```
  rollback_test.go:559: error copying the index: error backing up index snapshot: segment: /var/folders/5n/g80bkslj5qn6xn8srh6pxv_r0000gp/T/bleve-scorch-test-TestLatestSnapshotCheckpointed/000000000004.zap copy err: stat /var/folders/5n/g80bkslj5qn6xn8srh6pxv_r0000gp/T/bleve-scorch-test-TestLatestSnapshotCheckpointed/000000000004.zap: no such file or directory
  ```
- The PR addresses this issue by firstly preserving the latest snapshot within bolt and n-1 time-series based checkpoints and also marking the file as ineligible for removal as an layer of protection. 
- There is also a bug fix along a specific merger path where the old snapshot's ref count wasn't being decremented appropriately which can potentially cause file leak and memory bloat due to invalid snapshots still being present.