### PR TITLE
MB-60401: Optimizations for score fusion

### DIFF
--- a/fusion/rrf.go
+++ b/fusion/rrf.go
@@ -90,11 +90,8 @@ func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64
 			}
 		}
 		for i := limit; i < len(hits); i++ {
+			// These FTS hits are not counted in the results, so set to 0
 			hits[i].Score = 0.0
-		}
-	} else {
-		for _, hit := range hits {
-			hit.Score = 0.0
 		}
 	}
 

--- a/fusion/rrf.go
+++ b/fusion/rrf.go
@@ -63,7 +63,7 @@ func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64
 			hit := hits[i]
 			originalScore := hit.Score
 			if originalScore == 0.0 {
-				continue
+				break
 			}
 			rank := i + 1
 			if explain {

--- a/fusion/rrf.go
+++ b/fusion/rrf.go
@@ -31,11 +31,11 @@ func formatRRFMessage(weight float64, rank int, rankConstant int) string {
 // results and each KNN sub-query. Ranks are limited to `windowSize` per source,
 // weighted, and combined into a single fused score, with optional explanation
 // details.
-func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64, rankConstant int, windowSize int, numKNNQueries int, explain bool) FusionResult {
+func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64, rankConstant int, windowSize int, numKNNQueries int, explain bool) *FusionResult {
 	nHits := len(hits)
 	if nHits == 0 || windowSize == 0 {
-		return FusionResult{
-			Hits:     hits,
+		return &FusionResult{
+			Hits:     search.DocumentMatchCollection{},
 			Total:    0,
 			MaxScore: 0.0,
 		}
@@ -135,7 +135,7 @@ func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64
 	if nHits > windowSize {
 		hits = hits[:windowSize]
 	}
-	return FusionResult{
+	return &FusionResult{
 		Hits:     hits,
 		Total:    uint64(len(hits)),
 		MaxScore: maxScore,

--- a/fusion/rrf.go
+++ b/fusion/rrf.go
@@ -50,7 +50,7 @@ func ReciprocalRankFusion(hits search.DocumentMatchCollection, weights []float64
 		limit = windowSize
 	}
 
-	// precompute rank+scores to prevend additional division ops later
+	// precompute rank+scores to prevent additional division ops later
 	var rankReciprocals []float64
 	if limit > 0 {
 		rankReciprocals = make([]float64, limit)

--- a/fusion/rrf_test.go
+++ b/fusion/rrf_test.go
@@ -204,7 +204,7 @@ func TestReciprocalRankFusion(t *testing.T) {
 				hit.HitNumber = uint64(i)
 			}
 
-			if got := ReciprocalRankFusion(tt.hits, tt.weights, tt.rank_constant, tt.window_size, tt.numKNNQueries, false); !compareFusionResults(got, tt.want) {
+			if got := ReciprocalRankFusion(tt.hits, tt.weights, tt.rank_constant, tt.window_size, tt.numKNNQueries, false); !compareFusionResults(*got, tt.want) {
 				t.Errorf("ReciprocalRankFusion() = %v, want %v", got, tt.want)
 			}
 		})

--- a/fusion/rrf_test.go
+++ b/fusion/rrf_test.go
@@ -200,6 +200,10 @@ func TestReciprocalRankFusion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for i, hit := range tt.hits {
+				hit.HitNumber = uint64(i)
+			}
+
 			if got := ReciprocalRankFusion(tt.hits, tt.weights, tt.rank_constant, tt.window_size, tt.numKNNQueries, false); !compareFusionResults(got, tt.want) {
 				t.Errorf("ReciprocalRankFusion() = %v, want %v", got, tt.want)
 			}

--- a/fusion/rsf.go
+++ b/fusion/rsf.go
@@ -92,11 +92,8 @@ func RelativeScoreFusion(hits search.DocumentMatchCollection, weights []float64,
 			hit.Score = contrib
 		}
 		for i := ftsLimit; i < len(hits); i++ {
+			// These FTS hits are not counted in the results, so set to 0
 			hits[i].Score = 0.0
-		}
-	} else {
-		for _, hit := range hits {
-			hit.Score = 0.0
 		}
 	}
 

--- a/fusion/rsf.go
+++ b/fusion/rsf.go
@@ -65,7 +65,7 @@ func RelativeScoreFusion(hits search.DocumentMatchCollection, weights []float64,
 		ftsLimit = windowSize
 	}
 
-	// calculate fts rank+scores
+	// calculate fts scores
 	if ftsLimit > 0 {
 		max := hits[0].Score
 		min := hits[ftsLimit-1].Score
@@ -100,7 +100,7 @@ func RelativeScoreFusion(hits search.DocumentMatchCollection, weights []float64,
 		}
 	}
 
-	// Code from here is for calculating knn ranks+scores
+	// Code from here is for calculating knn scores
 	for queryIdx := 0; queryIdx < numKNNQueries; queryIdx++ {
 		sortDocMatchesByBreakdown(hits, queryIdx)
 

--- a/fusion/rsf_test.go
+++ b/fusion/rsf_test.go
@@ -186,6 +186,10 @@ func TestRelativeScoreFusion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for i, hit := range tt.hits {
+				hit.HitNumber = uint64(i)
+			}
+
 			if got := RelativeScoreFusion(tt.hits, tt.weights, tt.windowSize, tt.numKNNQueries, false); !compareFusionResults(got, tt.want) {
 				t.Errorf("RelativeScoreFusion() = %v, want %v", got, tt.want)
 				// Print detailed comparison for debugging

--- a/fusion/rsf_test.go
+++ b/fusion/rsf_test.go
@@ -190,7 +190,7 @@ func TestRelativeScoreFusion(t *testing.T) {
 				hit.HitNumber = uint64(i)
 			}
 
-			if got := RelativeScoreFusion(tt.hits, tt.weights, tt.windowSize, tt.numKNNQueries, false); !compareFusionResults(got, tt.want) {
+			if got := RelativeScoreFusion(tt.hits, tt.weights, tt.windowSize, tt.numKNNQueries, false); !compareFusionResults(*got, tt.want) {
 				t.Errorf("RelativeScoreFusion() = %v, want %v", got, tt.want)
 				// Print detailed comparison for debugging
 				t.Logf("Got hits:")

--- a/fusion/util.go
+++ b/fusion/util.go
@@ -16,70 +16,57 @@
 package fusion
 
 import (
+	"sort"
+
 	"github.com/blevesearch/bleve/v2/search"
 )
 
-// scoreBreakdownSortFunc returns a comparison function for sorting DocumentMatch objects
-// by their ScoreBreakdown at the specified index in descending order.
-// In case of ties, documents with lower HitNumber (earlier hits) are preferred.
-// If either document is missing the ScoreBreakdown for the specified index,
-// it's treated as having a score of 0.0.
-func scoreBreakdownSortFunc(idx int) func(i, j *search.DocumentMatch) int {
-	return func(i, j *search.DocumentMatch) int {
-		// Safely extract scores, defaulting to 0.0 if missing
-		iScore := 0.0
-		jScore := 0.0
-
-		if i.ScoreBreakdown != nil {
-			if score, ok := i.ScoreBreakdown[idx]; ok {
-				iScore = score
-			}
-		}
-
-		if j.ScoreBreakdown != nil {
-			if score, ok := j.ScoreBreakdown[idx]; ok {
-				jScore = score
-			}
-		}
-
-		// Sort by score in descending order (higher scores first)
-		if iScore > jScore {
-			return -1
-		} else if iScore < jScore {
-			return 1
-		}
-
-		// Break ties by HitNumber in ascending order (lower HitNumber wins)
-		if i.HitNumber < j.HitNumber {
-			return -1
-		} else if i.HitNumber > j.HitNumber {
-			return 1
-		}
-
-		return 0 // Equal scores and HitNumbers
-	}
+// docScore captures a score for a document index, letting callers reuse
+// precomputed values without re-reading the match or its breakdown map.
+type docScore struct {
+	idx   int
+	score float64
 }
 
-func scoreSortFunc() func(i, j *search.DocumentMatch) int {
-	return func(i, j *search.DocumentMatch) int {
-		// Sort by score in descending order
-		if i.Score > j.Score {
-			return -1
-		} else if i.Score < j.Score {
-			return 1
-		}
-
-		// Break ties by HitNumber
-		if i.HitNumber < j.HitNumber {
-			return -1
-		} else if i.HitNumber > j.HitNumber {
-			return 1
-		}
-
-		return 0
+// sortDocMatchesByScore orders the provided collection in-place by the primary
+// score in descending order, breaking ties with the original `HitNumber` to
+// ensure deterministic output.
+func sortDocMatchesByScore(hits search.DocumentMatchCollection) {
+	if len(hits) < 2 {
+		return
 	}
+
+	sort.Slice(hits, func(a, b int) bool {
+		i := hits[a]
+		j := hits[b]
+		if i.Score == j.Score {
+			return i.HitNumber < j.HitNumber
+		}
+		return i.Score > j.Score
+	})
 }
 
+// sortDocScores orders the supplied `docScore` slice in descending score order
+// while still breaking ties on `HitNumber`. It allows callers to sort cached
+// score data without rebuilding intermediate `[]*DocumentMatch` slices.
+func sortDocScores(scores []docScore, hits search.DocumentMatchCollection) {
+	if len(scores) < 2 {
+		return
+	}
+
+	sort.Slice(scores, func(a, b int) bool {
+		i := scores[a]
+		j := scores[b]
+		if i.score == j.score {
+			return hits[i.idx].HitNumber < hits[j.idx].HitNumber
+		}
+		return i.score > j.score
+	})
+}
+
+// getFusionExplAt copies the existing explanation child at the requested index
+// and wraps it in a new node describing how the fusion algorithm adjusted the
+// score.
 func getFusionExplAt(hit *search.DocumentMatch, i int, value float64, message string) *search.Explanation {
 	return &search.Explanation{
 		Value:    value,
@@ -88,6 +75,9 @@ func getFusionExplAt(hit *search.DocumentMatch, i int, value float64, message st
 	}
 }
 
+// finalizeFusionExpl installs the collection of fusion explanation children and
+// updates the root message so the caller sees the fused score as the sum of its
+// parts.
 func finalizeFusionExpl(hit *search.DocumentMatch, explChildren []*search.Explanation) {
 	hit.Expl.Children = explChildren
 

--- a/fusion/util.go
+++ b/fusion/util.go
@@ -59,12 +59,24 @@ func sortDocMatchesByBreakdown(hits search.DocumentMatchCollection, queryIdx int
 	}
 
 	sort.SliceStable(hits, func(a, b int) bool {
-		leftScore, leftOK := scoreBreakdownForQuery(hits[a], queryIdx)
-		rightScore, rightOK := scoreBreakdownForQuery(hits[b], queryIdx)
+		left := hits[a]
+		right := hits[b]
+
+		var leftScore float64
+		leftOK := false
+		if left != nil && left.ScoreBreakdown != nil {
+			leftScore, leftOK = left.ScoreBreakdown[queryIdx]
+		}
+
+		var rightScore float64
+		rightOK := false
+		if right != nil && right.ScoreBreakdown != nil {
+			rightScore, rightOK = right.ScoreBreakdown[queryIdx]
+		}
 
 		if leftOK && rightOK {
 			if leftScore == rightScore {
-				return hits[a].HitNumber < hits[b].HitNumber
+				return left.HitNumber < right.HitNumber
 			}
 			return leftScore > rightScore
 		}
@@ -73,7 +85,7 @@ func sortDocMatchesByBreakdown(hits search.DocumentMatchCollection, queryIdx int
 			return leftOK
 		}
 
-		return hits[a].HitNumber < hits[b].HitNumber
+		return left.HitNumber < right.HitNumber
 	})
 }
 

--- a/rescorer.go
+++ b/rescorer.go
@@ -95,7 +95,7 @@ func (r *rescorer) restoreSearchRequest() {
 func (r *rescorer) rescore(ftsHits, knnHits search.DocumentMatchCollection) (search.DocumentMatchCollection, uint64, float64) {
 	mergedHits := r.mergeDocs(ftsHits, knnHits)
 
-	var fusionResult fusion.FusionResult
+	var fusionResult *fusion.FusionResult
 
 	switch r.req.Score {
 	case ScoreRRF:

--- a/rescorer.go
+++ b/rescorer.go
@@ -95,11 +95,11 @@ func (r *rescorer) restoreSearchRequest() {
 func (r *rescorer) rescore(ftsHits, knnHits search.DocumentMatchCollection) (search.DocumentMatchCollection, uint64, float64) {
 	mergedHits := r.mergeDocs(ftsHits, knnHits)
 
-	var fusionResult *fusion.FusionResult
+	var fusionResult fusion.FusionResult
 
 	switch r.req.Score {
 	case ScoreRRF:
-		res := fusion.ReciprocalRankFusion(
+		fusionResult = fusion.ReciprocalRankFusion(
 			mergedHits,
 			r.origBoosts,
 			r.req.Params.ScoreRankConstant,
@@ -107,16 +107,14 @@ func (r *rescorer) rescore(ftsHits, knnHits search.DocumentMatchCollection) (sea
 			numKNNQueries(r.req),
 			r.req.Explain,
 		)
-		fusionResult = &res
 	case ScoreRSF:
-		res := fusion.RelativeScoreFusion(
+		fusionResult = fusion.RelativeScoreFusion(
 			mergedHits,
 			r.origBoosts,
 			r.req.Params.ScoreWindowSize,
 			numKNNQueries(r.req),
 			r.req.Explain,
 		)
-		fusionResult = &res
 	}
 
 	return fusionResult.Hits, fusionResult.Total, fusionResult.MaxScore

--- a/rescorer_test.go
+++ b/rescorer_test.go
@@ -225,6 +225,7 @@ func cloneDocumentMatches(src search.DocumentMatchCollection) search.DocumentMat
 	}
 	return dst
 }
+
 func getFTSDocuments() []map[string]interface{} {
 	documents := []map[string]interface{}{
 		{

--- a/rescorer_test.go
+++ b/rescorer_test.go
@@ -15,6 +15,7 @@
 package bleve
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/search"
@@ -68,6 +69,162 @@ func createFTSIndex(path string) (Index, error) {
 	return New(path, indexMapping)
 }
 
+var benchmarkResult search.DocumentMatchCollection
+
+type benchmarkConfig struct {
+	name       string
+	ftsHits    int
+	knnHits    int
+	knnQueries int
+}
+
+func BenchmarkRescorerRRF(b *testing.B) {
+	runRescorerBenchmarks(b, ScoreRRF)
+}
+
+func BenchmarkRescorerRSF(b *testing.B) {
+	runRescorerBenchmarks(b, ScoreRSF)
+}
+
+func runRescorerBenchmarks(b *testing.B, scoreMode string) {
+	configs := []benchmarkConfig{
+		{name: "small", ftsHits: 256, knnHits: 192, knnQueries: 1},
+		{name: "medium", ftsHits: 1024, knnHits: 896, knnQueries: 2},
+		{name: "large", ftsHits: 4096, knnHits: 3584, knnQueries: 3},
+	}
+
+	for _, cfg := range configs {
+		b.Run(fmt.Sprintf("%s/%s", scoreMode, cfg.name), func(b *testing.B) {
+			b.ReportAllocs()
+
+			rescorer, baseFTSHits, baseKNNHits := buildBenchmarkInputs(cfg, scoreMode)
+
+			var last search.DocumentMatchCollection
+			b.StopTimer()
+			for i := 0; i < b.N; i++ {
+				ftsHits := cloneDocumentMatches(baseFTSHits)
+				knnHits := cloneDocumentMatches(baseKNNHits)
+
+				b.StartTimer()
+				hits, _, _ := rescorer.rescore(ftsHits, knnHits)
+				b.StopTimer()
+
+				last = hits
+			}
+
+			if len(last) == 0 {
+				b.Fatalf("rescorer returned no hits for config %q", cfg.name)
+			}
+
+			benchmarkResult = last
+		})
+	}
+}
+
+func buildBenchmarkInputs(cfg benchmarkConfig, scoreMode string) (*rescorer, search.DocumentMatchCollection, search.DocumentMatchCollection) {
+	windowSize := cfg.ftsHits
+	if cfg.knnHits > windowSize {
+		windowSize = cfg.knnHits
+	}
+
+	matchQuery := query.NewMatchQuery("rescorer benchmark payload")
+	matchQuery.SetBoost(1.0)
+
+	req := &SearchRequest{
+		Query:  matchQuery,
+		Size:   cfg.ftsHits,
+		From:   0,
+		Score:  scoreMode,
+		Params: &RequestParams{ScoreRankConstant: DefaultScoreRankConstant, ScoreWindowSize: windowSize},
+	}
+
+	activeKNNQueries := cfg.knnQueries
+	if knnAdder, ok := interface{}(req).(interface {
+		AddKNN(field string, vector []float32, k int64, boost float64)
+	}); ok {
+		for i := 0; i < cfg.knnQueries; i++ {
+			knnAdder.AddKNN(fmt.Sprintf("vector_%d", i), []float32{1.0, 0.5, 0.25}, int64(cfg.knnHits), 1.0)
+		}
+	} else {
+		activeKNNQueries = 0
+	}
+
+	r := newRescorer(req)
+	r.origBoosts = make([]float64, activeKNNQueries+1)
+	for i := range r.origBoosts {
+		r.origBoosts[i] = 1.0
+	}
+
+	ftsHits, knnHits := buildBenchmarkHits(cfg, activeKNNQueries)
+	return r, ftsHits, knnHits
+}
+
+func buildBenchmarkHits(cfg benchmarkConfig, activeKNNQueries int) (search.DocumentMatchCollection, search.DocumentMatchCollection) {
+	ftsHits := make(search.DocumentMatchCollection, cfg.ftsHits)
+	for i := 0; i < cfg.ftsHits; i++ {
+		ftsHits[i] = &search.DocumentMatch{
+			ID:        fmt.Sprintf("doc-%06d", i),
+			Score:     float64(cfg.ftsHits - i),
+			HitNumber: uint64(i + 1),
+		}
+	}
+
+	knnHits := make(search.DocumentMatchCollection, cfg.knnHits)
+	for i := 0; i < cfg.knnHits; i++ {
+		id := fmt.Sprintf("doc-%06d", i)
+		if cfg.ftsHits > 0 {
+			id = fmt.Sprintf("doc-%06d", i%cfg.ftsHits)
+		}
+		if cfg.ftsHits == 0 || i%4 == 0 {
+			id = fmt.Sprintf("knn-only-%06d", i/4)
+		}
+
+		scoreBreakdown := make(map[int]float64, activeKNNQueries)
+		for q := 0; q < activeKNNQueries; q++ {
+			scoreBreakdown[q] = float64(cfg.knnHits - i + q + 1)
+		}
+
+		knnHits[i] = &search.DocumentMatch{
+			ID:             id,
+			Score:          float64(cfg.knnHits - i),
+			ScoreBreakdown: scoreBreakdown,
+			HitNumber:      uint64(i + 1),
+		}
+	}
+
+	return ftsHits, knnHits
+}
+
+func cloneDocumentMatches(src search.DocumentMatchCollection) search.DocumentMatchCollection {
+	dst := make(search.DocumentMatchCollection, len(src))
+	for i, hit := range src {
+		if hit == nil {
+			continue
+		}
+
+		cloned := *hit
+
+		if hit.ScoreBreakdown != nil {
+			cloned.ScoreBreakdown = make(map[int]float64, len(hit.ScoreBreakdown))
+			for k, v := range hit.ScoreBreakdown {
+				cloned.ScoreBreakdown[k] = v
+			}
+		}
+
+		if len(hit.Sort) > 0 {
+			cloned.Sort = append([]string(nil), hit.Sort...)
+		}
+		if len(hit.DecodedSort) > 0 {
+			cloned.DecodedSort = append([]string(nil), hit.DecodedSort...)
+		}
+		if len(hit.IndexNames) > 0 {
+			cloned.IndexNames = append([]string(nil), hit.IndexNames...)
+		}
+
+		dst[i] = &cloned
+	}
+	return dst
+}
 func getFTSDocuments() []map[string]interface{} {
 	documents := []map[string]interface{}{
 		{


### PR DESCRIPTION
Optimizes rrf and rsf.
- In place updates of scores instead of extra maps
- Extra sorts removed

Original benchmarks:
```
BenchmarkRescorerRRF/rrf/small-14         	   28918	     41116 ns/op	   59655 B/op	     325 allocs/op
BenchmarkRescorerRRF/rrf/medium-14        	    5394	    208945 ns/op	  250594 B/op	    1277 allocs/op
BenchmarkRescorerRRF/rrf/large-14         	    1411	    823237 ns/op	 1129037 B/op	    5085 allocs/op
BenchmarkRescorerRSF/rsf/small-14         	   41151	     29468 ns/op	   41060 B/op	      21 allocs/op
BenchmarkRescorerRSF/rsf/medium-14        	    9566	    128250 ns/op	  158735 B/op	      29 allocs/op
BenchmarkRescorerRSF/rsf/large-14         	    2215	    541930 ns/op	  743451 B/op	      84 allocs/op
```

Optimized benchmarks:
```
BenchmarkRescorerRRF/rrf/small-14         	   58382	     20003 ns/op	   13642 B/op	      10 allocs/op
BenchmarkRescorerRRF/rrf/medium-14        	   12789	     91741 ns/op	   47990 B/op	      10 allocs/op
BenchmarkRescorerRRF/rrf/large-14         	    2982	    387546 ns/op	  299895 B/op	      36 allocs/op
BenchmarkRescorerRSF/rsf/small-14         	   61227	     19480 ns/op	   11595 B/op	       9 allocs/op
BenchmarkRescorerRSF/rsf/medium-14        	   13282	     89511 ns/op	   39795 B/op	       9 allocs/op
BenchmarkRescorerRSF/rsf/large-14         	    3184	    409432 ns/op	  266798 B/op	      35 allocs/op
```