### PR TITLE
bug: use `index.TrainedIndexCallbackFn` signature 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/bits-and-blooms/bitset v1.24.2
-	github.com/blevesearch/bleve_index_api v1.3.7
+	github.com/blevesearch/bleve_index_api v1.3.9
 	github.com/blevesearch/geo v0.2.5
 	github.com/blevesearch/go-faiss v1.0.30
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
@@ -25,7 +25,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.3
 	github.com/blevesearch/zapx/v15 v15.4.3
 	github.com/blevesearch/zapx/v16 v16.3.2
-	github.com/blevesearch/zapx/v17 v17.0.7
+	github.com/blevesearch/zapx/v17 v17.0.8
 	github.com/couchbase/moss v0.2.0
 	github.com/spf13/cobra v1.10.2
 	go.etcd.io/bbolt v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWf
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.3.7 h1:x3C4pl6o3MlSJ3rNKLQpZMRF0uR9+BDvmF3t8LYCOpk=
-github.com/blevesearch/bleve_index_api v1.3.7/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/bleve_index_api v1.3.9 h1:TLoiBaqcfWGfI1Il0+zzky452uYCPoSMosDSltkCfKs=
+github.com/blevesearch/bleve_index_api v1.3.9/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/blevesearch/geo v0.2.5 h1:yJg9FX1oRwLnjXSXF+ECHfXFTF4diF02Ca/qUGVjJhE=
 github.com/blevesearch/geo v0.2.5/go.mod h1:Jhq7WE2K6mJTx1xS44M2pUO6Io+wjCSHh1+co3YOgH4=
 github.com/blevesearch/go-faiss v1.0.30 h1:pWX3/Si4Z7GlwsD2eRXoF3SfVaDkg8plBlPdUKuhGts=
@@ -45,8 +45,8 @@ github.com/blevesearch/zapx/v15 v15.4.3 h1:iJiMJOHrz216jyO6lS0m9RTCEkprUnzvqAI2l
 github.com/blevesearch/zapx/v15 v15.4.3/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.3.2 h1:R8alnAeYxzKO4JjQY4FBqJduJwcPE3YjcgevWgI+XT0=
 github.com/blevesearch/zapx/v16 v16.3.2/go.mod h1:zCFjv7McXWm1C8rROL+3mUoD5WYe2RKsZP3ufqcYpLY=
-github.com/blevesearch/zapx/v17 v17.0.7 h1:NeoqfGa4Ul5n2AqU3jp3A0FnEIOtviskvRysGZLbgZs=
-github.com/blevesearch/zapx/v17 v17.0.7/go.mod h1:9306AsJLjhUnZvX3ff03FJ0GlF2ndG25UEgdHJkf4Ro=
+github.com/blevesearch/zapx/v17 v17.0.8 h1:KmmgaqI9z4Dq4b7A9IZoEH2dvi3EBMH2vfzBZcee9SE=
+github.com/blevesearch/zapx/v17 v17.0.8/go.mod h1:13roZQUA2yNegJJ/1rXnVZ655irxv18v/+3D3oIXo7w=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -79,7 +79,7 @@ func (t *vectorTrainer) trainLoop() {
 		t.parent.asyncTasks.Done()
 	}()
 	// initialize stuff
-	t.parent.segmentConfig[index.TrainedIndexCallback] = t.getCentroidIndex
+	t.parent.segmentConfig[index.TrainedIndexCallback] = index.TrainedIndexCallbackFn(t.getCentroidIndex)
 	path := filepath.Join(t.parent.path, index.TrainedIndexFileName)
 	for {
 		select {


### PR DESCRIPTION
- use the same func signature in the both zapx and bleve for fetching the trained index to avoid panics caused by differing func signatures