### PR TITLE
fix: golangci-lint findings, fifth delivery

### DIFF
--- a/analysis/char/asciifolding/asciifolding.go
+++ b/analysis/char/asciifolding/asciifolding.go
@@ -3561,7 +3561,6 @@ func foldToASCII(input []rune, inputPos int, output []rune, outputPos int, lengt
 			case '\uFF5E': // ～ [FULLWIDTH TILDE]
 				output[outputPos] = '~'
 				outputPos++
-				break
 
 			default:
 				output[outputPos] = c

--- a/analysis/char/asciifolding/asciifolding_test.go
+++ b/analysis/char/asciifolding/asciifolding_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestAsciiFoldingFilter(t *testing.T) {
-
 	tests := []struct {
 		input  []byte
 		output []byte
@@ -40,18 +39,76 @@ func TestAsciiFoldingFilter(t *testing.T) {
 			// Umlauts are folded to plain ASCII
 			input:  []byte(`The quick bröwn fox jümps over the läzy dog`),
 			output: []byte(`The quick brown fox jumps over the lazy dog`),
-		}, {
+		},
+		{
 			// composite unicode runes are folded to more than one ASCII rune
 			input:  []byte(`ÆꜴ`),
 			output: []byte(`AEAO`),
-		}, {
+		},
+		{
 			// apples from https://issues.couchbase.com/browse/MB-33486
 			input:  []byte(`Ápple Àpple Äpple Âpple Ãpple Åpple`),
 			output: []byte(`Apple Apple Apple Apple Apple Apple`),
-		}, {
+		},
+		{
 			// Fix ASCII folding of \u24A2
 			input:  []byte(`⒢`),
 			output: []byte(`(g)`),
+		},
+		{
+			// Test folding of \u2053 (SWUNG DASH)
+			input:  []byte(`a⁓b`),
+			output: []byte(`a~b`),
+		},
+		{
+			// Test folding of \uFF5E (FULLWIDTH TILDE)
+			input:  []byte(`c～d`),
+			output: []byte(`c~d`),
+		},
+		{
+			// Test folding of \uFF3F (FULLWIDTH LOW LINE) - case before tilde
+			input:  []byte(`e＿f`),
+			output: []byte(`e_f`),
+		},
+		{
+			// Test mix including tilde and default fallthrough (using a character not explicitly folded)
+			input:  []byte(`a⁓b✅c～d`),
+			output: []byte(`a~b✅c~d`),
+		},
+		{
+			// Test start of 'A' fallthrough block
+			input:  []byte(`ÀBC`),
+			output: []byte(`ABC`),
+		},
+		{
+			// Test end of 'A' fallthrough block
+			input:  []byte(`DEFẶ`),
+			output: []byte(`DEFA`),
+		},
+		{
+			// Test start of 'AE' fallthrough block
+			input:  []byte(`Æ`),
+			output: []byte(`AE`),
+		},
+		{
+			// Test end of 'AE' fallthrough block
+			input:  []byte(`ᴁ`),
+			output: []byte(`AE`),
+		},
+		{
+			// Test 'DZ' multi-rune output
+			input:  []byte(`Ǆebra`),
+			output: []byte(`DZebra`),
+		},
+		{
+			// Test start of 'a' fallthrough block
+			input:  []byte(`àbc`),
+			output: []byte(`abc`),
+		},
+		{
+			// Test end of 'a' fallthrough block
+			input:  []byte(`defａ`),
+			output: []byte(`defa`),
 		},
 	}
 

--- a/analysis/datetime/iso/iso.go
+++ b/analysis/datetime/iso/iso.go
@@ -173,21 +173,25 @@ func parseISOString(layout string) (string, error) {
 					}
 				case 'h', 'K':
 					// hour (1-12)
-					if count == 2 {
+					switch count {
+					case 2:
+						// hh, KK -> 03
 						dateTimeLayout.WriteString("03")
-					} else if count == 1 {
+					case 1:
+						// h, K -> 3
 						dateTimeLayout.WriteString("3")
-					} else {
+					default:
+						// e.g., hhh
 						return "", invalidFormatError(character, count)
 					}
 				case 'E':
 					// day of week
 					if count == 4 {
-						dateTimeLayout.WriteString("Monday")
+						dateTimeLayout.WriteString("Monday") // EEEE -> Monday
 					} else if count <= 3 {
-						dateTimeLayout.WriteString("Mon")
+						dateTimeLayout.WriteString("Mon") // E, EE, EEE -> Mon
 					} else {
-						return "", invalidFormatError(character, count)
+						return "", invalidFormatError(character, count) // e.g., EEEEE
 					}
 				case 'S':
 					// fraction of second

--- a/analysis/datetime/iso/iso_test.go
+++ b/analysis/datetime/iso/iso_test.go
@@ -75,15 +75,108 @@ func TestConversionFromISOStyle(t *testing.T) {
 			output: "",
 			err:    fmt.Errorf("invalid format string, unknown format specifier: MMMMM"),
 		},
+		{
+			input:  "yy", // year (2 digits)
+			output: "06",
+			err:    nil,
+		},
+		{
+			input:  "yyyyy", // year (5 digits, padded)
+			output: "02006",
+			err:    nil,
+		},
+		{
+			input:  "h", // hour 1-12 (1 digit)
+			output: "3",
+			err:    nil,
+		},
+		{
+			input:  "hh", // hour 1-12 (2 digits)
+			output: "03",
+			err:    nil,
+		},
+		{
+			input:  "KK", // hour 1-12 (2 digits, alt)
+			output: "03",
+			err:    nil,
+		},
+		{
+			input:  "hhh", // invalid hour count
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: hhh"),
+		},
+		{
+			input:  "E", // Day of week (short)
+			output: "Mon",
+			err:    nil,
+		},
+		{
+			input:  "EEE", // Day of week (short)
+			output: "Mon",
+			err:    nil,
+		},
+		{
+			input:  "EEEE", // Day of week (long)
+			output: "Monday",
+			err:    nil,
+		},
+		{
+			input:  "EEEEE", // Day of week (long)
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: EEEEE"),
+		},
+		{
+			input:  "S", // Fraction of second (1 digit)
+			output: "0",
+			err:    nil,
+		},
+		{
+			input:  "SSSSSSSSS", // Fraction of second (9 digits)
+			output: "000000000",
+			err:    nil,
+		},
+		{
+			input:  "SSSSSSSSSS", // Invalid fraction of second count
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: SSSSSSSSSS"),
+		},
+		{
+			input:  "z", // Timezone name (short)
+			output: "MST",
+			err:    nil,
+		},
+		{
+			input:  "zzz", // Timezone name (short) - Corrected expectation
+			output: "MST", // Should output MST
+			err:    nil,   // Should not produce an error
+		},
+		{
+			input:  "zzzz", // Timezone name (long) - Corrected expectation
+			output: "MST",  // Should output MST
+			err:    nil,    // Should not produce an error
+		},
+		{
+			input:  "G", // Era designator (unsupported)
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: G"),
+		},
+		{
+			input:  "W", // Week of month (unsupported)
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: W"),
+		},
 	}
-	for _, test := range tests {
-		out, err := parseISOString(test.input)
-		if err != nil && test.err == nil || err == nil && test.err != nil {
-			t.Fatalf("expected error %v, got error %v", test.err, err)
-		}
-		if out != test.output {
-			t.Fatalf("expected output %v, got %v", test.output, out)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test %d: %s", i, test.input), func(t *testing.T) {
+			out, err := parseISOString(test.input)
+			// Check error matching
+			if (err != nil && test.err == nil) || (err == nil && test.err != nil) || (err != nil && test.err != nil && err.Error() != test.err.Error()) {
+				t.Fatalf("expected error %v, got error %v", test.err, err)
+			}
+			// Check output matching only if no error was expected/occurred
+			if err == nil && test.err == nil && out != test.output {
+				t.Fatalf("expected output '%v', got '%v'", test.output, out)
+			}
+		})
 	}
-
 }

