### PR TITLE
MB-71375: Bolt Wrappers for File Callbacks

### DIFF
--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 	segment "github.com/blevesearch/scorch_segment_api/v2"
-	bolt "go.etcd.io/bbolt"
 )
 
 const DefaultBuilderBatchSize = 1000
@@ -291,7 +291,7 @@ func (o *Builder) Close() error {
 
 	// create the root bolt
 	rootBoltPath := o.path + string(os.PathSeparator) + "root.bolt"
-	rootBolt, err := bolt.Open(rootBoltPath, 0600, nil)
+	rootBolt, err := util.OpenBolt(rootBoltPath, 0600, nil)
 	if err != nil {
 		return err
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -626,7 +626,7 @@ func persistToDirectory(seg segment.UnpersistedSegment, d index.Directory,
 	return err
 }
 
-func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segPlugin SegmentPlugin,
+func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path string, segPlugin SegmentPlugin,
 	exclude map[uint64]struct{}, d index.Directory) ([]string, map[uint64]string, error) {
 	snapshotsBucket, err := tx.CreateBucketIfNotExists(util.BoltSnapshotsBucket)
 	if err != nil {
@@ -643,13 +643,13 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 	if err != nil {
 		return nil, nil, err
 	}
-	err = metaBucket.Put(util.BoltMetaDataSegmentTypeKey, []byte(segPlugin.Type()))
+	err = metaBucket.Put(util.BoltMetaDataSegmentTypeKey, []byte(segPlugin.Type()), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	buf := make([]byte, binary.MaxVarintLen32)
 	binary.BigEndian.PutUint32(buf, segPlugin.Version())
-	err = metaBucket.Put(util.BoltMetaDataSegmentVersionKey, buf)
+	err = metaBucket.Put(util.BoltMetaDataSegmentVersionKey, buf, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -665,7 +665,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 	}
 
 	// persist the writer ID used for the bolt snapshot
-	err = metaBucket.Put(util.BoltMetaDataFileWriterIDKey, []byte(writer.Id()))
+	err = metaBucket.Put(util.BoltMetaDataFileWriterIDKey, []byte(writer.Id()), writer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -679,7 +679,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 	if err != nil {
 		return nil, nil, err
 	}
-	err = metaBucket.Put(util.BoltMetaDataTimeStamp, timeStampBinary)
+	err = metaBucket.Put(util.BoltMetaDataTimeStamp, timeStampBinary, writer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -701,8 +701,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 		val := make([]byte, 8)
 		bytesWritten := atomic.LoadUint64(&snapshot.parent.stats.TotBytesWrittenAtIndexTime)
 		binary.LittleEndian.PutUint64(val, bytesWritten)
-		buf := writer.Process(val)
-		err = internalBucket.Put(util.TotBytesWrittenKey, buf)
+		err = internalBucket.Put(util.TotBytesWrittenKey, val, writer)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -714,7 +713,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 	// first ensure that each segment in this snapshot has been persisted
 	for _, segmentSnapshot := range snapshot.segment {
 		var persistedSeg bool
-		var snapshotSegmentBucket *bolt.Bucket
+		var snapshotSegmentBucket *util.BoltBucketImpl
 		switch seg := segmentSnapshot.segment.(type) {
 		case segment.PersistedSegment:
 			snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
@@ -728,7 +727,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 				return nil, nil, fmt.Errorf("segment: %s copy err: %v", segPath, err)
 			}
 			filename := filepath.Base(segPath)
-			err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename))
+			err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), writer)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -750,7 +749,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 					return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
 				}
 				newSegmentPaths[segmentSnapshot.id] = path
-				err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename))
+				err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), nil)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -781,8 +780,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 				if err != nil {
 					return nil, nil, fmt.Errorf("error persisting roaring bytes: %v", err)
 				}
