### PR TITLE
Fix: Increment `searches` stat correctly during presearch phase

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -567,6 +567,10 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		if err != nil {
 			return nil, err
 		}
+		// increment the search count here itself,
+		// since the presearch may already satisfy
+		// the search request
+		atomic.AddUint64(&i.stats.searches, 1)
 		return preSearchResult, nil
 	}
 
@@ -811,7 +815,11 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 	totalSearchCost += storedFieldsCost
 	search.RecordSearchCost(ctx, search.AddM, storedFieldsCost)
 
-	atomic.AddUint64(&i.stats.searches, 1)
+	if req.PreSearchData == nil {
+		// increment the search count only if this is not a second-phase search
+		// (e.g., for Hybrid Search), since the first-phase search already increments it
+		atomic.AddUint64(&i.stats.searches, 1)
+	}
 	searchDuration := time.Since(searchStart)
 	atomic.AddUint64(&i.stats.searchTime, uint64(searchDuration))
 

--- a/index_impl.go
+++ b/index_impl.go
@@ -571,6 +571,12 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		// since the presearch may already satisfy
 		// the search request
 		atomic.AddUint64(&i.stats.searches, 1)
+		// increment the search time stat here as well,
+		// since presearch is part of the overall search
+		// operation and should be included in the search
+		// time stat
+		searchDuration := time.Since(searchStart)
+		atomic.AddUint64(&i.stats.searchTime, uint64(searchDuration))
 		return preSearchResult, nil
 	}
 
@@ -820,6 +826,8 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 		// (e.g., for Hybrid Search), since the first-phase search already increments it
 		atomic.AddUint64(&i.stats.searches, 1)
 	}
+	// increment the search time stat, as the first-phase search is part of
+	// the overall operation; adding second-phase time later keeps it accurate
 	searchDuration := time.Since(searchStart)
 	atomic.AddUint64(&i.stats.searchTime, uint64(searchDuration))
 


### PR DESCRIPTION
- Previously, the `searches` stat was only incremented at the end of the second phase in two-phase searches.
- If the search request was satisfied during the presearch phase and the second phase was skipped, the `searches` stat was not incremented.
- This PR fixes the issue by incrementing the stat at the end of the presearch phase itself, ensuring it correctly reflects the number of searches whether the request is satisfied in the first phase or requires both phases.
- Also fixes the `searchTime` stat to ensure accurate values for both single-phase and two-phase searches.