--- a/analysis/datetime/percent/percent.go
+++ b/analysis/datetime/percent/percent.go
@@ -133,26 +133,6 @@ func checkTZOptions(formatString string, idx int) (string, int) {
 	return layout, finalIdx
 }
 
-// func checkTZOptions(formatString string, idx int) (string, int) {
-// 	// idx is pointing to %
-// 	// idx + 1 is pointing to z
-// 	if idx+2 < len(formatString) {
-// 		if formatString[idx+2] == ':' {
-// 			// check if there is a character after the colon
-// 			if idx+3 < len(formatString) && (formatString[idx+3] == 'M' || formatString[idx+3] == 'S') {
-// 				return timezoneOptions[fmt.Sprintf("z:%s", string(formatString[idx+3]))], idx + 4
-// 			}
-// 			// %z:<some char> OR %z: detected; return the default layout Z0700 and increment idx by 2 to print : literally
-// 			return timezoneOptions["z"], idx + 2
-// 		} else if formatString[idx+2] == 'H' || formatString[idx+2] == 'S' {
-// 			// %zH or %zS detected; return the layouts Z07 / z070000 and increment idx by 2 to point to the next character
-// 			// after %zH or %zS
-// 			return timezoneOptions[fmt.Sprintf("z%s", string(formatString[idx+2]))], idx + 3
-// 		}
-// 	}
-// 	return timezoneOptions["z"], idx + 2
-// }
-
 func parseFormatString(formatString string) (string, error) {
 	var dateTimeLayout strings.Builder
 	// iterate over the format string and replace the format specifiers with

--- a/analysis/datetime/percent/percent.go
+++ b/analysis/datetime/percent/percent.go
@@ -81,24 +81,77 @@ func New(layouts []string) *DateTimeParser {
 }
 
 func checkTZOptions(formatString string, idx int) (string, int) {
-	// idx is pointing to %
-	// idx + 1 is pointing to z
-	if idx+2 < len(formatString) {
-		if formatString[idx+2] == ':' {
-			// check if there is a character after the colon
-			if idx+3 < len(formatString) && (formatString[idx+3] == 'M' || formatString[idx+3] == 'S') {
-				return timezoneOptions[fmt.Sprintf("z:%s", string(formatString[idx+3]))], idx + 4
+	// idx points to '%'
+	// We know formatString[idx+1] == 'z'
+	nextIdx := idx + 2 // Index of the character immediately after 'z'
+
+	// Default values assume only '%z' is present
+	layout := timezoneOptions["z"]
+	finalIdx := nextIdx // Index after '%z'
+
+	if nextIdx < len(formatString) {
+		switch formatString[nextIdx] {
+		case ':':
+			// Check for modifier after the colon ':'
+			colonModifierIdx := nextIdx + 1
+			if colonModifierIdx < len(formatString) {
+				switch formatString[colonModifierIdx] {
+				case 'M':
+					// Found %z:M
+					layout = timezoneOptions["z:M"]
+					finalIdx = colonModifierIdx + 1 // Index after %z:M
+				case 'S':
+					// Found %z:S
+					layout = timezoneOptions["z:S"]
+					finalIdx = colonModifierIdx + 1 // Index after %z:S
+					// default: If %z: is followed by something else, or just %z: at the end.
+					// Keep the default layout ("z") and finalIdx (idx + 2).
+					// The ':' will be treated as a literal by the main loop.
+				}
 			}
-			// %z:<some char> OR %z: detected; return the default layout Z0700 and increment idx by 2 to print : literally
-			return timezoneOptions["z"], idx + 2
-		} else if formatString[idx+2] == 'H' || formatString[idx+2] == 'S' {
-			// %zH or %zS detected; return the layouts Z07 / z070000 and increment idx by 2 to point to the next character
-			// after %zH or %zS
-			return timezoneOptions[fmt.Sprintf("z%s", string(formatString[idx+2]))], idx + 3
+			// else: %z: is at the very end of the string.
+			// Keep the default layout ("z") and finalIdx (idx + 2).
+			// The ':' will be treated as a literal by the main loop.
+
+		case 'H':
+			// Found %zH
+			layout = timezoneOptions["zH"]
+			finalIdx = nextIdx + 1 // Index after %zH
+		case 'S':
+			// Found %zS
+			layout = timezoneOptions["zS"]
+			finalIdx = nextIdx + 1 // Index after %zS
+
+			// default: If %z is followed by something other than ':', 'H', or 'S'.
+			// Keep the default layout ("z") and finalIdx (idx + 2).
+			// The character formatString[nextIdx] will be handled by the main loop.
 		}
 	}
-	return timezoneOptions["z"], idx + 2
+	// else: %z is at the very end of the string.
+	// Keep the default layout ("z") and finalIdx (idx + 2).
+
+	return layout, finalIdx
 }
+
+// func checkTZOptions(formatString string, idx int) (string, int) {
+// 	// idx is pointing to %
+// 	// idx + 1 is pointing to z
+// 	if idx+2 < len(formatString) {
+// 		if formatString[idx+2] == ':' {
+// 			// check if there is a character after the colon
+// 			if idx+3 < len(formatString) && (formatString[idx+3] == 'M' || formatString[idx+3] == 'S') {
+// 				return timezoneOptions[fmt.Sprintf("z:%s", string(formatString[idx+3]))], idx + 4
+// 			}
+// 			// %z:<some char> OR %z: detected; return the default layout Z0700 and increment idx by 2 to print : literally
+// 			return timezoneOptions["z"], idx + 2
+// 		} else if formatString[idx+2] == 'H' || formatString[idx+2] == 'S' {
+// 			// %zH or %zS detected; return the layouts Z07 / z070000 and increment idx by 2 to point to the next character
+// 			// after %zH or %zS
+// 			return timezoneOptions[fmt.Sprintf("z%s", string(formatString[idx+2]))], idx + 3
+// 		}
+// 	}
+// 	return timezoneOptions["z"], idx + 2
+// }
 
 func parseFormatString(formatString string) (string, error) {
 	var dateTimeLayout strings.Builder
@@ -109,7 +162,7 @@ func parseFormatString(formatString string) (string, error) {
 		if formatString[idx] == formatDelimiter {
 			// check if there is a character after the format delimiter (%)
 			if idx+1 >= len(formatString) {
-				return "", fmt.Errorf("invalid format string, expected character after " + string(formatDelimiter))
+				return "", fmt.Errorf("invalid format string, expected character after %s", string(formatDelimiter))
 			}
 			formatSpecifier := formatString[idx+1]
 			if layout, ok := formatSpecifierToLayout[formatSpecifier]; ok {
@@ -122,7 +175,7 @@ func parseFormatString(formatString string) (string, error) {
 				tzLayout, idx = checkTZOptions(formatString, idx)
 				dateTimeLayout.WriteString(tzLayout)
 			} else {
-				return "", fmt.Errorf("invalid format string, unknown format specifier: " + string(formatSpecifier))
+				return "", fmt.Errorf("invalid format string, unknown format specifier: %s", string(formatSpecifier))
 			}
 			continue
 		}
@@ -148,7 +201,8 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 	if !ok {
 		return nil, fmt.Errorf("must specify layouts")
 	}
-	var layoutStrs []string
+
+	layoutStrs := make([]string, 0, len(layouts))
 	for _, layout := range layouts {
 		layoutStr, ok := layout.(string)
 		if ok {
@@ -159,6 +213,7 @@ func DateTimeParserConstructor(config map[string]interface{}, cache *registry.Ca
 			layoutStrs = append(layoutStrs, layout)
 		}
 	}
+
 	return New(layoutStrs), nil
 }
 

--- a/analysis/datetime/percent/percent_test.go
+++ b/analysis/datetime/percent/percent_test.go
@@ -16,99 +16,459 @@ package percent
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve/v2/analysis"
 )
 
 func TestConversionFromPercentStyle(t *testing.T) {
 	tests := []struct {
+		name   string // Added name field
 		input  string
 		output string
 		err    error
 	}{
 		{
+			name:   "basic YMD",
 			input:  "%Y-%m-%d",
 			output: "2006-01-02",
 			err:    nil,
 		},
 		{
+			name:   "YMD with double percent and literal T",
 			input:  "%Y/%m%%%%%dT%H%M:%S",
 			output: "2006/01%%02T1504:05",
 			err:    nil,
 		},
 		{
+			name:   "YMD T HMS Z z",
 			input:  "%Y-%m-%dT%H:%M:%S %Z%z",
 			output: "2006-01-02T15:04:05 MSTZ0700",
 			err:    nil,
 		},
 		{
+			name:   "Full month, padded day/hour, am/pm, z:M",
 			input:  "%B %e, %Y %l:%i %P %z:M",
 			output: "January 2, 2006 3:4 pm Z07:00",
 			err:    nil,
 		},
 		{
+			name:   "Long format with literals and timezone literal :S",
 			input:  "Hour %H Minute %Mseconds %S.%N Timezone:%Z:S, Weekday %a; Day %d Month %b, Year %y",
 			output: "Hour 15 Minute 04seconds 05.999999999 Timezone:MST:S, Weekday Mon; Day 02 Month Jan, Year 06",
 			err:    nil,
 		},
 		{
+			name:   "YMD T HMS with nanoseconds",
 			input:  "%Y-%m-%dT%H:%M:%S.%N",
 			output: "2006-01-02T15:04:05.999999999",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z z",
 			input:  "%H:%M:%S %Z %z",
 			output: "15:04:05 MST Z0700",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z z literal colon",
 			input:  "%H:%M:%S %Z %z:",
 			output: "15:04:05 MST Z0700:",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z z:M",
 			input:  "%H:%M:%S %Z %z:M",
 			output: "15:04:05 MST Z07:00",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z z:S",
+			input:  "%H:%M:%S %Z %z:S",
+			output: "15:04:05 MST Z07:00:00",
+			err:    nil,
+		},
+		{
+			name:   "HMS Z z: literal A",
 			input:  "%H:%M:%S %Z %z:A",
 			output: "15:04:05 MST Z0700:A",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z z literal M",
 			input:  "%H:%M:%S %Z %zM",
 			output: "15:04:05 MST Z0700M",
 			err:    nil,
 		},
 		{
+			name:   "HMS Z zH",
+			input:  "%H:%M:%S %Z %zH",
+			output: "15:04:05 MST Z07",
+			err:    nil,
+		},
+		{
+			name:   "HMS Z zS",
 			input:  "%H:%M:%S %Z %zS",
 			output: "15:04:05 MST Z070000",
 			err:    nil,
 		},
 		{
+			name:   "Complex combination z zS z: zH",
 			input:  "%H:%M:%S %Z %z%Z %zS%z:%zH",
 			output: "15:04:05 MST Z0700MST Z070000Z0700:Z07",
 			err:    nil,
 		},
 		{
+			name:   "z at end",
+			input:  "%Y-%m-%d %z",
+			output: "2006-01-02 Z0700",
+			err:    nil,
+		},
+		{
+			name:   "z: at end",
+			input:  "%Y-%m-%d %z:",
+			output: "2006-01-02 Z0700:",
+			err:    nil,
+		},
+		{
+			name:   "zH at end",
+			input:  "%Y-%m-%d %zH",
+			output: "2006-01-02 Z07",
+			err:    nil,
+		},
+		{
+			name:   "zS at end",
+			input:  "%Y-%m-%d %zS",
+			output: "2006-01-02 Z070000",
+			err:    nil,
+		},
+		{
+			name:   "z:M at end",
+			input:  "%Y-%m-%d %z:M",
+			output: "2006-01-02 Z07:00",
+			err:    nil,
+		},
+		{
+			name:   "z:S at end",
+			input:  "%Y-%m-%d %z:S",
+			output: "2006-01-02 Z07:00:00",
+			err:    nil,
+		},
+		{
+			name:   "z followed by literal X",
+			input:  "%Y-%m-%d %zX",
+			output: "2006-01-02 Z0700X",
+			err:    nil,
+		},
+		{
+			name:   "z: followed by literal X",
+			input:  "%Y-%m-%d %z:X",
+			output: "2006-01-02 Z0700:X",
+			err:    nil,
+		},
+		{
+			name:   "Invalid specifier T",
 			input:  "%Y-%m-%d%T%H:%M:%S %ZM",
 			output: "",
 			err:    fmt.Errorf("invalid format string, unknown format specifier: T"),
 		},
 		{
+			name:   "Ends with %",
 			input:  "%Y-%m-%dT%H:%M:%S %ZM%",
 			output: "",
-			err:    fmt.Errorf("invalid format string, invalid format string, expected character after %%"),
+			err:    fmt.Errorf("invalid format string, expected character after %%"),
+		},
+		{
+			name:   "Just %",
+			input:  "%",
+			output: "",
+			err:    fmt.Errorf("invalid format string, expected character after %%"),
+		},
+		{
+			name:   "Just %%",
+			input:  "%%",
+			output: "%",
+			err:    nil,
+		},
+		{
+			name:   "Unknown specifier x",
+			input:  "%x",
+			output: "",
+			err:    fmt.Errorf("invalid format string, unknown format specifier: x"),
+		},
+		{
+			name:   "Literal prefix",
+			input:  "literal %Y",
+			output: "literal 2006",
+			err:    nil,
+		},
+		{
+			name:   "Literal suffix",
+			input:  "%Y literal",
+			output: "2006 literal",
+			err:    nil,
 		},
 	}
 	for _, test := range tests {
-		out, err := parseFormatString(test.input)
-		if err != nil && test.err == nil || err == nil && test.err != nil {
-			t.Fatalf("expected error %v, got error %v", test.err, err)
-		}
-		if out != test.output {
-			t.Fatalf("expected output %v, got %v", test.output, out)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			out, err := parseFormatString(test.input)
+
+			// Enhanced Error Check:
+			expectedErrStr := ""
+			if test.err != nil {
+				expectedErrStr = test.err.Error()
+			}
+			actualErrStr := ""
+			if err != nil {
+				actualErrStr = err.Error()
+			}
+
+			if expectedErrStr != actualErrStr {
+				// Provide more detailed output if errors don't match as strings
+				t.Fatalf("error mismatch:\nExpected error: %q\nGot error     : %q", expectedErrStr, actualErrStr)
+			}
+
+			// Original error presence check (redundant if string check passes, but safe to keep)
+			if (err != nil && test.err == nil) || (err == nil && test.err != nil) {
+				t.Fatalf("presence mismatch: expected error %v, got error %v", test.err, err)
+			}
+
+			// Check output matching only if no error was expected/occurred
+			if err == nil && test.err == nil && out != test.output {
+				t.Fatalf("output mismatch: expected '%v', got '%v'", test.output, out)
+			}
+		})
+	}
+}
+
+func TestDateTimeParser_ParseDateTime(t *testing.T) {
+	// Pre-create some parsers with known Go layouts
+	parser1 := New([]string{"2006-01-02", "01/02/2006"}) // YYYY-MM-DD, MM/DD/YYYY
+	parser2 := New([]string{"15:04:05"})                 // HH:MM:SS
+	parserEmpty := New([]string{})                       // No layouts
+
+	// Define expected time values
+	time1, _ := time.Parse("2006-01-02", "2023-10-27")
+	time2, _ := time.Parse("01/02/2006", "10/27/2023")
+	time3, _ := time.Parse("15:04:05", "14:30:00")
+
+	tests := []struct {
+		name         string
+		parser       *DateTimeParser
+		input        string
+		expectTime   time.Time
+		expectLayout string
+		expectErr    error
+	}{
+		{
+			name:         "match first layout",
+			parser:       parser1,
+			input:        "2023-10-27",
+			expectTime:   time1,
+			expectLayout: "2006-01-02",
+			expectErr:    nil,
+		},
+		{
+			name:         "match second layout",
+			parser:       parser1,
+			input:        "10/27/2023",
+			expectTime:   time2,
+			expectLayout: "01/02/2006",
+			expectErr:    nil,
+		},
+		{
+			name:         "no matching layout",
+			parser:       parser1,
+			input:        "14:30:00", // Matches parser2's layout, not parser1's
+			expectTime:   time.Time{},
+			expectLayout: "",
+			expectErr:    analysis.ErrInvalidDateTime,
+		},
+		{
+			name:         "match only layout",
+			parser:       parser2,
+			input:        "14:30:00",
+			expectTime:   time3,
+			expectLayout: "15:04:05",
+			expectErr:    nil,
+		},
+		{
+			name:         "invalid date format for layout",
+			parser:       parser1,
+			input:        "27-10-2023", // Wrong separators
+			expectTime:   time.Time{},
+			expectLayout: "",
+			expectErr:    analysis.ErrInvalidDateTime, // time.Parse fails on all, returns ErrInvalidDateTime
+		},
+		{
+			name:         "empty input",
+			parser:       parser1,
+			input:        "",
+			expectTime:   time.Time{},
+			expectLayout: "",
+			expectErr:    analysis.ErrInvalidDateTime,
+		},
+		{
+			name:         "parser with no layouts",
+			parser:       parserEmpty,
+			input:        "2023-10-27",
+			expectTime:   time.Time{},
+			expectLayout: "",
+			expectErr:    analysis.ErrInvalidDateTime,
+		},
+		{
+			name:         "not a date string",
+			parser:       parser1,
+			input:        "hello world",
+			expectTime:   time.Time{},
+			expectLayout: "",
+			expectErr:    analysis.ErrInvalidDateTime,
+		},
 	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotTime, gotLayout, gotErr := test.parser.ParseDateTime(test.input)
+
+			// Check error
+			if !reflect.DeepEqual(gotErr, test.expectErr) {
+				t.Fatalf("error mismatch:\nExpected: %v\nGot:      %v", test.expectErr, gotErr)
+			}
+
+			// Check time only if no error expected
+			if test.expectErr == nil {
+				if !gotTime.Equal(test.expectTime) {
+					t.Errorf("time mismatch:\nExpected: %v\nGot:      %v", test.expectTime, gotTime)
+				}
+				if gotLayout != test.expectLayout {
+					t.Errorf("layout mismatch:\nExpected: %q\nGot:      %q", test.expectLayout, gotLayout)
+				}
+			}
+		})
+	}
+}
+
+func TestDateTimeParserConstructor(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        map[string]interface{}
+		expectLayouts []string // Expected Go layouts after parsing
+		expectErr     error
+	}{
+		{
+			name: "valid config with multiple layouts",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%Y-%m-%d", "%H:%M:%S %Z"},
+			},
+			expectLayouts: []string{"2006-01-02", "15:04:05 MST"},
+			expectErr:     nil,
+		},
+		{
+			name: "valid config with single layout",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%Y/%m/%d %z:M"},
+			},
+			expectLayouts: []string{"2006/01/02 Z07:00"},
+			expectErr:     nil,
+		},
+		{
+			name: "valid config with complex layout",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%a, %d %b %Y %H:%M:%S %zH"},
+			},
+			expectLayouts: []string{"Mon, 02 Jan 2006 15:04:05 Z07"},
+			expectErr:     nil,
+		},
+		{
+			name: "config missing layouts key",
+			config: map[string]interface{}{
+				"other_key": "value",
+			},
+			expectLayouts: nil,
+			expectErr:     fmt.Errorf("must specify layouts"),
+		},
+		{
+			name: "config layouts not a slice",
+			config: map[string]interface{}{
+				"layouts": "not-a-slice", // Value is a string
+			},
+			expectLayouts: nil,
+			// Update the expected error message
+			expectErr: fmt.Errorf("must specify layouts"),
+		},
+		{
+			name: "config layouts contains non-string",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%Y-%m-%d", 123},
+			},
+			// Should process the valid string, ignore the int
+			expectLayouts: []string{"2006-01-02"},
+			expectErr:     nil,
+		},
+		{
+			name: "config layouts contains invalid percent format",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%Y-%m-%d", "%x"}, // %x is invalid
+			},
+			expectLayouts: nil,
+			expectErr:     fmt.Errorf("invalid format string, unknown format specifier: x"),
+		},
+		{
+			name: "config layouts contains format ending in %",
+			config: map[string]interface{}{
+				"layouts": []interface{}{"%Y-%m-%d", "%H:%M:%"},
+			},
+			expectLayouts: nil,
+			expectErr:     fmt.Errorf("invalid format string, expected character after %%"),
+		},
+		{
+			name: "config with empty layouts slice",
+			config: map[string]interface{}{
+				"layouts": []interface{}{},
+			},
+			expectLayouts: []string{}, // Expect an empty slice, not nil
+			expectErr:     nil,
+		},
+		{
+			name:          "nil config",
+			config:        nil,
+			expectLayouts: nil,
+			expectErr:     fmt.Errorf("must specify layouts"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Cache is not used by this constructor, so nil is fine
+			parserIntf, err := DateTimeParserConstructor(test.config, nil)
+
+			// Check error
+			// Use string comparison for errors as they might be created differently
+			expectedErrStr := ""
+			if test.expectErr != nil {
+				expectedErrStr = test.expectErr.Error()
+			}
+			actualErrStr := ""
+			if err != nil {
+				actualErrStr = err.Error()
+			}
+			if expectedErrStr != actualErrStr {
+				t.Fatalf("error mismatch:\nExpected: %q\nGot:      %q", expectedErrStr, actualErrStr)
+			}
+
+			// Check layouts only if no error expected
+			if test.expectErr == nil {
+				// Type assert to access the layouts field
+				parser, ok := parserIntf.(*DateTimeParser)
+				if !ok {
+					t.Fatalf("constructor did not return a *DateTimeParser")
+				}
+				if !reflect.DeepEqual(parser.layouts, test.expectLayouts) {
+					t.Errorf("layouts mismatch:\nExpected: %v\nGot:      %v", test.expectLayouts, parser.layouts)
+				}
+			}
+		})
+	}
 }

