### PR TITLE
MB-66112: fix an edge case related to index convergence

### DIFF
--- a/index/scorch/mergeplan/merge_plan.go
+++ b/index/scorch/mergeplan/merge_plan.go
@@ -295,8 +295,10 @@ func plan(segmentsIn []Segment, o *MergePlanOptions) (*MergePlan, error) {
 		if len(bestRoster) == 0 {
 			return rv, nil
 		}
-
-		rv.Tasks = append(rv.Tasks, &MergeTask{Segments: bestRoster})
+		// create tasks with valid merges - i.e. there should be atleast 2 non-empty segments
+		if len(bestRoster) > 1 {
+			rv.Tasks = append(rv.Tasks, &MergeTask{Segments: bestRoster})
+		}
 
 		eligibles = removeSegments(eligibles, bestRoster)
 	}


### PR DESCRIPTION
- As an edge case, the segment layout can be such that the merge planning generates tasks having only a single non-empty segment. 
- When this task is processed and introduced into the scorch system, the root doesn't change and you'd be stuck in an infinite loop because the same segment is still present in the system and the plan keeps generating the task with the same single segment, which doesn't converge the index to a steady state.