### PR TITLE
Fix: Prevent infinite loop in synonym search with legacy (`<v16`) segment plugins

### DIFF
--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -1033,11 +1033,12 @@ func (is *IndexSnapshot) CloseCopyReader() error {
 
 func (is *IndexSnapshot) ThesaurusTermReader(ctx context.Context, thesaurusName string, term []byte) (index.ThesaurusTermReader, error) {
 	rv := &IndexSnapshotThesaurusTermReader{
-		name:      thesaurusName,
-		snapshot:  is,
-		postings:  make([]segment.SynonymsList, len(is.segment)),
-		iterators: make([]segment.SynonymsIterator, len(is.segment)),
-		thesauri:  make([]segment.Thesaurus, len(is.segment)),
+		name:          thesaurusName,
+		snapshot:      is,
+		postings:      make([]segment.SynonymsList, len(is.segment)),
+		iterators:     make([]segment.SynonymsIterator, len(is.segment)),
+		thesauri:      make([]segment.Thesaurus, len(is.segment)),
+		segmentOffset: 0,
 	}
 
 	for i, s := range is.segment {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -1032,32 +1032,21 @@ func (is *IndexSnapshot) CloseCopyReader() error {
 }
 
 func (is *IndexSnapshot) ThesaurusTermReader(ctx context.Context, thesaurusName string, term []byte) (index.ThesaurusTermReader, error) {
-	rv := &IndexSnapshotThesaurusTermReader{}
-	rv.name = thesaurusName
-	rv.snapshot = is
-	if rv.postings == nil {
-		rv.postings = make([]segment.SynonymsList, len(is.segment))
-	}
-	if rv.iterators == nil {
-		rv.iterators = make([]segment.SynonymsIterator, len(is.segment))
-	}
-	rv.segmentOffset = 0
-
-	if rv.thesauri == nil {
-		rv.thesauri = make([]segment.Thesaurus, len(is.segment))
-		for i, s := range is.segment {
-			if synSeg, ok := s.segment.(segment.ThesaurusSegment); ok {
-				thes, err := synSeg.Thesaurus(thesaurusName)
-				if err != nil {
-					return nil, err
-				}
-				rv.thesauri[i] = thes
-			}
-		}
+	rv := &IndexSnapshotThesaurusTermReader{
+		name:      thesaurusName,
+		snapshot:  is,
+		postings:  make([]segment.SynonymsList, len(is.segment)),
+		iterators: make([]segment.SynonymsIterator, len(is.segment)),
+		thesauri:  make([]segment.Thesaurus, len(is.segment)),
 	}
 
 	for i, s := range is.segment {
-		if _, ok := s.segment.(segment.ThesaurusSegment); ok {
+		if synSeg, ok := s.segment.(segment.ThesaurusSegment); ok {
+			thes, err := synSeg.Thesaurus(thesaurusName)
+			if err != nil {
+				return nil, err
+			}
+			rv.thesauri[i] = thes
 			pl, err := rv.thesauri[i].SynonymsList(term, s.deleted, rv.postings[i])
 			if err != nil {
 				return nil, err

--- a/index/scorch/snapshot_index_str.go
+++ b/index/scorch/snapshot_index_str.go
@@ -42,11 +42,15 @@ func (i *IndexSnapshotThesaurusTermReader) Size() int {
 		len(i.name) + size.SizeOfString
 
 	for _, postings := range i.postings {
-		sizeInBytes += postings.Size()
+		if postings != nil {
+			sizeInBytes += postings.Size()
+		}
 	}
 
 	for _, iterator := range i.iterators {
-		sizeInBytes += iterator.Size()
+		if iterator != nil {
+			sizeInBytes += iterator.Size()
+		}
 	}
 
 	return sizeInBytes
@@ -64,8 +68,8 @@ func (i *IndexSnapshotThesaurusTermReader) Next() (string, error) {
 				synTerm := next.Term()
 				return synTerm, nil
 			}
-			i.segmentOffset++
 		}
+		i.segmentOffset++
 	}
 	return "", nil
 }


### PR DESCRIPTION
- Fixed a bug where legacy segment plugins caused an infinite loop during query execution; the synonym set is now correctly left empty, triggering fallback to basic FTS search without synonyms
- Refactored related code for improved clarity and performance