-				roaringBytes := writer.Process(roaringBuf.Bytes())
-				err = snapshotSegmentBucket.Put(util.BoltDeletedKey, roaringBytes)
+				err = snapshotSegmentBucket.Put(util.BoltDeletedKey, roaringBuf.Bytes(), writer)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -790,12 +788,11 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 
 			// store segment stats
 			if segmentSnapshot.stats != nil {
-				b, err := json.Marshal(segmentSnapshot.stats.Fetch())
+				statsBytes, err := json.Marshal(segmentSnapshot.stats.Fetch())
 				if err != nil {
 					return nil, nil, err
 				}
-				statsBytes := writer.Process(b)
-				err = snapshotSegmentBucket.Put(util.BoltStatsKey, statsBytes)
+				err = snapshotSegmentBucket.Put(util.BoltStatsKey, statsBytes, writer)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -803,13 +800,12 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 
 			// store updated field info
 			if segmentSnapshot.updatedFields != nil {
-				b, err := json.Marshal(segmentSnapshot.updatedFields)
+				updatedFieldsBytes, err := json.Marshal(segmentSnapshot.updatedFields)
 				if err != nil {
 					return nil, nil, err
 				}
-				updatedFieldsBytes := writer.Process(b)
 				err = snapshotSegmentBucket.Put(
-					util.BoltUpdatedFieldsKey, updatedFieldsBytes)
+					util.BoltUpdatedFieldsKey, updatedFieldsBytes, writer)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -819,8 +815,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string, segP
 
 	// now the internal values are reflective of the on-disk data, update in bolt
 	for k, v := range internal {
-		buf := writer.Process(v)
-		err = internalBucket.Put([]byte(k), buf)
+		err = internalBucket.Put([]byte(k), v, writer)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -918,7 +913,7 @@ func zapFileName(epoch uint64) string {
 
 // bolt snapshot code
 func (s *Scorch) loadFromBolt() error {
-	err := s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
@@ -935,7 +930,7 @@ func (s *Scorch) loadFromBolt() error {
 				s.AddEligibleForRemoval(snapshotEpoch)
 				continue
 			}
-			snapshot := snapshots.Bucket(k)
+			snapshot := snapshots.GetBucket(k)
 			if snapshot == nil {
 				log.Printf("snapshot key, but bucket missing %x, continuing", k)
 				s.AddEligibleForRemoval(snapshotEpoch)
@@ -970,7 +965,7 @@ func (s *Scorch) loadFromBolt() error {
 		// try init trainer and load the trained data
 		if trainer := initTrainer(s, s.config); trainer != nil {
 			s.trainer = trainer
-			trainerBucket := snapshots.Bucket(util.BoltTrainerKey)
+			trainerBucket := snapshots.GetBucket(util.BoltTrainerKey)
 			err := s.trainer.loadTrainedData(trainerBucket)
 			if err != nil {
 				return err
@@ -994,13 +989,13 @@ func (s *Scorch) loadFromBolt() error {
 // LoadSnapshot loads the segment with the specified epoch
 // NOTE: this is currently ONLY intended to be used by the command-line tool
 func (s *Scorch) LoadSnapshot(epoch uint64) (rv *IndexSnapshot, err error) {
-	err = s.rootBolt.View(func(tx *bolt.Tx) error {
+	err = s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
 		}
 		snapshotKey := encodeUvarintAscending(nil, epoch)
-		snapshot := snapshots.Bucket(snapshotKey)
+		snapshot := snapshots.GetBucket(snapshotKey)
 		if snapshot == nil {
 			return fmt.Errorf("snapshot with epoch: %v - doesn't exist", epoch)
 		}
@@ -1013,7 +1008,7 @@ func (s *Scorch) LoadSnapshot(epoch uint64) (rv *IndexSnapshot, err error) {
 	return rv, nil
 }
 
-func (s *Scorch) loadSnapshot(snapshot *bolt.Bucket) (*IndexSnapshot, error) {
+func (s *Scorch) loadSnapshot(snapshot *util.BoltBucketImpl) (*IndexSnapshot, error) {
 	rv := &IndexSnapshot{
 		parent:   s,
 		internal: make(map[string][]byte),
@@ -1023,23 +1018,35 @@ func (s *Scorch) loadSnapshot(snapshot *bolt.Bucket) (*IndexSnapshot, error) {
 	// first we look for the meta-data bucket, this will tell us
 	// which segment type/version was used for this snapshot
 	// all operations for this scorch will use this type/version
-	metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+	metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 	if metaBucket == nil {
 		_ = rv.DecRef()
 		return nil, fmt.Errorf("meta-data bucket missing")
 	}
-	segmentType := string(metaBucket.Get(util.BoltMetaDataSegmentTypeKey))
-	segmentVersion := binary.BigEndian.Uint32(
-		metaBucket.Get(util.BoltMetaDataSegmentVersionKey))
-	err := s.loadSegmentPlugin(segmentType, segmentVersion)
+	segmentType, err := metaBucket.Get(util.BoltMetaDataSegmentTypeKey, nil)
+	if err != nil {
+		_ = rv.DecRef()
+		return nil, fmt.Errorf("segment type missing: %v", err)
+	}
+	segmentVersionBytes, err := metaBucket.Get(util.BoltMetaDataSegmentVersionKey, nil)
+	if err != nil {
+		_ = rv.DecRef()
+		return nil, fmt.Errorf("segment version missing: %v", err)
+	}
+	segmentVersion := binary.BigEndian.Uint32(segmentVersionBytes)
+	err = s.loadSegmentPlugin(string(segmentType), segmentVersion)
 	if err != nil {
 		_ = rv.DecRef()
 		return nil, fmt.Errorf(
 			"unable to load correct segment wrapper: %v", err)
 	}
-	fileWriterID := string(metaBucket.Get(util.BoltMetaDataFileWriterIDKey))
+	fileWriterID, err := metaBucket.Get(util.BoltMetaDataFileWriterIDKey, nil)
+	if err != nil {
+		_ = rv.DecRef()
+		return nil, fmt.Errorf("file writer id missing: %v", err)
+	}
 	reader, err := util.NewFileReader(
-		fileWriterID, []byte(s.path+string(os.PathSeparator)+"root.bolt"))
+		string(fileWriterID), []byte(s.path+string(os.PathSeparator)+"root.bolt"))
 	if err != nil {
 		_ = rv.DecRef()
 		return nil, fmt.Errorf("unable to load correct reader: %v", err)
@@ -1049,25 +1056,21 @@ func (s *Scorch) loadSnapshot(snapshot *bolt.Bucket) (*IndexSnapshot, error) {
 	c := snapshot.Cursor()
 	for k, _ := c.First(); k != nil; k, _ = c.Next() {
 		if k[0] == util.BoltInternalKey[0] {
-			internalBucket := snapshot.Bucket(k)
+			internalBucket := snapshot.GetBucket(k)
 			if internalBucket == nil {
 				_ = rv.DecRef()
 				return nil, fmt.Errorf("internal bucket missing")
 			}
 			err := internalBucket.ForEach(func(key []byte, val []byte) error {
-				copiedVal, err := reader.Process(append([]byte(nil), val...))
-				if err != nil {
-					return err
-				}
-				rv.internal[string(key)] = copiedVal
+				rv.internal[string(key)] = val
 				return nil
-			})
+			}, reader)
 			if err != nil {
 				_ = rv.DecRef()
 				return nil, err
 			}
 		} else if k[0] != util.BoltMetaDataKey[0] {
-			segmentBucket := snapshot.Bucket(k)
+			segmentBucket := snapshot.GetBucket(k)
 			if segmentBucket == nil {
 				_ = rv.DecRef()
 				return nil, fmt.Errorf("segment key, but bucket missing %x", k)
@@ -1094,9 +1097,9 @@ func (s *Scorch) loadSnapshot(snapshot *bolt.Bucket) (*IndexSnapshot, error) {
 	return rv, nil
 }
 
-func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket, reader util.FileReader) (
+func (s *Scorch) loadSegment(segmentBucket *util.BoltBucketImpl, reader util.FileReader) (
 	*SegmentSnapshot, error) {
-	pathBytes := segmentBucket.Get(util.BoltPathKey)
+	pathBytes, err := segmentBucket.Get(util.BoltPathKey, nil)
 	if pathBytes == nil {
 		return nil, fmt.Errorf("segment path missing")
 	}
@@ -1111,13 +1114,12 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket, reader util.FileReader)
 		cachedDocs: &cachedDocs{cache: nil},
 		cachedMeta: &cachedMeta{meta: nil},
 	}
-	deletedBytes := segmentBucket.Get(util.BoltDeletedKey)
+	deletedBytes, err := segmentBucket.Get(util.BoltDeletedKey, reader)
+	if err != nil {
+		_ = seg.Close()
+		return nil, fmt.Errorf("error getting deleted bytes: %v", err)
+	}
 	if deletedBytes != nil {
-		deletedBytes, err = reader.Process(deletedBytes)
-		if err != nil {
-			_ = seg.Close()
-			return nil, err
-		}
 		deletedBitmap := roaring.NewBitmap()
 		r := bytes.NewReader(deletedBytes)
 		_, err := deletedBitmap.ReadFrom(r)
@@ -1129,30 +1131,27 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket, reader util.FileReader)
 			rv.deleted = deletedBitmap
 		}
 	}
-	statBytes := segmentBucket.Get(util.BoltStatsKey)
+	statBytes, err := segmentBucket.Get(util.BoltStatsKey, reader)
+	if err != nil {
+		_ = seg.Close()
+		return nil, fmt.Errorf("error getting stat bytes: %v", err)
+	}
 	if statBytes != nil {
 		var statsMap map[string]map[string]uint64
-		statBytes, err = reader.Process(statBytes)
-		if err != nil {
-			_ = seg.Close()
-			return nil, err
-		}
 		err := json.Unmarshal(statBytes, &statsMap)
-		stats := &fieldStats{statMap: statsMap}
 		if err != nil {
 			_ = seg.Close()
 			return nil, fmt.Errorf("error reading stat bytes: %v", err)
 		}
-		rv.stats = stats
+		rv.stats = &fieldStats{statMap: statsMap}
 	}
-	updatedFieldBytes := segmentBucket.Get(util.BoltUpdatedFieldsKey)
+	updatedFieldBytes, err := segmentBucket.Get(util.BoltUpdatedFieldsKey, reader)
+	if err != nil {
+		_ = seg.Close()
+		return nil, fmt.Errorf("error getting updated field bytes: %v", err)
+	}
 	if updatedFieldBytes != nil {
 		var updatedFields map[string]*index.UpdateFieldInfo
-		updatedFieldBytes, err := reader.Process(updatedFieldBytes)
-		if err != nil {
-			_ = seg.Close()
-			return nil, err
-		}
 		err = json.Unmarshal(updatedFieldBytes, &updatedFields)
 		if err != nil {
 			_ = seg.Close()
@@ -1169,23 +1168,26 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket, reader util.FileReader)
 // identify all the file callback writer ids that are in use by boltdb
 func (s *Scorch) boltFileWriterIDsInUse() (map[string]struct{}, error) {
 	idMap := make(map[string]struct{})
-	err := s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
 		}
 		c := snapshots.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			snapshot := snapshots.Bucket(k)
+			snapshot := snapshots.GetBucket(k)
 			if snapshot == nil {
 				continue
 			}
-			metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+			metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 			if metaBucket == nil {
 				continue
 			}
-			id := string(metaBucket.Get(util.BoltMetaDataFileWriterIDKey))
-			idMap[id] = struct{}{}
+			id, err := metaBucket.Get(util.BoltMetaDataFileWriterIDKey, nil)
+			if err != nil {
+				return err
+			}
+			idMap[string(id)] = struct{}{}
 		}
 		return nil
 	})
@@ -1205,22 +1207,26 @@ func (s *Scorch) removeBoltFileWriterIDs(ids map[string]struct{}) error {
 		return err
 	}
 
-	err = s.rootBolt.Update(func(tx *bolt.Tx) error {
+	err = s.rootBolt.Update(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
 		}
 		c := snapshots.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			snapshot := snapshots.Bucket(k)
+			snapshot := snapshots.GetBucket(k)
 			if snapshot == nil {
 				continue
 			}
-			metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+			metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 			if metaBucket == nil {
 				continue
 			}
-			fileWriterID := string(metaBucket.Get(util.BoltMetaDataFileWriterIDKey))
+			fileWriterIDBytes, err := metaBucket.Get(util.BoltMetaDataFileWriterIDKey, nil)
+			if err != nil {
+				return err
+			}
+			fileWriterID := string(fileWriterIDBytes)
 			if _, ok := ids[fileWriterID]; ok {
 				reader, err := util.NewFileReader(fileWriterID, []byte(filePath))
 				if err != nil {
@@ -1229,67 +1235,60 @@ func (s *Scorch) removeBoltFileWriterIDs(ids map[string]struct{}) error {
 				c := snapshots.Cursor()
 				for kk, _ := c.First(); kk != nil; kk, _ = c.Next() {
 					if k[0] == util.BoltInternalKey[0] {
-						internalBucket := snapshot.Bucket(kk)
+						internalBucket := snapshot.GetBucket(kk)
 						if internalBucket == nil {
 							continue
 						}
 						// process all of the internal values and replace them with new values
+						internalBucketVals := make(map[string][]byte)
 						err := internalBucket.ForEach(func(key []byte, val []byte) error {
-							buf, err := reader.Process(val)
-							if err != nil {
-								return err
-							}
-
-							newBuf := writer.Process(buf)
-							return internalBucket.Put(key, newBuf)
-						})
+							internalBucketVals[string(key)] = val
+							return nil
+						}, reader)
 						if err != nil {
 							return err
 						}
+						for key, val := range internalBucketVals {
+							err = internalBucket.Put([]byte(key), val, writer)
+							if err != nil {
+								return err
+							}
+						}
 					} else if kk[0] != util.BoltMetaDataKey[0] {
-						segmentBucket := snapshot.Bucket(kk)
+						segmentBucket := snapshot.GetBucket(kk)
 						if segmentBucket == nil {
 							continue
 						}
 						// process the updated field key
-						updatedFieldBytes := segmentBucket.Get(util.BoltUpdatedFieldsKey)
+						updatedFieldBytes, err := segmentBucket.Get(util.BoltUpdatedFieldsKey, reader)
+						if err != nil {
+							return fmt.Errorf("error getting updated field bytes: %v", err)
+						}
 						if updatedFieldBytes != nil {
-							buf, err := reader.Process(updatedFieldBytes)
-							if err != nil {
-								return err
-							}
-
-							newBuf := writer.Process(buf)
-							err = segmentBucket.Put(util.BoltUpdatedFieldsKey, newBuf)
+							err = segmentBucket.Put(util.BoltUpdatedFieldsKey, updatedFieldBytes, writer)
 							if err != nil {
 								return err
 							}
 						}
 
 						// process the deleted key
-						deletedBytes := segmentBucket.Get(util.BoltDeletedKey)
+						deletedBytes, err := segmentBucket.Get(util.BoltDeletedKey, reader)
+						if err != nil {
+							return fmt.Errorf("error getting deleted bytes: %v", err)
+						}
 						if deletedBytes != nil {
-							buf, err := reader.Process(deletedBytes)
-							if err != nil {
-								return err
-							}
-
-							newBuf := writer.Process(buf)
-							err = segmentBucket.Put(util.BoltDeletedKey, newBuf)
+							err = segmentBucket.Put(util.BoltDeletedKey, deletedBytes, writer)
 							if err != nil {
 								return err
 							}
 						}
 						// process the stats key
-						statsBytes := segmentBucket.Get(util.BoltStatsKey)
+						statsBytes, err := segmentBucket.Get(util.BoltStatsKey, reader)
+						if err != nil {
+							return fmt.Errorf("error getting stats bytes: %v", err)
+						}
 						if statsBytes != nil {
-							buf, err := reader.Process(statsBytes)
-							if err != nil {
-								return err
-							}
-
-							newBuf := writer.Process(buf)
-							err = segmentBucket.Put(util.BoltStatsKey, newBuf)
+							err = segmentBucket.Put(util.BoltStatsKey, statsBytes, writer)
 							if err != nil {
 								return err
 							}
@@ -1297,7 +1296,7 @@ func (s *Scorch) removeBoltFileWriterIDs(ids map[string]struct{}) error {
 					}
 				}
 				err = metaBucket.Put(util.BoltMetaDataFileWriterIDKey,
-					[]byte(writer.Id()))
+					[]byte(writer.Id()), writer)
 				if err != nil {
 					return err
 				}
@@ -1602,7 +1601,7 @@ func (s *Scorch) rootBoltSnapshotMetaData() ([]*snapshotMetaData, error) {
 	// for eg for n = 3 the checkpoints preserved should be tc, tc - d, tc - 2d
 	expirationDuration := time.Duration(s.numSnapshotsToKeep-1) * s.rollbackSamplingInterval
 
-	err := s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
@@ -1623,15 +1622,18 @@ func (s *Scorch) rootBoltSnapshotMetaData() ([]*snapshotMetaData, error) {
 				continue
 			}
 
-			snapshot := snapshots.Bucket(sk)
+			snapshot := snapshots.GetBucket(sk)
 			if snapshot == nil {
 				continue
 			}
-			metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+			metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 			if metaBucket == nil {
 				continue
 			}
-			timeStampBytes := metaBucket.Get(util.BoltMetaDataTimeStamp)
+			timeStampBytes, err := metaBucket.Get(util.BoltMetaDataTimeStamp, nil)
+			if err != nil {
+				continue
+			}
 			var timeStamp time.Time
 			err = timeStamp.UnmarshalText(timeStampBytes)
 			if err != nil {
@@ -1667,7 +1669,7 @@ func (s *Scorch) rootBoltSnapshotMetaData() ([]*snapshotMetaData, error) {
 
 func (s *Scorch) RootBoltSnapshotEpochs() ([]uint64, error) {
 	var rv []uint64
-	err := s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
@@ -1688,14 +1690,14 @@ func (s *Scorch) RootBoltSnapshotEpochs() ([]uint64, error) {
 // Returns the *.zap file names that are listed in the rootBolt.
 func (s *Scorch) loadZapFileNames() (map[string]struct{}, error) {
 	rv := map[string]struct{}{}
-	err := s.rootBolt.View(func(tx *bolt.Tx) error {
+	err := s.rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
 		}
 		sc := snapshots.Cursor()
 		for sk, _ := sc.First(); sk != nil; sk, _ = sc.Next() {
-			snapshot := snapshots.Bucket(sk)
+			snapshot := snapshots.GetBucket(sk)
 			if snapshot == nil {
 				continue
 			}
@@ -1704,11 +1706,14 @@ func (s *Scorch) loadZapFileNames() (map[string]struct{}, error) {
 				if segk[0] == util.BoltInternalKey[0] {
 					continue
 				}
-				segmentBucket := snapshot.Bucket(segk)
+				segmentBucket := snapshot.GetBucket(segk)
 				if segmentBucket == nil {
 					continue
 				}
-				pathBytes := segmentBucket.Get(util.BoltPathKey)
+				pathBytes, err := segmentBucket.Get(util.BoltPathKey, nil)
+				if err != nil {
+					continue
+				}
 				if pathBytes == nil {
 					continue
 				}

--- a/index/scorch/rollback.go
+++ b/index/scorch/rollback.go
@@ -44,7 +44,7 @@ func RollbackPoints(path string) ([]*RollbackPoint, error) {
 	rootBoltOpt := &bolt.Options{
 		ReadOnly: true,
 	}
-	rootBolt, err := bolt.Open(rootBoltPath, 0600, rootBoltOpt)
+	rootBolt, err := util.OpenBolt(rootBoltPath, 0600, rootBoltOpt)
 	if err != nil || rootBolt == nil {
 		return nil, err
 	}
@@ -78,20 +78,23 @@ func RollbackPoints(path string) ([]*RollbackPoint, error) {
 			continue
 		}
 
-		snapshot := snapshots.Bucket(k)
+		snapshot := snapshots.GetBucket(k)
 		if snapshot == nil {
 			log.Printf("RollbackPoints:"+
 				" snapshot key, but bucket missing %x, continuing", k)
 			continue
 		}
 
-		metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+		metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 		if metaBucket == nil {
 			return nil, fmt.Errorf("meta-data bucket missing")
 		}
 
-		fileWriterID := string(metaBucket.Get(util.BoltMetaDataFileWriterIDKey))
-		reader, err := util.NewFileReader(fileWriterID, []byte(rootBoltPath))
+		fileWriterID, err := metaBucket.Get(util.BoltMetaDataFileWriterIDKey, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load file writer ID: %v", err)
+		}
+		reader, err := util.NewFileReader(string(fileWriterID), []byte(rootBoltPath))
 		if err != nil {
 			return nil, fmt.Errorf("unable to load correct reader: %v", err)
 		}
@@ -100,20 +103,15 @@ func RollbackPoints(path string) ([]*RollbackPoint, error) {
 		c2 := snapshot.Cursor()
 		for j, _ := c2.First(); j != nil; j, _ = c2.Next() {
 			if j[0] == util.BoltInternalKey[0] {
-				internalBucket := snapshot.Bucket(j)
+				internalBucket := snapshot.GetBucket(j)
 				if internalBucket == nil {
 					err = fmt.Errorf("internal bucket missing")
 					break
 				}
 				err = internalBucket.ForEach(func(key []byte, val []byte) error {
-					val, err = reader.Process(val)
-					if err != nil {
-						return err
-					}
-					copiedVal := append([]byte(nil), val...)
-					meta[string(key)] = copiedVal
+					meta[string(key)] = val
 					return nil
-				})
+				}, reader)
 				if err != nil {
 					break
 				}
@@ -151,7 +149,7 @@ func Rollback(path string, to *RollbackPoint) error {
 	rootBoltOpt := &bolt.Options{
 		ReadOnly: false,
 	}
-	rootBolt, err := bolt.Open(rootBoltPath, 0600, rootBoltOpt)
+	rootBolt, err := util.OpenBolt(rootBoltPath, 0600, rootBoltOpt)
 	if err != nil || rootBolt == nil {
 		return err
 	}
@@ -166,7 +164,7 @@ func Rollback(path string, to *RollbackPoint) error {
 	// including the target one.
 	var found bool
 	var eligibleEpochs []uint64
-	err = rootBolt.View(func(tx *bolt.Tx) error {
+	err = rootBolt.View(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -80,7 +80,7 @@ type Scorch struct {
 	merges                   chan *segmentMerge
 	introducerNotifier       chan *epochWatcher
 	persisterNotifier        chan *epochWatcher
-	rootBolt                 *bolt.DB
+	rootBolt                 *util.RootBoltImpl
 	asyncTasks               sync.WaitGroup
 
 	trainer trainer
@@ -113,13 +113,13 @@ type trainer interface {
 	train(batch *index.Batch) error
 
 	// to load the metadata from the bolt under the BoltTrainerKey
-	loadTrainedData(*bolt.Bucket) error
+	loadTrainedData(*util.BoltBucketImpl) error
 	// to fetch the internal data from the component
 	getInternal(key []byte) ([]byte, error)
 
 	// trainer specific file transfer operations
 	copyFileLOCKED(file string, d index.IndexDirectory) error
-	updateBolt(snapshotsBucket *bolt.Bucket, key []byte, value []byte) error
+	updateBolt(snapshotsBucket *util.BoltBucketImpl, key []byte, value []byte) error
 }
 
 type ScorchErrorType string
@@ -361,7 +361,7 @@ func (s *Scorch) openBolt() error {
 	rootBoltPath := s.path + string(os.PathSeparator) + "root.bolt"
 	var err error
 	if s.path != "" {
-		s.rootBolt, err = bolt.Open(rootBoltPath, 0o600, &rootBoltOpt)
+		s.rootBolt, err = util.OpenBolt(rootBoltPath, 0o600, &rootBoltOpt)
 		if err != nil {
 			return err
 		}
@@ -1167,7 +1167,7 @@ func (s *Scorch) OpenMeta() error {
 // Merge and update deleted field info and rewrite index mapping
 func (s *Scorch) updateBolt(fieldInfo map[string]*index.UpdateFieldInfo, mappingBytes []byte) error {
 	filePath := s.path + string(os.PathSeparator) + "root.bolt"
-	return s.rootBolt.Update(func(tx *bolt.Tx) error {
+	return s.rootBolt.Update(func(tx *util.BoltTxImpl) error {
 		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
 		if snapshots == nil {
 			return nil
@@ -1180,8 +1180,8 @@ func (s *Scorch) updateBolt(fieldInfo map[string]*index.UpdateFieldInfo, mapping
 				fmt.Printf("unable to parse segment epoch %x, continuing", k)
 				continue
 			}
-			snapshot := snapshots.Bucket(k)
-			metaBucket := snapshot.Bucket(util.BoltMetaDataKey)
+			snapshot := snapshots.GetBucket(k)
+			metaBucket := snapshot.GetBucket(util.BoltMetaDataKey)
 			if metaBucket == nil {
 				return fmt.Errorf("meta-data bucket missing")
 			}
@@ -1191,13 +1191,19 @@ func (s *Scorch) updateBolt(fieldInfo map[string]*index.UpdateFieldInfo, mapping
 				return fmt.Errorf("unable to load correct writer: %v", err)
 			}
 
-			fileWriterID := string(metaBucket.Get(util.BoltMetaDataFileWriterIDKey))
-			reader, err := util.NewFileReader(fileWriterID, []byte(filePath))
+			fileWriterID, err := metaBucket.Get(util.BoltMetaDataFileWriterIDKey, nil)
+			if err != nil {
+				return fmt.Errorf("unable to get file writer id: %v", err)
+			}
+			if fileWriterID == nil {
+				return fmt.Errorf("file writer id missing in meta data")
+			}
+			reader, err := util.NewFileReader(string(fileWriterID), []byte(filePath))
 			if err != nil {
 				return fmt.Errorf("unable to load correct reader: %v", err)
 			}
 
-			err = metaBucket.Put(util.BoltMetaDataFileWriterIDKey, []byte(writer.Id()))
+			err = metaBucket.Put(util.BoltMetaDataFileWriterIDKey, []byte(writer.Id()), writer)
 			if err != nil {
 				return err
 			}
@@ -1205,53 +1211,38 @@ func (s *Scorch) updateBolt(fieldInfo map[string]*index.UpdateFieldInfo, mapping
 			cc := snapshot.Cursor()
 			for kk, _ := cc.First(); kk != nil; kk, _ = cc.Next() {
 				if kk[0] == util.BoltInternalKey[0] {
-					internalBucket := snapshot.Bucket(kk)
+					internalBucket := snapshot.GetBucket(kk)
 					if internalBucket == nil {
 						return fmt.Errorf("segment key, but bucket missing %x", kk)
 					}
 
 					internalVals := make(map[string][]byte)
 					err := internalBucket.ForEach(func(key []byte, val []byte) error {
-						copiedVal, err := reader.Process(append([]byte(nil), val...))
-						if err != nil {
-							return err
-						}
-						internalVals[string(key)] = copiedVal
+						internalVals[string(key)] = val
 						return nil
-					})
+					}, reader)
 					if err != nil {
 						return err
 					}
 
 					for key, val := range internalVals {
-						valBytes := writer.Process(val)
-						if key == string(util.MappingInternalKey) {
-							buf := writer.Process(mappingBytes)
-							err = internalBucket.Put([]byte(key), buf)
-							if err != nil {
-								return err
-							}
-						} else {
-							err = internalBucket.Put([]byte(key), valBytes)
-							if err != nil {
-								return err
-							}
+						err = internalBucket.Put([]byte(key), val, writer)
+						if err != nil {
+							return err
 						}
 					}
 				} else if kk[0] != util.BoltMetaDataKey[0] {
-					segmentBucket := snapshot.Bucket(kk)
+					segmentBucket := snapshot.GetBucket(kk)
 					if segmentBucket == nil {
 						return fmt.Errorf("segment key, but bucket missing %x", kk)
 					}
 					var updatedFields map[string]*index.UpdateFieldInfo
-					updatedFieldBytes := segmentBucket.Get(util.BoltUpdatedFieldsKey)
+					updatedFieldBytes, err := segmentBucket.Get(util.BoltUpdatedFieldsKey, reader)
+					if err != nil {
+						return fmt.Errorf("error getting updated field bytes: %v", err)
+					}
 					if updatedFieldBytes != nil {
-						buf, err := reader.Process(updatedFieldBytes)
-						if err != nil {
-							return err
-						}
-
-						err = json.Unmarshal(buf, &updatedFields)
+						err = json.Unmarshal(updatedFieldBytes, &updatedFields)
 						if err != nil {
 							return fmt.Errorf("error reading updated field bytes: %v", err)
 						}
@@ -1270,39 +1261,32 @@ func (s *Scorch) updateBolt(fieldInfo map[string]*index.UpdateFieldInfo, mapping
 					} else {
 						updatedFields = fieldInfo
 					}
-					b, err := json.Marshal(updatedFields)
+					buf, err := json.Marshal(updatedFields)
 					if err != nil {
 						return err
 					}
-					buf := writer.Process(b)
-					err = segmentBucket.Put(util.BoltUpdatedFieldsKey, buf)
+					err = segmentBucket.Put(util.BoltUpdatedFieldsKey, buf, writer)
 					if err != nil {
 						return err
 					}
 
-					deletedBytes := segmentBucket.Get(util.BoltDeletedKey)
+					deletedBytes, err := segmentBucket.Get(util.BoltDeletedKey, reader)
+					if err != nil {
+						return fmt.Errorf("error getting deleted bytes: %v", err)
+					}
 					if deletedBytes != nil {
-						deletedBytes, err = reader.Process(deletedBytes)
-						if err != nil {
-							return err
-						}
-
-						buf := writer.Process(deletedBytes)
-						err = segmentBucket.Put(util.BoltDeletedKey, buf)
+						err = segmentBucket.Put(util.BoltDeletedKey, deletedBytes, writer)
 						if err != nil {
 							return err
 						}
 					}
 
-					statBytes := segmentBucket.Get(util.BoltStatsKey)
+					statBytes, err := segmentBucket.Get(util.BoltStatsKey, reader)
+					if err != nil {
+						return fmt.Errorf("error getting stats bytes: %v", err)
+					}
 					if statBytes != nil {
-						statBytes, err = reader.Process(statBytes)
-						if err != nil {
-							return err
-						}
-
-						buf := writer.Process(statBytes)
-						err = segmentBucket.Put(util.BoltStatsKey, buf)
+						err = segmentBucket.Put(util.BoltStatsKey, statBytes, writer)
 						if err != nil {
 							return err
 						}

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/blevesearch/bleve/v2/document"
+	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 	segment "github.com/blevesearch/scorch_segment_api/v2"
 	"github.com/blevesearch/vellum"
 	lev "github.com/blevesearch/vellum/levenshtein"
-	bolt "go.etcd.io/bbolt"
 )
 
 // re usable, threadsafe levenshtein builders
@@ -993,7 +993,7 @@ func (is *IndexSnapshot) CopyTo(d index.Directory) error {
 		return fmt.Errorf("invalid root.bolt file found")
 	}
 
-	copyBolt, err := bolt.Open(rootFile.Name(), 0o600, nil)
+	copyBolt, err := util.OpenBolt(rootFile.Name(), 0o600, nil)
 	if err != nil {
 		return err
 	}

--- a/index/scorch/train_noop.go
+++ b/index/scorch/train_noop.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	index "github.com/blevesearch/bleve_index_api"
-	bolt "go.etcd.io/bbolt"
 )
 
 func initTrainer(s *Scorch, config map[string]interface{}) *noopTrainer {
@@ -37,7 +36,7 @@ func (t *noopTrainer) train(batch *index.Batch) error {
 	return fmt.Errorf("training is not supported with this build")
 }
 
-func (t *noopTrainer) loadTrainedData(bucket *bolt.Bucket) error {
+func (t *noopTrainer) loadTrainedData(bucket *util.BoltBucket) error {
 	// noop
 	return nil
 }
@@ -50,6 +49,6 @@ func (t *noopTrainer) copyFileLOCKED(file string, d index.IndexDirectory) error 
 	return nil
 }
 
-func (t *noopTrainer) updateBolt(snapshotsBucket *bolt.Bucket, key []byte, value []byte) error {
+func (t *noopTrainer) updateBolt(snapshotsBucket *util.BoltBucket, key []byte, value []byte) error {
 	return nil
 }

--- a/index/scorch/train_noop.go
+++ b/index/scorch/train_noop.go
@@ -37,7 +37,7 @@ func (t *noopTrainer) train(batch *index.Batch) error {
 	return fmt.Errorf("training is not supported with this build")
 }
 
-func (t *noopTrainer) loadTrainedData(bucket *util.BoltBucket) error {
+func (t *noopTrainer) loadTrainedData(bucket *util.BoltBucketImpl) error {
 	// noop
 	return nil
 }
@@ -50,6 +50,6 @@ func (t *noopTrainer) copyFileLOCKED(file string, d index.IndexDirectory) error 
 	return nil
 }
 
-func (t *noopTrainer) updateBolt(snapshotsBucket *util.BoltBucket, key []byte, value []byte) error {
+func (t *noopTrainer) updateBolt(snapshotsBucket *util.BoltBucketImpl, key []byte, value []byte) error {
 	return nil
 }

--- a/index/scorch/train_noop.go
+++ b/index/scorch/train_noop.go
@@ -20,6 +20,7 @@ package scorch
 import (
 	"fmt"
 
+	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 )
 

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -34,7 +34,6 @@ import (
 	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 	segment "github.com/blevesearch/scorch_segment_api/v2"
-	bolt "go.etcd.io/bbolt"
 )
 
 type trainRequest struct {
@@ -101,19 +100,19 @@ func (t *vectorTrainer) persistToBolt(trainReq *trainRequest) error {
 	if err != nil {
 		return fmt.Errorf("error creating centroid bucket: %v", err)
 	}
-	err = trainerBucket.Put(util.BoltPathKey, []byte(index.TrainedIndexFileName))
+	err = trainerBucket.Put(util.BoltPathKey, []byte(index.TrainedIndexFileName), nil)
 	if err != nil {
 		return fmt.Errorf("error updating centroid bucket: %v", err)
 	}
 
 	t.trainingComplete.Store(trainReq.finalSample)
-	err = trainerBucket.Put(util.BoltTrainCompleteKey, []byte(strconv.FormatBool(trainReq.finalSample)))
+	err = trainerBucket.Put(util.BoltTrainCompleteKey, []byte(strconv.FormatBool(trainReq.finalSample)), nil)
 	if err != nil {
 		return fmt.Errorf("error updating train complete key: %v", err)
 	}
 
 	totSamples := atomic.AddUint64(&t.trainedSamples, uint64(trainReq.sampleSize))
-	err = trainerBucket.Put(util.BoltTrainedSamplesKey, binary.LittleEndian.AppendUint64(nil, totSamples))
+	err = trainerBucket.Put(util.BoltTrainedSamplesKey, binary.LittleEndian.AppendUint64(nil, totSamples), nil)
 	if err != nil {
 		return fmt.Errorf("error updating trained samples key: %v", err)
 	}
@@ -227,7 +226,7 @@ func (t *vectorTrainer) trainLoop() {
 
 // loads the metadata specific to the centroid index from boltdb, happens during init
 // no lock needed
-func (t *vectorTrainer) loadTrainedData(bucket *bolt.Bucket) error {
+func (t *vectorTrainer) loadTrainedData(bucket *util.BoltBucketImpl) error {
 	if bucket == nil {
 		return nil
 	}
@@ -237,8 +236,14 @@ func (t *vectorTrainer) loadTrainedData(bucket *bolt.Bucket) error {
 	}
 
 	// get the training status out of bolt
-	trainComplete := bucket.Get(util.BoltTrainCompleteKey)
-	trainedSamples := bucket.Get(util.BoltTrainedSamplesKey)
+	trainComplete, err := bucket.Get(util.BoltTrainCompleteKey, nil)
+	if err != nil {
+		return fmt.Errorf("error getting train complete: %v", err)
+	}
+	trainedSamples, err := bucket.Get(util.BoltTrainedSamplesKey, nil)
+	if err != nil {
+		return fmt.Errorf("error getting trained samples: %v", err)
+	}
 	atomic.StoreUint64(&t.trainedSamples, binary.LittleEndian.Uint64(trainedSamples))
 	comp, err := strconv.ParseBool(string(trainComplete))
 	if err != nil {
@@ -345,7 +350,7 @@ func (t *vectorTrainer) copyFileLOCKED(file string, d index.IndexDirectory) erro
 	return nil
 }
 
-func (t *vectorTrainer) updateBolt(snapshotsBucket *bolt.Bucket, key []byte, value []byte) error {
+func (t *vectorTrainer) updateBolt(snapshotsBucket *util.BoltBucketImpl, key []byte, value []byte) error {
 	if bytes.Equal(key, util.BoltTrainerKey) {
 		trainerBucket, err := snapshotsBucket.CreateBucketIfNotExists(util.BoltTrainerKey)
 		if err != nil {
@@ -356,12 +361,15 @@ func (t *vectorTrainer) updateBolt(snapshotsBucket *bolt.Bucket, key []byte, val
 		}
 
 		// guard against duplicate updates
-		existingValue := trainerBucket.Get(util.BoltPathKey)
+		existingValue, err := trainerBucket.Get(util.BoltPathKey, nil)
+		if err != nil {
+			return fmt.Errorf("error checking existing value: %v", err)
+		}
 		if existingValue != nil {
 			return fmt.Errorf("key already exists %v %v", t.parent.path, string(existingValue))
 		}
 
-		err = trainerBucket.Put(util.BoltPathKey, value)
+		err = trainerBucket.Put(util.BoltPathKey, value, nil)
 		if err != nil {
 			return err
 		}

--- a/util/bolt.go
+++ b/util/bolt.go
@@ -1,0 +1,167 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// All of the bolt impls provide a layer of indirection to allow for processing
+// of values as they are read/written to bolt depending on the key or bucket name
+// This is used to allow better support for file callbacks
+
+// wrapper around bolt.DB
+type RootBoltImpl struct {
+	*bolt.DB
+}
+
+// wrapper around bolt.Tx
+type BoltTxImpl struct {
+	*bolt.Tx
+}
+
+// wrapper around bolt.Bucket
+type BoltBucketImpl struct {
+	*bolt.Bucket
+
+	name string // store the name of the bucket during creation
+}
+
+func OpenBolt(path string, mode os.FileMode, options *bolt.Options) (*RootBoltImpl, error) {
+	db, err := bolt.Open(path, mode, options)
+	if err != nil {
+		return nil, err
+	}
+	return &RootBoltImpl{DB: db}, nil
+}
+
+func (r *RootBoltImpl) Begin(writable bool) (*BoltTxImpl, error) {
+	tx, err := r.DB.Begin(writable)
+	if err != nil {
+		return nil, err
+	}
+	return &BoltTxImpl{Tx: tx}, nil
+}
+
+func (r *RootBoltImpl) View(fn func(*BoltTxImpl) error) error {
+	return r.DB.View(func(tx *bolt.Tx) error {
+		return fn(&BoltTxImpl{Tx: tx})
+	})
+}
+
+func (r *RootBoltImpl) Update(fn func(*BoltTxImpl) error) error {
+	return r.DB.Update(func(tx *bolt.Tx) error {
+		return fn(&BoltTxImpl{Tx: tx})
+	})
+}
+
+func (tx *BoltTxImpl) CreateBucketIfNotExists(name []byte) (*BoltBucketImpl, error) {
+	bucket, err := tx.Tx.CreateBucketIfNotExists(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BoltBucketImpl{
+		name:   string(name),
+		Bucket: bucket,
+	}, nil
+}
+
+func (tx *BoltTxImpl) Bucket(name []byte) *BoltBucketImpl {
+	bucket := tx.Tx.Bucket(name)
+	if bucket == nil {
+		return nil
+	}
+	return &BoltBucketImpl{
+		name:   string(name),
+		Bucket: bucket,
+	}
+}
+
+func (b *BoltBucketImpl) GetBucket(name []byte) *BoltBucketImpl {
+	bucket := b.Bucket.Bucket(name)
+	if bucket == nil {
+		return nil
+	}
+	return &BoltBucketImpl{
+		name:   string(name),
+		Bucket: bucket,
+	}
+}
+
+func (b *BoltBucketImpl) CreateBucketIfNotExists(name []byte) (*BoltBucketImpl, error) {
+	bucket, err := b.Bucket.CreateBucketIfNotExists(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BoltBucketImpl{
+		name:   string(name),
+		Bucket: bucket,
+	}, nil
+}
+
+// Process values during ForEach if the bucket name or key is in the boltKeysProcessed map
+func (b *BoltBucketImpl) ForEach(fn func(key []byte, value []byte) error, reader FileReader) error {
+	return b.Bucket.ForEach(func(k, v []byte) error {
+		if _, ok := boltKeysProcessed[b.name]; ok {
+			if reader == nil {
+				return fmt.Errorf("reader callback is required for bucket %s", b.name)
+			}
+			processedValue, err := reader.Process(v)
+			if err != nil {
+				return err
+			}
+			return fn(k, processedValue)
+		}
+		return fn(k, v)
+	})
+}
+
+// Process values during Put/Get if the bucket name or key is in the boltKeysProcessed map
+func (b *BoltBucketImpl) Put(key []byte, value []byte, writer FileWriter) error {
+	_, ok1 := boltKeysProcessed[string(key)]
+	_, ok2 := boltKeysProcessed[b.name]
+	if ok1 || ok2 {
+		if writer == nil {
+			return fmt.Errorf("writer callback is required for key %s", string(key))
+		}
+		processedValue := writer.Process(value)
+		return b.Bucket.Put(key, processedValue)
+	}
+	return b.Bucket.Put(key, value)
+}
+
+// Process values during Put/Get if the bucket name or key is in the boltKeysProcessed map
+func (b *BoltBucketImpl) Get(key []byte, reader FileReader) ([]byte, error) {
+	_, ok1 := boltKeysProcessed[string(key)]
+	_, ok2 := boltKeysProcessed[b.name]
+	if ok1 || ok2 {
+		if reader == nil {
+			return nil, fmt.Errorf("reader callback is required for key %s", string(key))
+		}
+		val := b.Bucket.Get(key)
+		if val == nil {
+			return nil, nil
+		}
+		processedVal, err := reader.Process(val)
+		if err != nil {
+			return nil, err
+		}
+		return processedVal, nil
+	}
+	return b.Bucket.Get(key), nil
+}

--- a/util/file_callbacks.go
+++ b/util/file_callbacks.go
@@ -116,3 +116,14 @@ func (r *fileReaderImpl) Process(data []byte) ([]byte, error) {
 func (r *fileReaderImpl) Id() string {
 	return r.id
 }
+
+// -----------------------------------------------------------------------
+
+// set of bolt keys and bucket names that require processing by the reader
+// and writer callbacks.
+var boltKeysProcessed = map[string]struct{}{
+	string(BoltDeletedKey):       {},
+	string(BoltInternalKey):      {},
+	string(BoltStatsKey):         {},
+	string(BoltUpdatedFieldsKey): {},
+}


### PR DESCRIPTION
 - Wrap bolt.DB, bolt.TX and bolt.Bucket with impls
 - Override all bucket, transaction and key functions currently in use
 - Use a map to track keys and bucket names that require file callback handling
 - Process values internally before returning data outside the wrappers