### PR TITLE
MB-65170: Add filter support to BooleanQuery

### DIFF
--- a/search/query/boolean.go
+++ b/search/query/boolean.go
@@ -250,6 +250,7 @@ func (q *BooleanQuery) UnmarshalJSON(data []byte) error {
 		Must    json.RawMessage `json:"must,omitempty"`
 		Should  json.RawMessage `json:"should,omitempty"`
 		MustNot json.RawMessage `json:"must_not,omitempty"`
+		Filter  json.RawMessage `json:"filter,omitempty"`
 		Boost   *Boost          `json:"boost,omitempty"`
 	}{}
 	err := util.UnmarshalJSON(data, &tmp)
@@ -287,6 +288,13 @@ func (q *BooleanQuery) UnmarshalJSON(data []byte) error {
 		_, isDisjunctionQuery := q.MustNot.(*DisjunctionQuery)
 		if !isDisjunctionQuery {
 			return fmt.Errorf("must not clause must be disjunction")
+		}
+	}
+
+	if tmp.Filter != nil {
+		q.Filter, err = ParseQuery(tmp.Filter)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/search/query/query.go
+++ b/search/query/query.go
@@ -196,7 +196,8 @@ func ParseQuery(input []byte) (Query, error) {
 	_, hasMust := tmp["must"]
 	_, hasShould := tmp["should"]
 	_, hasMustNot := tmp["must_not"]
-	if hasMust || hasShould || hasMustNot {
+	_, hasFilter := tmp["filter"]
+	if hasMust || hasShould || hasMustNot || hasFilter {
 		var rv BooleanQuery
 		err := util.UnmarshalJSON(input, &rv)
 		if err != nil {

--- a/search/searcher/search_geoboundingbox.go
+++ b/search/searcher/search_geoboundingbox.go
@@ -208,7 +208,7 @@ func buildIsIndexedFunc(ctx context.Context, indexReader index.IndexReader, fiel
 func buildRectFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	minLon, minLat, maxLon, maxLat float64,
 ) FilterFunc {
-	return func(d *search.DocumentMatch) bool {
+	return func(sctx *search.SearchContext, d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed
 		var lons, lats []float64
 		var found bool

--- a/search/searcher/search_geopointdistance.go
+++ b/search/searcher/search_geopointdistance.go
@@ -115,7 +115,7 @@ func boxSearcher(ctx context.Context, indexReader index.IndexReader,
 
 func buildDistFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	centerLon, centerLat, maxDist float64) FilterFunc {
-	return func(d *search.DocumentMatch) bool {
+	return func(sctx *search.SearchContext, d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed
 		var lons, lats []float64
 		var found bool

--- a/search/searcher/search_geopolygon.go
+++ b/search/searcher/search_geopolygon.go
@@ -85,7 +85,7 @@ func almostEqual(a, b float64) bool {
 // here: https://wrf.ecse.rpi.edu/nikola/pubdetails/pnpoly.html
 func buildPolygonFilter(ctx context.Context, dvReader index.DocValueReader, field string,
 	coordinates []geo.Point) FilterFunc {
-	return func(d *search.DocumentMatch) bool {
+	return func(sctx *search.SearchContext, d *search.DocumentMatch) bool {
 		// check geo matches against all numeric type terms indexed
 		var lons, lats []float64
 		var found bool

--- a/search/searcher/search_geoshape.go
+++ b/search/searcher/search_geoshape.go
@@ -77,7 +77,7 @@ func buildRelationFilterOnShapes(ctx context.Context, dvReader index.DocValueRea
 		bufPool = bufPoolCallback()
 	}
 
-	return func(d *search.DocumentMatch) bool {
+	return func(sctx *search.SearchContext, d *search.DocumentMatch) bool {
 		var found bool
 
 		err := dvReader.VisitDocValues(d.IndexInternalID,


### PR DESCRIPTION
- Add a Filter query for Boolean queries, which filters the document set returned by the
Boolean query itself.
- The filter query does not affect scores, and any document returned by the Boolean query
must also satisfy the filter query.
- The key difference between using a Filter query and placing an equivalent query in the
Must clause is that queries in the Must clause contribute to the score. The Filter
query is intended purely for filtering purposes without modifying the document scores
set by the base Boolean query.
- Requires a Bug Fix (https://github.com/blevesearch/bleve/pull/2146)
to allow for the usage of the Advanced API in case the FilterQuery is an optimized
composite searcher.
- Resolves https://github.com/blevesearch/bleve/issues/2037