--- a/analysis/lang/cjk/cjk_bigram.go
+++ b/analysis/lang/cjk/cjk_bigram.go
@@ -132,6 +132,7 @@ func (s *CJKBigramFilter) flush(r *ring.Ring, itemsInRing *int, pos int) *analys
 	}
 	r.Value = nil
 	*itemsInRing = 0
+
 	return rv
 }
 
@@ -158,11 +159,13 @@ func (s *CJKBigramFilter) outputBigram(r *ring.Ring, itemsInRing *int, pos int) 
 		}
 		return &token
 	}
+
 	return nil
 }
 
 func (s *CJKBigramFilter) buildUnigram(r *ring.Ring, itemsInRing *int, pos int) *analysis.Token {
-	if *itemsInRing == 2 {
+	switch *itemsInRing {
+	case 2:
 		thisShingleRing := r.Move(-1)
 		// do first token
 		prev := thisShingleRing.Value.(*analysis.Token)
@@ -174,7 +177,7 @@ func (s *CJKBigramFilter) buildUnigram(r *ring.Ring, itemsInRing *int, pos int) 
 			End:      prev.End,
 		}
 		return &token
-	} else if *itemsInRing == 1 {
+	case 1:
 		// do first token
 		prev := r.Value.(*analysis.Token)
 		token := analysis.Token{
@@ -186,6 +189,7 @@ func (s *CJKBigramFilter) buildUnigram(r *ring.Ring, itemsInRing *int, pos int) 
 		}
 		return &token
 	}
+
 	return nil
 }
 

