### PR TITLE
MB-62182: Implement File transfer APIs

### DIFF
--- a/index.go
+++ b/index.go
@@ -353,13 +353,6 @@ type IndexCopyable interface {
 	CopyTo(d index.Directory) error
 }
 
-// IndexFileCopyable is an index supporting the transfer of a single file between
-// two indexes
-type IndexFileCopyable interface {
-	SetPathInBolt(key []byte, value []byte) error
-	CopyFile(file string, d index.IndexDirectory) error
-}
-
 // FileSystemDirectory is the default implementation for the
 // index.Directory interface.
 type FileSystemDirectory string

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -79,8 +79,6 @@ type Scorch struct {
 	persisterNotifier        chan *epochWatcher
 	rootBolt                 *bolt.DB
 	asyncTasks               sync.WaitGroup
-	// not a real searchable segment
-	centroidIndex *SegmentSnapshot
 
 	trainer trainer
 

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -263,16 +263,19 @@ func (t *vectorTrainer) getInternal(key []byte) ([]byte, error) {
 
 func (t *vectorTrainer) getCentroidIndex(field string) (interface{}, error) {
 	// return the coarse quantizer of the centroid index belonging to the field
-	trainedSegment, ok := t.centroidIndex.segment.(segment.TrainedSegment)
-	if !ok {
-		return nil, fmt.Errorf("segment is not a centroid index segment")
-	}
+	if t.centroidIndex != nil {
+		trainedSegment, ok := t.centroidIndex.segment.(segment.TrainedSegment)
+		if !ok {
+			return nil, fmt.Errorf("segment is not a centroid index segment")
+		}
 
-	coarseQuantizer, err := trainedSegment.GetCoarseQuantizer(field)
-	if err != nil {
-		return nil, err
+		coarseQuantizer, err := trainedSegment.GetCoarseQuantizer(field)
+		if err != nil {
+			return nil, err
+		}
+		return coarseQuantizer, nil
 	}
-	return coarseQuantizer, nil
+	return nil, nil
 }
 
 func (t *vectorTrainer) copyFileLOCKED(file string, d index.IndexDirectory) error {

--- a/index_impl.go
+++ b/index_impl.go
@@ -72,9 +72,9 @@ func indexStorePath(path string) string {
 	return path + string(os.PathSeparator) + storePath
 }
 
-func newIndexUsing(path string, im mapping.IndexMapping, indexType string, kvstore string, kvconfig map[string]interface{}) (*indexImpl, error) {
+func newIndexUsing(path string, mapping mapping.IndexMapping, indexType string, kvstore string, kvconfig map[string]interface{}) (*indexImpl, error) {
 	// first validate the mapping
-	err := im.Validate()
+	err := mapping.Validate()
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func newIndexUsing(path string, im mapping.IndexMapping, indexType string, kvsto
 	rv := indexImpl{
 		path: path,
 		name: path,
-		m:    im,
+		m:    mapping,
 		meta: newIndexMeta(indexType, kvstore, kvconfig),
 	}
 	rv.stats = &IndexStat{i: &rv}
@@ -106,12 +106,6 @@ func newIndexUsing(path string, im mapping.IndexMapping, indexType string, kvsto
 	} else {
 		kvconfig["path"] = ""
 	}
-
-	mappingBytes, err := util.MarshalJSON(im)
-	if err != nil {
-		return nil, err
-	}
-	kvconfig["index_mapping"] = mappingBytes
 
 	// open the index
 	indexTypeConstructor := registry.IndexTypeConstructorByName(rv.meta.IndexType)
@@ -134,6 +128,10 @@ func newIndexUsing(path string, im mapping.IndexMapping, indexType string, kvsto
 	}(&rv)
 
 	// now persist the mapping
+	mappingBytes, err := util.MarshalJSON(mapping)
+	if err != nil {
+		return nil, err
+	}
 	err = rv.i.SetInternal(util.MappingInternalKey, mappingBytes)
 	if err != nil {
 		return nil, err

--- a/mapping/index.go
+++ b/mapping/index.go
@@ -58,7 +58,6 @@ type IndexMappingImpl struct {
 	IndexDynamic          bool                        `json:"index_dynamic"`
 	DocValuesDynamic      bool                        `json:"docvalues_dynamic"`
 	CustomAnalysis        *customAnalysis             `json:"analysis,omitempty"`
-	VectorOptimization    string                      `json:"vector_optimization,omitempty"`
 	cache                 *registry.Cache
 }
 
@@ -325,12 +324,6 @@ func (im *IndexMappingImpl) UnmarshalJSON(data []byte) error {
 			}
 		case "scoring_model":
 			err := util.UnmarshalJSON(v, &im.ScoringModel)
-			if err != nil {
-				return err
-			}
-
-		case "vector_optimization":
-			err := util.UnmarshalJSON(v, &im.VectorOptimization)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Utilizes the new file transfer APIs to able to transfer the trained index file from one bleve index to another. This is helpful in a multi-partition scenario with a single datasource - where only one bleve index is trained on a set of vectors and then transfer the generated file to the other bleve indexes. 
- The file transfer is currently focused around the trained index file but the protocol is such that its future extendable for other files if needed.
- The main control flow here is that the application needs to implement the `IndexDirectory` interface which maintains a reference to the destination bleve index. 
    - Now, when the `srcIndex.CopyFile(index.TrainedIndexFileName, directory)` is invoked, it internally fetches the writer on the destination using `directory.GetWriter()`
    - Then, as part of the CopyFile it does an `io.Copy()` of the specific file and currently this is focused only for trained index file.
    - This is followed by an update bolt transaction + commit and sync in the destination index by invoking `directory.SetPathInBolt(fileName, filePath)`. This is mandatory since bolt is reflective of the on-disk information.