### PR TITLE
Bug Fix: Validate KNN Filter Queries

### DIFF
--- a/search/query/knn.go
+++ b/search/query/knn.go
@@ -35,8 +35,7 @@ type KNNQuery struct {
 	BoostVal    *Boost    `json:"boost,omitempty"`
 
 	// see KNNRequest.Params for description
-	Params      json.RawMessage `json:"params"`
-	FilterQuery Query           `json:"filter,omitempty"`
+	Params json.RawMessage `json:"params"`
 	// elegibleSelector is used to filter out documents that are
 	// eligible for the KNN search from a pre-filter query.
 	elegibleSelector index.EligibleDocumentSelector

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -1263,7 +1263,10 @@ func TestKNNScoreBoosting(t *testing.T) {
 
 	batch := index.NewBatch()
 	for i := 0; i < len(dataset); i++ {
-		batch.Index(strconv.Itoa(i), dataset[i])
+		err = batch.Index(strconv.Itoa(i), dataset[i])
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	err = index.Batch(batch)
@@ -1354,7 +1357,10 @@ func TestKNNOperator(t *testing.T) {
 
 	batch := index.NewBatch()
 	for i := 0; i < len(dataset); i++ {
-		batch.Index(strconv.Itoa(i), dataset[i])
+		err = batch.Index(strconv.Itoa(i), dataset[i])
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	err = index.Batch(batch)
@@ -1464,7 +1470,10 @@ func TestKNNFiltering(t *testing.T) {
 	batch := index.NewBatch()
 	for i := 0; i < len(dataset); i++ {
 		// the id of term "i" is (i-1000)
-		batch.Index(strconv.Itoa(i), dataset[i])
+		err = batch.Index(strconv.Itoa(i), dataset[i])
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	err = index.Batch(batch)
@@ -1582,7 +1591,10 @@ func TestNestedVectors(t *testing.T) {
 
 	batch := index.NewBatch()
 	for docID, doc := range dataset {
-		batch.Index(docID, doc)
+		err = batch.Index(docID, doc)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	err = index.Batch(batch)


### PR DESCRIPTION
- Previously, filter queries were not validated during the KNN request validation phase, which could lead to unexpected filter query behavior. This has been fixed by adding proper validation.
- Also fixed an issue where errors during JSON unmarshalling of invalid filter queries were being silently ignored.