### PR TITLE
Bug Fix: Prevent Indexing of `vector` and `geoshape` fields when `Index` option is `False`

### DIFF
--- a/document/field_geoshape.go
+++ b/document/field_geoshape.go
@@ -158,7 +158,9 @@ func NewGeoShapeFieldWithIndexingOptions(name string, arrayPositions []uint64,
 		return nil
 	}
 
-	options = options | DefaultGeoShapeIndexingOptions
+	// docvalues are always enabled for geoshape fields, even if the
+	// indexing options are set to not include docvalues.
+	options = options | index.DocValues
 
 	return &GeoShapeField{
 		shape:             shape,
@@ -189,7 +191,9 @@ func NewGeometryCollectionFieldWithIndexingOptions(name string,
 		return nil
 	}
 
-	options = options | DefaultGeoShapeIndexingOptions
+	// docvalues are always enabled for geoshape fields, even if the
+	// indexing options are set to not include docvalues.
+	options = options | index.DocValues
 
 	return &GeoShapeField{
 		shape:             shape,
@@ -220,7 +224,9 @@ func NewGeoCircleFieldWithIndexingOptions(name string, arrayPositions []uint64,
 		return nil
 	}
 
-	options = options | DefaultGeoShapeIndexingOptions
+	// docvalues are always enabled for geoshape fields, even if the
+	// indexing options are set to not include docvalues.
+	options = options | index.DocValues
 
 	return &GeoShapeField{
 		shape:             shape,

--- a/document/field_vector.go
+++ b/document/field_vector.go
@@ -109,7 +109,6 @@ func NewVectorField(name string, arrayPositions []uint64,
 func NewVectorFieldWithIndexingOptions(name string, arrayPositions []uint64,
 	vector []float32, dims int, similarity, vectorIndexOptimizedFor string,
 	options index.FieldIndexingOptions) *VectorField {
-	options = options | DefaultVectorIndexingOptions
 
 	return &VectorField{
 		name:                    name,


### PR DESCRIPTION
- If a field mapping for a vector or geoshape has the `Index` option set to `false`, the field is still indexed because the current code incorrectly always overrides this option to `true`.

- This behavior has been fixed by ensuring that the Index option is not overridden and the field is only indexed if explicitly allowed by the user-specified Index setting.