--- a/analysis/lang/cjk/cjk_bigram_test.go
+++ b/analysis/lang/cjk/cjk_bigram_test.go
@@ -15,14 +15,246 @@
 package cjk
 
 import (
+	"container/ring"
 	"reflect"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/analysis"
 )
 
-func TestCJKBigramFilter(t *testing.T) {
+// Helper function to create a token
+func makeToken(term string, start, end, pos int) *analysis.Token {
+	return &analysis.Token{
+		Term:     []byte(term),
+		Start:    start,
+		End:      end,
+		Position: pos, // Note: buildUnigram uses the 'pos' argument, not the token's original pos
+		Type:     analysis.Ideographic,
+	}
+}
 
+func TestCJKBigramFilter_buildUnigram(t *testing.T) {
+	filter := NewCJKBigramFilter(false)
+
+	tests := []struct {
+		name        string
+		ringSetup   func() (*ring.Ring, int) // Function to set up the ring and itemsInRing
+		inputPos    int                      // Position to pass to buildUnigram
+		expectToken *analysis.Token
+	}{
+		{
+			name: "itemsInRing == 2",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("一", 0, 3, 1) // Original pos 1
+				token2 := makeToken("二", 3, 6, 2) // Original pos 2
+				r.Value = token1
+				r = r.Next()
+				r.Value = token2
+				// r currently points to token2, r.Move(-1) points to token1
+				return r, 2
+			},
+			inputPos: 10, // Expected output position
+			expectToken: &analysis.Token{
+				Type:     analysis.Single,
+				Term:     []byte("一"),
+				Position: 10, // Should use inputPos
+				Start:    0,
+				End:      3,
+			},
+		},
+		{
+			name: "itemsInRing == 1 (ring points to the single item)",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("三", 6, 9, 3)
+				r.Value = token1
+				// r points to token1
+				return r, 1
+			},
+			inputPos: 11,
+			expectToken: &analysis.Token{
+				Type:     analysis.Single,
+				Term:     []byte("三"),
+				Position: 11, // Should use inputPos
+				Start:    6,
+				End:      9,
+			},
+		},
+		{
+			name: "itemsInRing == 1 (ring points to nil, next is the single item)",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("四", 9, 12, 4)
+				r = r.Next() // r points to nil initially
+				r.Value = token1
+				// r points to token1
+				return r, 1
+			},
+			inputPos: 12,
+			expectToken: &analysis.Token{
+				Type:     analysis.Single,
+				Term:     []byte("四"),
+				Position: 12, // Should use inputPos
+				Start:    9,
+				End:      12,
+			},
+		},
+		{
+			name: "itemsInRing == 0",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				// Ring is empty
+				return r, 0
+			},
+			inputPos:    13,
+			expectToken: nil, // Expect nil when itemsInRing is not 1 or 2
+		},
+		{
+			name: "itemsInRing > 2 (should behave like 0)",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("五", 12, 15, 5)
+				token2 := makeToken("六", 15, 18, 6)
+				r.Value = token1
+				r = r.Next()
+				r.Value = token2
+				// Simulate incorrect itemsInRing count
+				return r, 3
+			},
+			inputPos:    14,
+			expectToken: nil, // Expect nil when itemsInRing is not 1 or 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ringPtr, itemsInRing := tt.ringSetup()
+			itemsInRingCopy := itemsInRing // Pass a pointer to a copy
+
+			gotToken := filter.buildUnigram(ringPtr, &itemsInRingCopy, tt.inputPos)
+
+			if !reflect.DeepEqual(gotToken, tt.expectToken) {
+				t.Errorf("buildUnigram() got = %v, want %v", gotToken, tt.expectToken)
+			}
+
+			// Check if itemsInRing was modified (it shouldn't be by buildUnigram)
+			if itemsInRingCopy != itemsInRing {
+				t.Errorf("buildUnigram() modified itemsInRing, got = %d, want %d", itemsInRingCopy, itemsInRing)
+			}
+		})
+	}
+}
+
+func TestCJKBigramFilter_outputBigram(t *testing.T) {
+	// Create a filter instance (outputUnigram value doesn't matter for outputBigram)
+	filter := NewCJKBigramFilter(false)
+
+	tests := []struct {
+		name        string
+		ringSetup   func() (*ring.Ring, int) // Function to set up the ring and itemsInRing
+		inputPos    int                      // Position to pass to outputBigram
+		expectToken *analysis.Token
+	}{
+		{
+			name: "itemsInRing == 2",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("一", 0, 3, 1) // Original pos 1
+				token2 := makeToken("二", 3, 6, 2) // Original pos 2
+				r.Value = token1
+				r = r.Next()
+				r.Value = token2
+				// r currently points to token2, r.Move(-1) points to token1
+				return r, 2
+			},
+			inputPos: 10, // Expected output position
+			expectToken: &analysis.Token{
+				Type:     analysis.Double,
+				Term:     []byte("一二"), // Combined term
+				Position: 10,           // Should use inputPos
+				Start:    0,            // Start of first token
+				End:      6,            // End of second token
+			},
+		},
+		{
+			name: "itemsInRing == 2 with different terms",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("你好", 0, 6, 1)
+				token2 := makeToken("世界", 6, 12, 2)
+				r.Value = token1
+				r = r.Next()
+				r.Value = token2
+				return r, 2
+			},
+			inputPos: 5,
+			expectToken: &analysis.Token{
+				Type:     analysis.Double,
+				Term:     []byte("你好世界"),
+				Position: 5,
+				Start:    0,
+				End:      12,
+			},
+		},
+		{
+			name: "itemsInRing == 1",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("三", 6, 9, 3)
+				r.Value = token1
+				return r, 1
+			},
+			inputPos:    11,
+			expectToken: nil, // Expect nil when itemsInRing is not 2
+		},
+		{
+			name: "itemsInRing == 0",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				// Ring is empty
+				return r, 0
+			},
+			inputPos:    13,
+			expectToken: nil, // Expect nil when itemsInRing is not 2
+		},
+		{
+			name: "itemsInRing > 2 (should behave like 0)",
+			ringSetup: func() (*ring.Ring, int) {
+				r := ring.New(2)
+				token1 := makeToken("五", 12, 15, 5)
+				token2 := makeToken("六", 15, 18, 6)
+				r.Value = token1
+				r = r.Next()
+				r.Value = token2
+				// Simulate incorrect itemsInRing count
+				return r, 3
+			},
+			inputPos:    14,
+			expectToken: nil, // Expect nil when itemsInRing is not 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ringPtr, itemsInRing := tt.ringSetup()
+			itemsInRingCopy := itemsInRing // Pass a pointer to a copy
+
+			gotToken := filter.outputBigram(ringPtr, &itemsInRingCopy, tt.inputPos)
+
+			if !reflect.DeepEqual(gotToken, tt.expectToken) {
+				t.Errorf("outputBigram() got = %v, want %v", gotToken, tt.expectToken)
+			}
+
+			// Check if itemsInRing was modified (it shouldn't be by outputBigram)
+			if itemsInRingCopy != itemsInRing {
+				t.Errorf("outputBigram() modified itemsInRing, got = %d, want %d", itemsInRingCopy, itemsInRing)
+			}
+		})
+	}
+}
+
+func TestCJKBigramFilter(t *testing.T) {
 	tests := []struct {
 		outputUnigram bool
 		input         analysis.TokenStream

--- a/index/scorch/merge_test.go
+++ b/index/scorch/merge_test.go
@@ -42,13 +42,14 @@ func TestObsoleteSegmentMergeIntroduction(t *testing.T) {
 	mergeIntroComplete.Add(1)
 	var segIntroCompleted int
 	RegistryEventCallbacks["test"] = func(e Event) bool {
-		if e.Kind == EventKindBatchIntroduction {
+		switch e.Kind {
+		case EventKindBatchIntroduction:
 			segIntroCompleted++
 			if segIntroCompleted == 3 {
 				// all 3 segments introduced
 				introComplete.Done()
 			}
-		} else if e.Kind == EventKindMergeTaskIntroductionStart {
+		case EventKindMergeTaskIntroductionStart:
 			// signal the start of merge task introduction so that
 			// we can introduce a new batch which obsoletes the
 			// merged segment's contents.
@@ -56,11 +57,12 @@ func TestObsoleteSegmentMergeIntroduction(t *testing.T) {
 			// hold the merge task introduction until the merged segment contents
 			// are obsoleted with the next batch/segment introduction.
 			introComplete.Wait()
-		} else if e.Kind == EventKindMergeTaskIntroduction {
+		case EventKindMergeTaskIntroduction:
 			// signal the completion of the merge task introduction.
 			mergeIntroComplete.Done()
 
 		}
+
 		return true
 	}
 

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -82,7 +82,7 @@ type IndexSnapshot struct {
 	m2        sync.Mutex                                 // Protects the fields that follow.
 	fieldTFRs map[string][]*IndexSnapshotTermFieldReader // keyed by field, recycled TFR's
 
-	m3               sync.RWMutex //bm25 metrics specific - not to interfere with TFR creation
+	m3               sync.RWMutex // bm25 metrics specific - not to interfere with TFR creation
 	fieldCardinality map[string]int
 }
 
@@ -331,9 +331,10 @@ func (is *IndexSnapshot) fieldDictRegexp(field string,
 func (is *IndexSnapshot) getLevAutomaton(term string,
 	fuzziness uint8,
 ) (vellum.Automaton, error) {
-	if fuzziness == 1 {
+	switch fuzziness {
+	case 1:
 		return lb1.BuildDfa(term, fuzziness)
-	} else if fuzziness == 2 {
+	case 2:
 		return lb2.BuildDfa(term, fuzziness)
 	}
 	return nil, fmt.Errorf("fuzziness exceeds the max limit")

--- a/index/scorch/snapshot_index_test.go
+++ b/index/scorch/snapshot_index_test.go
@@ -1,0 +1,90 @@
+package scorch
+
+import (
+	"testing"
+
+	"github.com/blevesearch/vellum"
+)
+
+func TestIndexSnapshot_getLevAutomaton(t *testing.T) {
+	// Create a dummy IndexSnapshot (parent doesn't matter for this method)
+	is := &IndexSnapshot{}
+
+	tests := []struct {
+		name        string
+		term        string
+		fuzziness   uint8
+		expectError bool
+		errorMsg    string // Optional: check specific error message
+	}{
+		{
+			name:        "fuzziness 1",
+			term:        "test",
+			fuzziness:   1,
+			expectError: false,
+		},
+		{
+			name:        "fuzziness 2",
+			term:        "another",
+			fuzziness:   2,
+			expectError: false,
+		},
+		{
+			name:        "fuzziness 0",
+			term:        "zero",
+			fuzziness:   0,
+			expectError: true,
+			errorMsg:    "fuzziness exceeds the max limit",
+		},
+		{
+			name:        "fuzziness 3",
+			term:        "three",
+			fuzziness:   3,
+			expectError: true,
+			errorMsg:    "fuzziness exceeds the max limit",
+		},
+		{
+			name:        "empty term fuzziness 1",
+			term:        "",
+			fuzziness:   1,
+			expectError: false,
+		},
+		{
+			name:        "empty term fuzziness 2",
+			term:        "",
+			fuzziness:   2,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAutomaton, err := is.getLevAutomaton(tt.term, tt.fuzziness)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("getLevAutomaton() expected an error but got nil")
+				} else if tt.errorMsg != "" && err.Error() != tt.errorMsg {
+					t.Errorf("getLevAutomaton() expected error msg %q but got %q", tt.errorMsg, err.Error())
+				}
+				if gotAutomaton != nil {
+					t.Errorf("getLevAutomaton() expected nil automaton on error but got %v", gotAutomaton)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("getLevAutomaton() got unexpected error: %v", err)
+				}
+				if gotAutomaton == nil {
+					t.Errorf("getLevAutomaton() expected a valid automaton but got nil")
+				}
+				// Optional: Check type if needed, though non-nil is usually sufficient
+				_, ok := gotAutomaton.(vellum.Automaton)
+				if !ok {
+					t.Errorf("getLevAutomaton() returned type is not vellum.Automaton")
+				}
+			}
+		})
+	}
+}
+
+// Add other tests for snapshot_index.go below if needed...

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -52,7 +52,8 @@ type DocumentMapping struct {
 }
 
 func (dm *DocumentMapping) Validate(cache *registry.Cache,
-	parentName string, fieldAliasCtx map[string]*FieldMapping) error {
+	parentName string, fieldAliasCtx map[string]*FieldMapping,
+) error {
 	var err error
 	if dm.DefaultAnalyzer != "" {
 		_, err := cache.AnalyzerNamed(dm.DefaultAnalyzer)
@@ -183,7 +184,8 @@ func (dm *DocumentMapping) fieldDescribedByPath(path string) *FieldMapping {
 // document or for an explicitly mapped field; the closest most specific
 // document mapping could be one that matches part of the provided path.
 func (dm *DocumentMapping) documentMappingForPathElements(pathElements []string) (
-	*DocumentMapping, *DocumentMapping) {
+	*DocumentMapping, *DocumentMapping,
+) {
 	var pathElementsCopy []string
 	if len(pathElements) == 0 {
 		pathElementsCopy = []string{""}
@@ -217,7 +219,8 @@ OUTER:
 // document or for an explicitly mapped field; the closest most specific
 // document mapping could be one that matches part of the provided path.
 func (dm *DocumentMapping) documentMappingForPath(path string) (
-	*DocumentMapping, *DocumentMapping) {
+	*DocumentMapping, *DocumentMapping,
+) {
 	pathElements := decodePath(path)
 	return dm.documentMappingForPathElements(pathElements)
 }
@@ -457,7 +460,6 @@ func (dm *DocumentMapping) walkDocument(data interface{}, path []string, indexes
 	case reflect.Bool:
 		dm.processProperty(val.Bool(), path, indexes, context)
 	}
-
 }
 
 func (dm *DocumentMapping) processProperty(property interface{}, path []string, indexes []uint64, context *walkContext) {
@@ -483,13 +485,14 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		if subDocMapping != nil {
 			// index by explicit mapping
 			for _, fieldMapping := range subDocMapping.Fields {
-				if fieldMapping.Type == "geoshape" {
+				switch fieldMapping.Type {
+				case "geoshape":
 					fieldMapping.processGeoShape(property, pathString, path, indexes, context)
-				} else if fieldMapping.Type == "geopoint" {
+				case "geopoint":
 					fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
-				} else if fieldMapping.Type == "vector_base64" {
+				case "vector_base64":
 					fieldMapping.processVectorBase64(property, pathString, path, indexes, context)
-				} else {
+				default:
 					fieldMapping.processString(propertyValueString, pathString, path, indexes, context)
 				}
 			}

--- a/mapping/document.go
+++ b/mapping/document.go
@@ -571,9 +571,10 @@ func (dm *DocumentMapping) processProperty(property interface{}, path []string, 
 		default:
 			if subDocMapping != nil {
 				for _, fieldMapping := range subDocMapping.Fields {
-					if fieldMapping.Type == "geopoint" {
+					switch fieldMapping.Type {
+					case "geopoint":
 						fieldMapping.processGeoPoint(property, pathString, path, indexes, context)
-					} else if fieldMapping.Type == "geoshape" {
+					case "geoshape":
 						fieldMapping.processGeoShape(property, pathString, path, indexes, context)
 					}
 				}

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -337,7 +337,8 @@ func (fm *FieldMapping) processGeoShape(propertyMightBeGeoShape interface{},
 		return
 	}
 
-	if shape == geo.CircleType {
+	switch shape {
+	case geo.CircleType:
 		center, radius, found := geo.ExtractCircle(propertyMightBeGeoShape)
 		if found {
 			fieldName := getFieldName(pathString, path, fm)
@@ -350,7 +351,7 @@ func (fm *FieldMapping) processGeoShape(propertyMightBeGeoShape interface{},
 				context.excludedFromAll = append(context.excludedFromAll, fieldName)
 			}
 		}
-	} else if shape == geo.GeometryCollectionType {
+	case geo.GeometryCollectionType:
 		coordinates, shapes, found := geo.ExtractGeometryCollection(propertyMightBeGeoShape)
 		if found {
 			fieldName := getFieldName(pathString, path, fm)
@@ -363,7 +364,7 @@ func (fm *FieldMapping) processGeoShape(propertyMightBeGeoShape interface{},
 				context.excludedFromAll = append(context.excludedFromAll, fieldName)
 			}
 		}
-	} else {
+	default:
 		coordinates, shape, found := geo.ExtractGeoShapeCoordinates(coordValue, shape)
 		if found {
 			fieldName := getFieldName(pathString, path, fm)

--- a/mapping/field.go
+++ b/mapping/field.go
@@ -231,7 +231,9 @@ func (fm *FieldMapping) Options() index.FieldIndexingOptions {
 func (fm *FieldMapping) processString(propertyValueString string, pathString string, path []string, indexes []uint64, context *walkContext) {
 	fieldName := getFieldName(pathString, path, fm)
 	options := fm.Options()
-	if fm.Type == "text" {
+
+	switch fm.Type {
+	case "text":
 		analyzer := fm.analyzerForField(path, context)
 		field := document.NewTextFieldCustom(fieldName, indexes, []byte(propertyValueString), options, analyzer)
 		context.doc.AddField(field)
@@ -239,7 +241,7 @@ func (fm *FieldMapping) processString(propertyValueString string, pathString str
 		if !fm.IncludeInAll {
 			context.excludedFromAll = append(context.excludedFromAll, fieldName)
 		}
-	} else if fm.Type == "datetime" {
+	case "datetime":
 		dateTimeFormat := context.im.DefaultDateTimeParser
 		if fm.DateFormat != "" {
 			dateTimeFormat = fm.DateFormat
@@ -251,7 +253,7 @@ func (fm *FieldMapping) processString(propertyValueString string, pathString str
 				fm.processTime(parsedDateTime, layout, pathString, path, indexes, context)
 			}
 		}
-	} else if fm.Type == "IP" {
+	case "IP":
 		ip := net.ParseIP(propertyValueString)
 		if ip != nil {
 			fm.processIP(ip, pathString, path, indexes, context)
@@ -328,7 +330,8 @@ func (fm *FieldMapping) processIP(ip net.IP, pathString string, path []string, i
 }
 
 func (fm *FieldMapping) processGeoShape(propertyMightBeGeoShape interface{},
-	pathString string, path []string, indexes []uint64, context *walkContext) {
+	pathString string, path []string, indexes []uint64, context *walkContext,
+) {
 	coordValue, shape, err := geo.ParseGeoShapeField(propertyMightBeGeoShape)
 	if err != nil {
 		return
@@ -401,7 +404,6 @@ func getFieldName(pathString string, path []string, fieldMapping *FieldMapping) 
 
 // UnmarshalJSON offers custom unmarshaling with optional strict validation
 func (fm *FieldMapping) UnmarshalJSON(data []byte) error {
-
 	var tmp map[string]json.RawMessage
 	err := util.UnmarshalJSON(data, &tmp)
 	if err != nil {

--- a/search/sort.go
+++ b/search/sort.go
@@ -154,15 +154,18 @@ func ParseSearchSortString(input string) SearchSort {
 	} else if strings.HasPrefix(input, "+") {
 		input = input[1:]
 	}
-	if input == "_id" {
+
+	switch input {
+	case "_id":
 		return &SortDocID{
 			Desc: descending,
 		}
-	} else if input == "_score" {
+	case "_score":
 		return &SortScore{
 			Desc: descending,
 		}
 	}
+
 	return &SortField{
 		Field: input,
 		Desc:  descending,

--- a/search/sort.go
+++ b/search/sort.go
@@ -429,7 +429,9 @@ func (s *SortField) filterTermsByMode(terms [][]byte) string {
 // prefix coded numbers with shift of 0
 func (s *SortField) filterTermsByType(terms [][]byte) [][]byte {
 	stype := s.Type
-	if stype == SortFieldAuto {
+
+	switch stype {
+	case SortFieldAuto:
 		allTermsPrefixCoded := true
 		termsWithShiftZero := s.tmp[:0]
 		for _, term := range terms {
@@ -445,7 +447,7 @@ func (s *SortField) filterTermsByType(terms [][]byte) [][]byte {
 			terms = termsWithShiftZero
 			s.tmp = termsWithShiftZero[:0]
 		}
-	} else if stype == SortFieldAsNumber || stype == SortFieldAsDate {
+	case SortFieldAsNumber, SortFieldAsDate:
 		termsWithShiftZero := s.tmp[:0]
 		for _, term := range terms {
 			valid, shift := numeric.ValidPrefixCodedTermBytes(term)
@@ -456,6 +458,7 @@ func (s *SortField) filterTermsByType(terms [][]byte) [][]byte {
 		terms = termsWithShiftZero
 		s.tmp = termsWithShiftZero[:0]
 	}
+
 	return terms
 }
 


### PR DESCRIPTION
Since I started using this project on my production workloads, I would like to contribute to the project.

__NOTES:__

- In the cases where I can use a `unit test` to test the code, I will do it. The unit test I added was created by `Github Copilot Agent` using the model `Gemini 2.5 Pro`, and most of them were adapted by me.
- Some of the improvements I made are not directly related to the `golangci-lint` findings, but I believe they are important for the project. All of them were proposed by `Github Copilot Agent` using the model `Gemini 2.5 Pro`, but I modified most of them so that they wouldn't alter  the code too much and facilitate the `code review`.


This delivery improves two golangci-lint findings:

1. `S1023:` redundant break statement (staticcheck)
2. `QF1003:` could use tagged switch on count (staticcheck)

```bash
golangci-lint --version
golangci-lint has version v2.1.2 built with go1.24.2 from (unknown, modified: ?, mod sum: "h1:bcOB+jVr4EYEgOEIskQIhtdxOpIGl+iOCwliG/hNPXw=") on (unknown)
```
This fifth delivery fixed the following files and lines:

- minor formatting changes
- `golangci-lint run --enable-only staticcheck ./... | grep "S1023"`
  - analysis/char/asciifolding/asciifolding.go:3564:5: S1023: redundant break statement (staticcheck)
- `golangci-lint run --enable-only staticcheck ./... | grep "QF1003"`
  - analysis/datetime/iso/iso.go:176:6: QF1003: could use tagged switch on count (staticcheck)
  - analysis/datetime/percent/percent.go:87:3: QF1003: could use tagged switch on formatString[idx+2] (staticcheck)
  - analysis/lang/cjk/cjk_bigram.go:165:2: QF1003: could use tagged switch on *itemsInRing (staticcheck)
  - index/scorch/merge_test.go:45:3: QF1003: could use tagged switch on e.Kind (staticcheck)
  - index/scorch/snapshot_index.go:334:2: QF1003: could use tagged switch on fuzziness (staticcheck)
  - mapping/document.go:486:5: QF1003: could use tagged switch on fieldMapping.Type (staticcheck)
  - mapping/document.go:571:6: QF1003: could use tagged switch on fieldMapping.Type (staticcheck)
  - mapping/field.go:234:2: QF1003: could use tagged switch on fm.Type (staticcheck)
  - mapping/field.go:337:2: QF1003: could use tagged switch on shape (staticcheck)
  - search/sort.go:157:2: QF1003: could use tagged switch on input (staticcheck)
  - search/sort.go:429:2: QF1003: could use tagged switch on stype (staticcheck)