### PR TITLE
MB-66163: fix checkpointing mechanism under sparse mutation scenarios 

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -846,7 +846,7 @@ var (
 )
 
 func (s *Scorch) loadFromBolt() error {
-	return s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *bolt.Tx) error {
 		snapshots := tx.Bucket(boltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
@@ -896,6 +896,16 @@ func (s *Scorch) loadFromBolt() error {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	persistedSnapshots, err := s.rootBoltSnapshotMetaData()
+	if err != nil {
+		return err
+	}
+	s.checkPoints = persistedSnapshots
+	return nil
 }
 
 // LoadSnapshot loads the segment with the specified epoch

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1283,7 +1283,7 @@ func (s *Scorch) removeOldZapFiles() error {
 // duration. This results in all of them being purged from the boltDB
 // and the next iteration of the removeOldData() would end up protecting
 // latest contiguous snapshot which is a poor pattern in the rollback checkpoints.
-// Hence we try to retain atleast retentionFactor portion worth of old snapshots
+// Hence we try to retain atmost retentionFactor portion worth of old snapshots
 // in such a scenario using the following function
 func getBoundaryCheckPoint(retentionFactor float64,
 	checkPoints []*snapshotMetaData, timeStamp time.Time,
@@ -1291,7 +1291,7 @@ func getBoundaryCheckPoint(retentionFactor float64,
 	if checkPoints != nil {
 		boundary := checkPoints[int(math.Floor(float64(len(checkPoints))*
 			retentionFactor))]
-		if timeStamp.Sub(boundary.timeStamp) < 0 {
+		if timeStamp.Sub(boundary.timeStamp) > 0 {
 			// too less checkPoints would be left.
 			return boundary.timeStamp
 		}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1302,10 +1302,12 @@ func getBoundaryCheckPoint(retentionFactor float64,
 		boundary := checkPoints[int(math.Floor(float64(len(checkPoints))*
 			retentionFactor))]
 		if timeStamp.Sub(boundary.timeStamp) > 0 {
-			// too less checkPoints would be left.
+			// return the extended boundary which will dictate the older snapshots
+			// to be retained
 			return boundary.timeStamp
 		}
 	}
+
 	return timeStamp
 }
 

--- a/index/scorch/rollback_test.go
+++ b/index/scorch/rollback_test.go
@@ -550,3 +550,77 @@ func TestBackupRacingWithPurge(t *testing.T) {
 		t.Fatalf("error copying the index: %v", err)
 	}
 }
+
+func TestSparseMutationCheckpointing(t *testing.T) {
+	cfg := CreateConfig("TestSparseMutationCheckpointing")
+	numSnapshotsToKeepOrig := NumSnapshotsToKeep
+	NumSnapshotsToKeep = 3
+	rollbackSamplingIntervalOrig := RollbackSamplingInterval
+	RollbackSamplingInterval = 2 * time.Second
+
+	err := InitTest(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		NumSnapshotsToKeep = numSnapshotsToKeepOrig
+		RollbackSamplingInterval = rollbackSamplingIntervalOrig
+		err := DestroyTest(cfg)
+		if err != nil {
+			t.Log(err)
+		}
+	}()
+
+	// disable merger and purger
+	RegistryEventCallbacks["test"] = func(e Event) bool {
+		if e.Kind == EventKindPreMergeCheck {
+			return false
+		}
+		return true
+	}
+	cfg["eventCallbackName"] = "test"
+	analysisQueue := index.NewAnalysisQueue(1)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scorchi, ok := idx.(*Scorch)
+	if !ok {
+		t.Fatalf("Not a scorch index?")
+	}
+
+	err = scorchi.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// replicate the following scenario of persistence of snapshots
+	// tc, tc - d/12, tc - d/6, tc - 3d/4, tc - 5d/6, tc - 6d/5
+	// approximate timestamps where there's a chance that the latest snapshot
+	// might not fit into the time-series
+	indexDummyData(t, scorchi, 1)
+	time.Sleep(RollbackSamplingInterval)
+	indexDummyData(t, scorchi, 3)
+	time.Sleep(RollbackSamplingInterval)
+	indexDummyData(t, scorchi, 5)
+	time.Sleep(RollbackSamplingInterval)
+	indexDummyData(t, scorchi, 7)
+
+	// now the another snapshot is persisted outside of the window of checkpointing
+	// and we should be able to retain some older checkpoints as well along with
+	// the latest one
+	time.Sleep(time.Duration(NumSnapshotsToKeep) * RollbackSamplingInterval)
+	indexDummyData(t, scorchi, 9)
+
+	persistedSnapshots, err := scorchi.rootBoltSnapshotMetaData()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// should have more than 1 snapshots
+	protectedSnapshots := getProtectedSnapshots(RollbackSamplingInterval, NumSnapshotsToKeep, persistedSnapshots)
+	if len(protectedSnapshots) <= 1 {
+		t.Fatalf("expected %d protected snapshots, got %d", NumSnapshotsToKeep, len(protectedSnapshots))
+	}
+}

--- a/index/scorch/rollback_test.go
+++ b/index/scorch/rollback_test.go
@@ -512,7 +512,7 @@ func TestBackupRacingWithPurge(t *testing.T) {
 	}
 
 	// replicate the following scenario of persistence of snapshots
-	// tc, tc - d/12, tc - d/6, tc - 3d/4, tc - 5d/6, tc - 6d/5, tc - 2d
+	// tc, tc - d/12, tc - d/6, tc - 3d/4, tc - 5d/6, tc - 6d/5
 	// approximate timestamps where there's a chance that the latest snapshot
 	// might not fit into the time-series
 	indexDummyData(t, scorchi, 1)
@@ -595,10 +595,7 @@ func TestSparseMutationCheckpointing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// replicate the following scenario of persistence of snapshots
-	// tc, tc - d/12, tc - d/6, tc - 3d/4, tc - 5d/6, tc - 6d/5
-	// approximate timestamps where there's a chance that the latest snapshot
-	// might not fit into the time-series
+	// create 4 snapshots every 2 seconds
 	indexDummyData(t, scorchi, 1)
 	time.Sleep(RollbackSamplingInterval)
 	indexDummyData(t, scorchi, 3)


### PR DESCRIPTION
- the checkpointing mechanism considers snapshots which fall within the `numSnapshotsToKeep * rollbackSamplingInterval` duration window. The snapshots outside this window are purged. 
- Under sparse mutation scenario for eg, when the workload pattern in such that it results in seldomly persisting snapshots that too outside this duration window - we could end up purging ALL those snapshots which makes the system fallback to preserving the latest snapshots
- For a better partial rollback behaviour, we retain `rollbackRetentionFactor` worth of snapshots out of this duration window such that the cost of rebuilding the index from scratch is avoided. 
- This PR fixes the decision logic involved in the scenario pointed and tracks the previous checkpoints while opening back the index as well.  