### PR TITLE
Fix lint errors in markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 We look forward to your contributions, but ask that you first review these guidelines.
 
-### Sign the CLA
+## Sign the CLA
 
 As Bleve is a Couchbase project we require contributors accept the [Couchbase Contributor License Agreement](http://review.couchbase.org/static/individual_agreement.html). To sign this agreement log into the Couchbase [code review tool](http://review.couchbase.org/). The Bleve project does not use this code review tool but it is still used to track acceptance of the contributor license agreements.
 
-### Submitting a Pull Request
+## Submitting a Pull Request
 
 All types of contributions are welcome, but please keep the following in mind:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ searchResult, _ := index.Search(searchRequest)
 
 To install the CLI for the latest release of bleve, run:
 
-```shell
+```bash
 go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,41 +16,41 @@ A modern indexing + search library in GO
 * Index any GO data structure or JSON
 * Intelligent defaults backed up by powerful configuration ([scorch](https://github.com/blevesearch/bleve/blob/master/index/scorch/README.md))
 * Supported field types:
-    * `text`, `number`, `datetime`, `boolean`, `geopoint`, `geoshape`, `IP`, `vector`
+  * `text`, `number`, `datetime`, `boolean`, `geopoint`, `geoshape`, `IP`, `vector`
 * Supported query types:
-    * `term`, `phrase`, `match`, `match_phrase`, `prefix`, `regexp`, `wildcard`, `fuzzy`
-    * term range, numeric range, date range, boolean field
-    * compound queries: `conjuncts`, `disjuncts`, boolean (`must`/`should`/`must_not`)
-    * [query string syntax](http://www.blevesearch.com/docs/Query-String-Query/)
-    * [geo spatial search](https://github.com/blevesearch/bleve/blob/master/geo/README.md)
-    * approximate k-nearest neighbors via [vector search](https://github.com/blevesearch/bleve/blob/master/docs/vectors.md)
-    * [synonym search](https://github.com/blevesearch/bleve/blob/master/docs/synonyms.md)
+  * `term`, `phrase`, `match`, `match_phrase`, `prefix`, `regexp`, `wildcard`, `fuzzy`
+  * term range, numeric range, date range, boolean field
+  * compound queries: `conjuncts`, `disjuncts`, boolean (`must`/`should`/`must_not`)
+  * [query string syntax](http://www.blevesearch.com/docs/Query-String-Query/)
+  * [geo spatial search](https://github.com/blevesearch/bleve/blob/master/geo/README.md)
+  * approximate k-nearest neighbors via [vector search](https://github.com/blevesearch/bleve/blob/master/docs/vectors.md)
+  * [synonym search](https://github.com/blevesearch/bleve/blob/master/docs/synonyms.md)
 * [tf-idf](https://github.com/blevesearch/bleve/blob/master/docs/scoring.md#tf-idf) / [bm25](https://github.com/blevesearch/bleve/blob/master/docs/scoring.md#bm25) scoring models
 * Hybrid search: exact + semantic
 * Query time boosting
 * Search result match highlighting with document fragments
 * Aggregations/faceting support:
-    * terms facet
-    * numeric range facet
-    * date range facet
+  * terms facet
+  * numeric range facet
+  * date range facet
 
 ## Indexing
 
 ```go
 message := struct{
-	Id   string
-	From string
-	Body string
+  Id   string
+  From string
+  Body string
 }{
-	Id:   "example",
-	From: "xyz@couchbase.com",
-	Body: "bleve indexing is easy",
+  Id:   "example",
+  From: "xyz@couchbase.com",
+  Body: "bleve indexing is easy",
 }
 
 mapping := bleve.NewIndexMapping()
 index, err := bleve.New("example.bleve", mapping)
 if err != nil {
-	panic(err)
+  panic(err)
 }
 index.Index(message.Id, message)
 ```
@@ -72,7 +72,7 @@ To install the CLI for the latest release of bleve, run:
 $ go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
 ```
 
-```
+```bash
 $ bleve --help
 Bleve is a command-line tool to interact with a bleve index.
 
@@ -113,6 +113,7 @@ Arabic (ar), Bulgarian (bg), Catalan (ca), Chinese-Japanese-Korean (cjk), Kurdis
 ## Discussion/Issues
 
 Discuss usage/development of bleve and/or report issues here:
+
 * [Github issues](https://github.com/blevesearch/bleve/issues)
 * [Google group](https://groups.google.com/forum/#!forum/bleve)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A modern indexing + search library in GO
 ## Indexing
 
 ```go
-message := struct{
+message := struct {
   Id   string
   From string
   Body string
@@ -69,7 +69,7 @@ searchResult, _ := index.Search(searchRequest)
 To install the CLI for the latest release of bleve, run:
 
 ```shell
-$ go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
+go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
 ```
 
 ```text

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ searchResult, _ := index.Search(searchRequest)
 
 To install the CLI for the latest release of bleve, run:
 
-```bash
+```shell
 $ go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
 ```
 
-```bash
+```text
 $ bleve --help
 Bleve is a command-line tool to interact with a bleve index.
 

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ A modern indexing + search library in GO
 
 ```go
 message := struct {
-  Id   string
-  From string
-  Body string
+    Id   string
+    From string
+    Body string
 }{
-  Id:   "example",
-  From: "xyz@couchbase.com",
-  Body: "bleve indexing is easy",
+    Id:   "example",
+    From: "xyz@couchbase.com",
+    Body: "bleve indexing is easy",
 }
 
 mapping := bleve.NewIndexMapping()
 index, err := bleve.New("example.bleve", mapping)
 if err != nil {
-  panic(err)
+    panic(err)
 }
 index.Index(message.Id, message)
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,12 @@
 
 ## Supported Versions
 
-We support the latest release (for example, bleve v2.3.x).
+We support the latest release (for example, bleve v2.5.x).
 
 ## Reporting a Vulnerability
 
-All security issues for this project should be reported by email to security@couchbase.com and fts-team@couchbase.com. 
+All security issues for this project should be reported via email to [security@couchbase.com](mailto:security@couchbase.com) and [fts-team@couchbase.com](mailto:fts-team@couchbase.com).
+
 This mail will be delivered to the owners of this project.
 
 - To ensure your report is NOT marked as spam, please include the word "security/vulnerability" along with the project name (blevesearch/bleve) in the subject of the email.

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -9,11 +9,11 @@
 ## BM25
 
 When it comes to scoring a document hit for a specific field, BM25 scoring mechanism requires the following stats:
+
 * fieldLen - The number of analyzed terms in the current document's field.
 * avgFieldLen - The average number of analyzed terms in the field across all the documents.
 * docTotal - The total number of documents in the index.
 * docTerm - The total number of documents containing the query term within the index.
-
 
 The scoring formula followed in BM25 is
 
@@ -22,13 +22,15 @@ The scoring formula followed in BM25 is
 ```
 
 $IDF(q_i)$ here refers to Inverse Document Frequency talks about how rare (and hence rich in information) is a particular query term $`q_i`$ across all the documents in the index, which is calculated as
+
 ```math
     \ln(1 + {{docTotal - docTerm + 0.5}\over{docTerm + 0.5}})
 ```
 
-Coming back to the BM25 scoring, $f(q_i,D)$ refers to the frequency of the query term in document $D$. The entire equation has certain multipliers 
+Coming back to the BM25 scoring, $f(q_i,D)$ refers to the frequency of the query term in document $D$. The entire equation has certain multipliers
+
 * $k1$ - helps in controlling the saturation of the score with respect to query term in a document. Basicaly if the query term's frequency is too high, the score value gets saturated and doesn't increase beyond a certain point.
-* $b$ - controls the extent to which the $fieldLen$ normalizes the term's frequency. 
+* $b$ - controls the extent to which the $fieldLen$ normalizes the term's frequency.
 
 ### How to enable and use BM25
 
@@ -40,7 +42,7 @@ For instance, while defining the index mapping for the data model that's been de
 indexMapping := bleve.NewIndexMapping()
 indexMapping.TypeField = "type"
 indexMapping.DefaultAnalyzer = "en"
-indexMapping.ScoringModel = index.BM25Scoring
+indexMapping.ScoringModel = "bm25"
 ```
 
 During search time there's explicit change involved, unless the user wants to perform a global scoring.
@@ -49,7 +51,7 @@ During search time there's explicit change involved, unless the user wants to pe
 
 Let's say that the user has a dataset which is quite large (let's say 3 million) and to have good throughput, they create 3 shards (with the same index mapping) for the "index". Each of these shards can be `bleve.Index` type and while performing a search over the entire dataset, a `bleve.IndexAlias` can be created over which a search can be performed. This parallelizes things pretty good, both on the indexing path and the search path.
 
-The concept of global scoring is applicable when the index is "sharded" (similar to above situation). This is because each index has data which is disjoint, and thereby while performing the scoring on document hits on each of them, the value of stats is not complete at a global level, since we're doing a search over the entire dataset using the `bleve.IndexAlias`. For eg: `docTotal` value while scoring the document hits would be 1 million which is incorrect at a global level. 
+The concept of global scoring is applicable when the index is "sharded" (similar to above situation). This is because each index has data which is disjoint, and thereby while performing the scoring on document hits on each of them, the value of stats is not complete at a global level, since we're doing a search over the entire dataset using the `bleve.IndexAlias`. For eg: `docTotal` value while scoring the document hits would be 1 million which is incorrect at a global level.
 
 So in order to keep the scoring roughly same across varying count of the number of shards involved, we provide a mechanism to enable "global scoring". In this type of search, an initial roundtrip is performed to gather and aggregate the stats necessary for the scoring mechanism and in the second phase, the actual search is performed. So naturally this comes at a cost of latency. As a reference here's how the user can go about with it
 
@@ -67,11 +69,11 @@ ctx = context.WithValue(ctx, search.SearchTypeKey, search.GlobalScoring)
 res, err := multiPartIndex.SearchInContext(ctx, searchRequest)
 ```
 
-A note here is that, this would only matter if the relative order of the document hits vary quite a bit (vs single shard case). This would be possible when the shard count increases quite a bit, in low doc count situations or if there is a heavy skew in the data distribution amongst the shards for some reason. Ideally the shards are created when the data is quite large and each of them index same amount of data - in which case the scores won't fluctuate much to affect the relative hit order and the user can choose to avoid the global scoring mechanism altogether. 
+A note here is that, this would only matter if the relative order of the document hits vary quite a bit (vs single shard case). This would be possible when the shard count increases quite a bit, in low doc count situations or if there is a heavy skew in the data distribution amongst the shards for some reason. Ideally the shards are created when the data is quite large and each of them index same amount of data - in which case the scores won't fluctuate much to affect the relative hit order and the user can choose to avoid the global scoring mechanism altogether.
 
 ## TF-IDF
 
-TF-IDF is the default scoring mechanism involved (for backward compatibility reasons) and requires no change from the user at index or search time to avail it. 
+TF-IDF is the default scoring mechanism involved (for backward compatibility reasons) and requires no change from the user at index or search time to avail it.
 
 The scoring formula involved is
 

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -11,6 +11,7 @@
 * A `vectors` GO TAG needs to be set for bleve to access all the supporting code. This TAG must be set only after the FAISS shared library is made available. Failure to do either will inhibit you from using this feature.
 * Please follow these [instructions](#setup-instructions) below for any assistance in the area.
 * Releases of `blevesearch/bleve` work with select checkpoints of `blevesearch/faiss` owing to API changes and improvements (tracking over the `bleve` branch):
+
     | bleve version(s) | blevesearch/faiss version |
     | --- | --- |
     | `v2.4.0` | [blevesearch/faiss@7b119f4](https://github.com/blevesearch/faiss/tree/7b119f4b9c408989b696b36f8cc53908e53de6db) (modified v1.7.4) |
@@ -23,36 +24,38 @@
 * The `vector` field type is an array that is to hold float32 values only.
 * The `vector_base64` field type to support base64 encoded strings using little endian byte ordering (v2.4.1+)
 * Supported similarity metrics are: [`"cosine"` (v2.4.3+), `"dot_product"`, `"l2_norm"`].
-    * `cosine` paths will additionally normalize vectors before indexing and search.
+  * `cosine` paths will additionally normalize vectors before indexing and search.
 * Supported dimensionality is between 1 and 2048 (v2.4.0), and up to **4096** (v2.4.1+).
 * Supported vector index optimizations: `latency`, `memory_efficient` (v2.4.1+), `recall`.
 * Vectors from documents that do not conform to the index mapping dimensionality are simply discarded at index time.
 * The dimensionality of the query vector must match the dimensionality of the indexed vectors to obtain any results.
 * Pure kNN searches can be performed, but the `query` attribute within the search request must be set - to `{"match_none": {}}` in this case. The `query` attribute is made optional when `knn` is available with v2.4.1+.
 * Hybrid searches are supported, where results from `query` are unioned (for now) with results from `knn`. The tf-idf scores from exact searches are simply summed with the similarity distances to determine the aggregate scores.
-```
+
+```text
 aggregate_score = (query_boost * query_hit_score) + (knn_boost * knn_hit_distance)
 ```
+
 * Multi kNN searches are supported - the `knn` object within the search request accepts an array of requests. These sub objects are unioned by default but this behavior can be overriden by setting `knn_operator` to `"and"`.
 * Previously supported pagination settings will work as they were, with size/limit being applied over the top-K hits combined with any exact search hits.
 
 ## Indexing
 
 ```go
-doc := struct{
+doc := struct {
     Id   string    `json:"id"`
     Text string    `json:"text"`
     Vec  []float32 `json:"vec"`
 }{
     Id:   "example",
     Text: "hello from united states",
-    Vec:  []float32{0,1,2,3,4,5,6,7,8,9},
+    Vec:  []float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 }
 
-textFieldMapping := mapping.NewTextFieldMapping()
-vectorFieldMapping := mapping.NewVectorFieldMapping()
+textFieldMapping := bleve.NewTextFieldMapping()
+vectorFieldMapping := bleve.NewVectorFieldMapping()
 vectorFieldMapping.Dims = 10
-vectorFieldMapping.Similarity = "l2_norm"   // euclidean distance
+vectorFieldMapping.Similarity = "l2_norm" // euclidean distance
 
 bleveMapping := bleve.NewIndexMapping()
 bleveMapping.DefaultMapping.Dynamic = false
@@ -69,12 +72,12 @@ index.Index(doc.Id, doc)
 ## Querying
 
 ```go
-searchRequest := NewSearchRequest(query.NewMatchNoneQuery())
+searchRequest := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
 searchRequest.AddKNN(
-    "vec",                                      // vector field name
-    []float32{10,11,12,13,14,15,16,17,18,19},   // query vector (same dims)
-    5,                                          // k
-    0,                                          // boost
+    "vec", // vector field name
+    []float32{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, // query vector (same dims)
+    5, // k
+    0, // boost
 )
 searchResult, err := index.Search(searchRequest)
 if err != nil {
@@ -86,14 +89,14 @@ fmt.Println(searchResult.Hits)
 ## Querying with filters (v2.4.3+)
 
 ```go
-searchRequest := NewSearchRequest(query.NewMatchNoneQuery())
-filterQuery := NewTermQuery("hello")
+searchRequest := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
+filterQuery := bleve.NewTermQuery("hello")
 searchRequest.AddKNNWithFilter(
-    "vec",                                      // vector field name
-    []float32{10,11,12,13,14,15,16,17,18,19},   // query vector (same dims)
-    5,                                          // k
-    0,                                          // boost
-    filterQuery,                                // filter query
+    "vec", // vector field name
+    []float32{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, // query vector (same dims)
+    5,           // k
+    0,           // boost
+    filterQuery, // filter query
 )
 searchResult, err := index.Search(searchRequest)
 if err != nil {
@@ -111,7 +114,7 @@ fmt.Println(searchResult.Hits)
 
 Also documented here - [go-faiss/README](https://github.com/blevesearch/go-faiss/blob/master/README.md).
 
-```
+```shell
 git clone https://github.com/blevesearch/faiss.git
 cd faiss
 cmake -B build -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_C_API=ON -DBUILD_SHARED_LIBS=ON .
@@ -120,7 +123,8 @@ sudo make -C build install
 ```
 
 Building will produce the dynamic library `faiss_c`. You will need to install it in a place where your system will find it (e.g. /usr/lib). You can do this with:
-```
+
+```shell
 sudo cp build/c_api/libfaiss_c.so /usr/local/lib
 ```
 
@@ -128,7 +132,7 @@ sudo cp build/c_api/libfaiss_c.so /usr/local/lib
 
 While you shouldn't need to do any different over osX x86_64, with aarch64 - some instructions need adjusting (see [facebookresearch/faiss#2111](https://github.com/facebookresearch/faiss/issues/2111)) ..
 
-```
+```shell
 LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CPPFLAGS="-I/opt/homebrew/opt/llvm/include" CXX=/opt/homebrew/opt/llvm/bin/clang++ CC=/opt/homebrew/opt/llvm/bin/clang cmake -B build -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_C_API=ON -DBUILD_SHARED_LIBS=ON -DFAISS_ENABLE_PYTHON=OFF .
 make -C build
 sudo make -C build install
@@ -139,11 +143,13 @@ sudo cp build/c_api/libfaiss_c.dylib /usr/local/lib
 
 Once the supporting library is built and made available, a sanity run is recommended to make sure all unit tests and especially those accessing the vectors' code pass. Here's how ..
 
-```
+```shell
 export DYLD_LIBRARY_PATH=/usr/local/lib
 go test -v ./... --tags=vectors
 ```
+
 -or-
-```
+
+```shell
 go test -ldflags "-r /usr/local/lib" ./... -tags=vectors
 ```

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -73,7 +73,7 @@ index.Index(doc.Id, doc)
 ## Querying
 
 ```go
-// Vector search: finds nearest neighbors using kNN on vectors
+// Vector Search: finds nearest neighbors using kNN on vectors
 searchRequest := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
 searchRequest.AddKNN(
     "vec",                                   // Vector field name in index
@@ -87,7 +87,7 @@ if err != nil {
 }
 fmt.Println(searchResult.Hits) // Scores are 1 / squared L2 distance, e.g., score = 0.25 for squared distance of 4
 
-// Hybrid search: combining kNN vector search with Bleve search
+// Hybrid Search: combining kNN vector search with Bleve search
 hybridRequest := bleve.NewSearchRequest(bleve.NewMatchQuery("united states")) // Bleve query (can be replaced with any Bleve query)
 hybridRequest.AddKNN(
     "vec",

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -109,11 +109,11 @@ fmt.Println(hybridResult.Hits) // Scores are the sum of text search and kNN scor
 searchRequest := bleve.NewSearchRequest(bleve.NewMatchNoneQuery()) // replace with any Bleve query for Pre-filtered Hybrid Search
 filterQuery := bleve.NewTermQuery("hello") // Filter query to narrow candidates
 searchRequest.AddKNNWithFilter(
-    "vec",                              // Vector field name
+    "vec",                                   // Vector field name
     []float32{0, 1, 1, 4, 4, 5, 7, 6, 8, 9}, // Query vector (must match indexed vector dims)
-    5,                                 // Number of nearest neighbors to return (k)
-    1,                                 // Boost factor for KNN score
-    filterQuery,                       // Filter query applied before KNN search
+    5,                                       // Number of nearest neighbors to return (k)
+    1,                                       // Boost factor for KNN score
+    filterQuery,                             // Filter query applied before KNN search
 )
 searchResult, err := index.Search(searchRequest)
 if err != nil {

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -108,7 +108,6 @@ fmt.Println(hybridResult.Hits) // Scores are the sum of text search and kNN scor
 // Pre-filtered vector/hybrid search: filter query narrows candidates before KNN search
 searchRequest := bleve.NewSearchRequest(bleve.NewMatchNoneQuery()) // replace with any Bleve query for Pre-filtered Hybrid Search
 filterQuery := bleve.NewTermQuery("hello") // Filter query to narrow candidates
-
 searchRequest.AddKNNWithFilter(
     "vec",                              // Vector field name
     []float32{0, 1, 1, 4, 4, 5, 7, 6, 8, 9}, // Query vector (must match indexed vector dims)

--- a/geo/README.md
+++ b/geo/README.md
@@ -1,8 +1,7 @@
 # Geo spatial search support in bleve
 
 Latest bleve spatial capabilities are powered by spatial hierarchical tokens generated from s2geometry.
-You can find more details about the [s2geometry basics here](http://s2geometry.io/), and explore the 
-extended functionality of our forked golang port of [s2geometry lib here](https://github.com/blevesearch/geo).
+You can find more details about the [s2geometry basics here](http://s2geometry.io/), and explore the extended functionality of our forked golang port of [s2geometry lib here](https://github.com/blevesearch/geo).
 
 Users can continue to index and query `geopoint` field type and the existing queries like,
 
@@ -14,7 +13,7 @@ as before.
 
 ## New Spatial Field Type - geoshape
 
-We have introduced a field type (`geoshape`) for representing the new spatial types. 
+We have introduced a field type (`geoshape`) for representing the new spatial types.
 
 Using the new `geoshape` field type, users can unblock the spatial capabilities  
 for the [geojson](https://datatracker.ietf.org/doc/html/rfc7946) shapes like,
@@ -37,7 +36,7 @@ To specify GeoJSON data, use a nested field with:
 - a field named type that specifies the GeoJSON object type and the type value will be case-insensitive.
 - a field named coordinates that specifies the object's coordinates.
 
-```
+```json
          "fieldName": { 
               "type": "GeoJSON Type", 
               "coordinates": <coordinates> 
@@ -50,69 +49,67 @@ To specify GeoJSON data, use a nested field with:
 - Shapes would be internally represented as geodesics.
 - The GeoJSON specification strongly suggests splitting geometries so that neither of their parts crosses the antimeridian.
 
-
 Examples for the various geojson shapes representations are as below.
 
 ## Point
 
 The following specifies a [Point](https://tools.ietf.org/html/rfc7946#section-3.1.2) field in a document:
 
-```
-    { 
-    "type": "point", 
-    "coordinates": [75.05687713623047,22.53539059204079]
-    }
+```json
+{
+  "type": "point",
+  "coordinates": [75.05687713623047, 22.53539059204079]
+}
 ```
 
 ## Linestring
 
 The following specifies a [Linestring](https://tools.ietf.org/html/rfc7946#section-3.1.4) field in a document:
 
-
-```
-{ 
-    "type": "linestring", 
-    "coordinates": [ 
-    [ 77.01416015625, 23.0797317624497], 
-    [ 78.134765625, 20.385825381874263] 
-    ] 
+```json
+{
+  "type": "linestring",
+  "coordinates": [
+    [77.01416015625, 23.0797317624497],
+    [78.134765625, 20.385825381874263]
+  ]
 }
 ```
-
 
 ## Polygon
 
 The following specifies a [Polygon](https://tools.ietf.org/html/rfc7946#section-3.1.6) field in a document:
 
-```
+```json
 {
- "type": "polygon",
- "coordinates": [ [ [ 85.605, 57.207], 
-                    [ 86.396, 55.998], 
-                    [ 87.033, 56.716], 
-                    [ 85.605, 57.207] 
-                ] ]
+  "type": "polygon",
+  "coordinates": [
+    [
+      [85.605, 57.207],
+      [86.396, 55.998],
+      [87.033, 56.716],
+      [85.605, 57.207]
+    ]
+  ]
 }
 ```
 
-
-The first and last coordinates must match in order to close the polygon. 
+The first and last coordinates must match in order to close the polygon.
 And the exterior coordinates have to be in Counter Clockwise Order in a polygon. (CCW)
-
 
 ## MultiPoint
 
 The following specifies a [Multipoint](https://tools.ietf.org/html/rfc7946#section-3.1.3) field in a document:
 
-```
+```json
 {
- "type": "multipoint",
- "coordinates": [
-    [ -115.8343505859375, 38.45789034424927],
-    [ -115.81237792968749, 38.19502155795575],
-    [ -120.80017089843749, 36.54053616262899],
-    [ -120.67932128906249, 36.33725319397006]
- ]
+  "type": "multipoint",
+  "coordinates": [
+    [-115.8343505859375, 38.45789034424927],
+    [-115.81237792968749, 38.19502155795575],
+    [-120.80017089843749, 36.54053616262899],
+    [-120.67932128906249, 36.33725319397006]
+  ]
 }
 ```
 
@@ -120,14 +117,23 @@ The following specifies a [Multipoint](https://tools.ietf.org/html/rfc7946#secti
 
 The following specifies a [MultiLineString](https://tools.ietf.org/html/rfc7946#section-3.1.5) field in a document:
 
-```
+```json
 {
- "type": "multilinestring",
- "coordinates": [
-    [ [ -118.31726074, 35.250105158],[ -117.509765624, 35.3756141] ],
-    [ [ -118.6962890, 34.624167789],[ -118.317260742, 35.03899204] ],
-    [ [ -117.9492187, 35.146862906], [ -117.6745605, 34.41144164] ]
-]
+  "type": "multilinestring",
+  "coordinates": [
+    [
+      [-118.31726074, 35.250105158],
+      [-117.509765624, 35.3756141]
+    ],
+    [
+      [-118.696289, 34.624167789],
+      [-118.317260742, 35.03899204]
+    ],
+    [
+      [-117.9492187, 35.146862906],
+      [-117.6745605, 34.41144164]
+    ]
+  ]
 }
 ```
 
@@ -135,119 +141,144 @@ The following specifies a [MultiLineString](https://tools.ietf.org/html/rfc7946#
 
 The following specifies a [MultiPolygon](https://tools.ietf.org/html/rfc7946#section-3.1.7) field in a document:
 
-```
+```json
 {
- "type": "multipolygon",
- "coordinates": [
-    [ [ [ -73.958, 40.8003 ], [ -73.9498, 40.7968 ], 
-        [ -73.9737, 40.7648 ], [ -73.9814, 40.7681 ], 
-        [ -73.958, 40.8003 ] ] ],
-
-
-    [ [ [ -73.958, 40.8003 ], [ -73.9498, 40.7968 ], 
-        [ -73.9737, 40.7648 ], [ -73.958, 40.8003 ] ] ]
- ]
+  "type": "multipolygon",
+  "coordinates": [
+    [
+      [
+        [-73.958, 40.8003],
+        [-73.9498, 40.7968],
+        [-73.9737, 40.7648],
+        [-73.9814, 40.7681],
+        [-73.958, 40.8003]
+      ]
+    ],
+    [
+      [
+        [-73.958, 40.8003],
+        [-73.9498, 40.7968],
+        [-73.9737, 40.7648],
+        [-73.958, 40.8003]
+      ]
+    ]
+  ]
 }
 ```
-
 
 ## GeometryCollection
 
 The following specifies a [GeometryCollection](https://tools.ietf.org/html/rfc7946#section-3.1.8) field in a document:
 
-```
+```json
 {
- "type": "geometrycollection",
- "geometries": [
+  "type": "geometrycollection",
+  "geometries": [
     {
       "type": "multipoint",
       "coordinates": [
-         [ -73.9580, 40.8003 ],
-         [ -73.9498, 40.7968 ],
-         [ -73.9737, 40.7648 ],
-         [ -73.9814, 40.7681 ]
+        [-73.958, 40.8003],
+        [-73.9498, 40.7968],
+        [-73.9737, 40.7648],
+        [-73.9814, 40.7681]
       ]
     },
     {
       "type": "multilinestring",
       "coordinates": [
-         [ [ -73.96943, 40.78519 ], [ -73.96082, 40.78095 ] ],
-         [ [ -73.96415, 40.79229 ], [ -73.95544, 40.78854 ] ],
-         [ [ -73.97162, 40.78205 ], [ -73.96374, 40.77715 ] ],
-         [ [ -73.97880, 40.77247 ], [ -73.97036, 40.76811 ] ]
+        [
+          [-73.96943, 40.78519],
+          [-73.96082, 40.78095]
+        ],
+        [
+          [-73.96415, 40.79229],
+          [-73.95544, 40.78854]
+        ],
+        [
+          [-73.97162, 40.78205],
+          [-73.96374, 40.77715]
+        ],
+        [
+          [-73.9788, 40.77247],
+          [-73.97036, 40.76811]
+        ]
       ]
     },
     {
-      "type" : "polygon",
-      "coordinates" : [
-    [ [ 0 , 0 ] , [ 3 , 6 ] , [ 6 , 1 ] , [ 0 , 0 ] ],
-    [ [ 2 , 2 ] , [ 3 , 3 ] , [ 4 , 2 ] , [ 2 , 2 ] ]
-    ]
-   }
-]
+      "type": "polygon",
+      "coordinates": [
+        [
+          [0, 0],
+          [3, 6],
+          [6, 1],
+          [0, 0]
+        ],
+        [
+          [2, 2],
+          [3, 3],
+          [4, 2],
+          [2, 2]
+        ]
+      ]
+    }
+  ]
 }
 ```
-
 
 ## Circle
 
-If the user wishes to cover a circular region over the earth’s surface, then they could use this shape.
+If the user wishes to cover a circular region over the earth's surface, then they could use this shape.
 A  sample circular shape is as below.
 
-```
-{ 
- "type": "circle", 
- "coordinates": [75.05687713623047,22.53539059204079],
- "radius": "1000m"
+```json
+{
+  "type": "circle",
+  "coordinates": [75.05687713623047, 22.53539059204079],
+  "radius": "1000m"
 }
 ```
 
- 
 Circle is specified over the center point coordinates along with the radius.
-Example formats supported for radius are: 
-"5in" , "5inch" , "7yd" , "7yards",  "9ft" , "9feet", "11km", "11kilometers", "3nm" 
-"3nauticalmiles", "13mm" , "13millimeters",  "15cm", "15centimeters", "17mi", "17miles" "19m" or "19meters".
+Example formats supported for radius are:
+"5in" , "5inch" , "7yd" , "7yards",  "9ft" , "9feet", "11km", "11kilometers", "3nm", "3nauticalmiles", "13mm" , "13millimeters",  "15cm", "15centimeters", "17mi", "17miles" "19m" or "19meters".
 
 If the unit cannot be determined, the entire string is parsed and the unit of meters is assumed.
 
-
 ## Envelope
 
-Envelope type, which consists of coordinates for upper left and lower right points of the shape 
-to represent a bounding rectangle in the format  [[minLon, maxLat], [maxLon, minLat]].
+Envelope type, which consists of coordinates for upper left and lower right points of the shape to represent a bounding rectangle in the format  [[minLon, maxLat], [maxLon, minLat]].
 
-```
+```json
 {
-    "type": "envelope",
-    "coordinates": [
-      [72.83, 18.979],
-      [78.508,17.4555]
-    ]
+  "type": "envelope",
+  "coordinates": [
+    [72.83, 18.979],
+    [78.508, 17.4555]
+  ]
 }
 ```
 
-
 ## GeoShape Query
 
-Geoshape query support three types/filters of spatial querying capability across those 
-heterogeneous types of documents indexed.
+Geoshape query support three types/filters of spatial querying capability across those heterogeneous types of documents indexed.
 
-### Query Structure:
+### Query Structure
 
-```
+```json
 {
   "query": {
     "geometry": {
       "shape": {
-        "type": "<shapeType>", 
-        "coordinates": [[[ ]]]
+        "type": "<shapeType>",
+        "coordinates": [
+          [[]]
+        ]
       },
       "relation": "<<filterName>>"
     }
   }
 }
 ```
-
 
 *shapeType* => can be any of the aforementioned types like Point, LineString, Polygon, MultiPoint,
 Geometrycollection, MultiLineString, MultiPolygon, Circle and Envelope.
@@ -256,15 +287,13 @@ Geometrycollection, MultiLineString, MultiPolygon, Circle and Envelope.
 
 ### Relation
 
-| 	FilterName	 |  Description	                                                            | 
-| 	:-----------:| 	:-----------------------------------------------------------------:     | 
-| 	`intersects` | 	Return all documents whose shape field intersects the query  geometry.	| 
-| 	`contains`	 | 	Return all documents whose shape field contains the query geometry   	| 
-| 	`within`     | 	Return all documents whose shape field is within the query geometry.	| 
+|   FilterName   |  Description                                                             |
+|   :-----------:|  :-----------------------------------------------------------------:     |
+|   `intersects` |  Return all documents whose shape field intersects the query  geometry.  |
+|   `contains`   |  Return all documents whose shape field contains the query geometry    |
+|   `within`     |  Return all documents whose shape field is within the query geometry.  |
 
 ------------------------------------------------------------------------------------------------------------------------
-
-
 
 ### Older Implementation
 

--- a/geo/README.md
+++ b/geo/README.md
@@ -240,7 +240,7 @@ A  sample circular shape is as below.
 
 Circle is specified over the center point coordinates along with the radius.
 Example formats supported for radius are:
-"5in" , "5inch" , "7yd" , "7yards",  "9ft" , "9feet", "11km", "11kilometers", "3nm", "3nauticalmiles", "13mm" , "13millimeters",  "15cm", "15centimeters", "17mi", "17miles" "19m" or "19meters".
+"5in" , "5inch" , "7yd" , "7yards",  "9ft" , "9feet", "11km", "11kilometers", "3nm", "3nauticalmiles", "13mm" , "13millimeters",  "15cm", "15centimeters", "17mi", "17miles", "19m" or "19meters".
 
 If the unit cannot be determined, the entire string is parsed and the unit of meters is assumed.
 

--- a/geo/README.md
+++ b/geo/README.md
@@ -290,8 +290,8 @@ Geometrycollection, MultiLineString, MultiPolygon, Circle and Envelope.
 |   FilterName   |  Description                                                             |
 |   :-----------:|  :-----------------------------------------------------------------:     |
 |   `intersects` |  Return all documents whose shape field intersects the query  geometry.  |
-|   `contains`   |  Return all documents whose shape field contains the query geometry    |
-|   `within`     |  Return all documents whose shape field is within the query geometry.  |
+|   `contains`   |  Return all documents whose shape field contains the query geometry      |
+|   `within`     |  Return all documents whose shape field is within the query geometry.    |
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/geo/README.md
+++ b/geo/README.md
@@ -36,7 +36,7 @@ To specify GeoJSON data, use a nested field with:
 - a field named type that specifies the GeoJSON object type and the type value will be case-insensitive.
 - a field named coordinates that specifies the object's coordinates.
 
-```json
+```text
          "fieldName": { 
               "type": "GeoJSON Type", 
               "coordinates": <coordinates> 


### PR DESCRIPTION
- Used a tool to identify and fix lint errors in all the markdown files.
- Fixed code examples to use only the exported bleve package (and not internal ones)
- Formatted JSON and code examples throughout
- Added Hybrid Search example to vectors.md