### PR TITLE
Fix `null` issue when parsing search request attributes

### DIFF
--- a/search.go
+++ b/search.go
@@ -834,8 +834,7 @@ func ParseParams(r *SearchRequest, input []byte) (*RequestParams, error) {
 	return params, nil
 }
 
-// OptionalRawMessage is a wrapper around json.RawMessage that treats empty or null JSON as nil,
-// to allow for optional parameters in search requests without requiring clients to send null explicitly.
+// OptionalRawMessage is a wrapper around json.RawMessage that treats empty or `null` JSON as nil.
 type OptionalRawMessage json.RawMessage
 
 func (n *OptionalRawMessage) UnmarshalJSON(data []byte) error {

--- a/search.go
+++ b/search.go
@@ -845,3 +845,10 @@ func (n *OptionalRawMessage) UnmarshalJSON(data []byte) error {
 	*n = slices.Clone(data)
 	return nil
 }
+
+func (n OptionalRawMessage) MarshalJSON() ([]byte, error) {
+	if n == nil {
+		return nil, nil
+	}
+	return n, nil
+}

--- a/search.go
+++ b/search.go
@@ -15,9 +15,11 @@
 package bleve
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -829,4 +831,17 @@ func ParseParams(r *SearchRequest, input []byte) (*RequestParams, error) {
 	}
 
 	return params, nil
+}
+
+// OptionalRawMessage is a wrapper around json.RawMessage that treats empty or null JSON as nil,
+// to allow for optional parameters in search requests without requiring clients to send null explicitly.
+type OptionalRawMessage []byte
+
+func (n *OptionalRawMessage) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*n = nil
+		return nil
+	}
+	*n = slices.Clone(data)
+	return nil
 }

--- a/search.go
+++ b/search.go
@@ -847,8 +847,8 @@ func (n *OptionalRawMessage) UnmarshalJSON(data []byte) error {
 }
 
 func (n OptionalRawMessage) MarshalJSON() ([]byte, error) {
-	if n == nil {
-		return nil, nil
+	if len(n) == 0 {
+		return []byte("null"), nil
 	}
 	return n, nil
 }

--- a/search.go
+++ b/search.go
@@ -16,6 +16,7 @@ package bleve
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -835,7 +836,7 @@ func ParseParams(r *SearchRequest, input []byte) (*RequestParams, error) {
 
 // OptionalRawMessage is a wrapper around json.RawMessage that treats empty or null JSON as nil,
 // to allow for optional parameters in search requests without requiring clients to send null explicitly.
-type OptionalRawMessage []byte
+type OptionalRawMessage json.RawMessage
 
 func (n *OptionalRawMessage) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 || bytes.Equal(data, []byte("null")) {

--- a/search_knn.go
+++ b/search_knn.go
@@ -43,18 +43,18 @@ type SearchRequest struct {
 	Query            query.Query       `json:"query"`
 	Size             int               `json:"size"`
 	From             int               `json:"from"`
-	Highlight        *HighlightRequest `json:"highlight"`
-	Fields           []string          `json:"fields"`
-	Facets           FacetsRequest     `json:"facets"`
+	Highlight        *HighlightRequest `json:"highlight,omitempty"`
+	Fields           []string          `json:"fields,omitempty"`
+	Facets           FacetsRequest     `json:"facets,omitempty"`
 	Explain          bool              `json:"explain"`
 	Sort             search.SortOrder  `json:"sort"`
 	IncludeLocations bool              `json:"includeLocations"`
 	Score            string            `json:"score,omitempty"`
-	SearchAfter      []string          `json:"search_after"`
-	SearchBefore     []string          `json:"search_before"`
+	SearchAfter      []string          `json:"search_after,omitempty"`
+	SearchBefore     []string          `json:"search_before,omitempty"`
 
-	KNN         []*KNNRequest `json:"knn"`
-	KNNOperator knnOperator   `json:"knn_operator"`
+	KNN         []*KNNRequest `json:"knn,omitempty"`
+	KNNOperator knnOperator   `json:"knn_operator,omitempty"`
 
 	// PreSearchData will be a  map that will be used
 	// in the second phase of any 2-phase search, to provide additional

--- a/search_knn.go
+++ b/search_knn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/collector"
 	"github.com/blevesearch/bleve/v2/search/query"
+	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
@@ -125,35 +126,35 @@ func (r *SearchRequest) AddKNNOperator(operator knnOperator) {
 // a SearchRequest
 func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	type tempKNNReq struct {
-		Field        string          `json:"field"`
-		Vector       []float32       `json:"vector"`
-		VectorBase64 string          `json:"vector_base64"`
-		K            int64           `json:"k"`
-		Boost        *query.Boost    `json:"boost,omitempty"`
-		Params       json.RawMessage `json:"params"`
-		FilterQuery  json.RawMessage `json:"filter,omitempty"`
+		Field        string             `json:"field"`
+		Vector       []float32          `json:"vector"`
+		VectorBase64 string             `json:"vector_base64"`
+		K            int64              `json:"k"`
+		Boost        *query.Boost       `json:"boost,omitempty"`
+		Params       OptionalRawMessage `json:"params"`
+		FilterQuery  OptionalRawMessage `json:"filter,omitempty"`
 	}
 
 	var temp struct {
-		Q                json.RawMessage   `json:"query"`
-		Size             *int              `json:"size"`
-		From             int               `json:"from"`
-		Highlight        *HighlightRequest `json:"highlight"`
-		Fields           []string          `json:"fields"`
-		Facets           FacetsRequest     `json:"facets"`
-		Explain          bool              `json:"explain"`
-		Sort             []json.RawMessage `json:"sort"`
-		IncludeLocations bool              `json:"includeLocations"`
-		Score            string            `json:"score"`
-		SearchAfter      []string          `json:"search_after"`
-		SearchBefore     []string          `json:"search_before"`
-		KNN              []*tempKNNReq     `json:"knn"`
-		KNNOperator      knnOperator       `json:"knn_operator"`
-		PreSearchData    json.RawMessage   `json:"pre_search_data"`
-		Params           json.RawMessage   `json:"params"`
+		Q                json.RawMessage    `json:"query"`
+		Size             *int               `json:"size"`
+		From             int                `json:"from"`
+		Highlight        *HighlightRequest  `json:"highlight"`
+		Fields           []string           `json:"fields"`
+		Facets           FacetsRequest      `json:"facets"`
+		Explain          bool               `json:"explain"`
+		Sort             []json.RawMessage  `json:"sort"`
+		IncludeLocations bool               `json:"includeLocations"`
+		Score            string             `json:"score"`
+		SearchAfter      []string           `json:"search_after"`
+		SearchBefore     []string           `json:"search_before"`
+		KNN              []*tempKNNReq      `json:"knn"`
+		KNNOperator      knnOperator        `json:"knn_operator"`
+		PreSearchData    OptionalRawMessage `json:"pre_search_data"`
+		Params           OptionalRawMessage `json:"params"`
 	}
 
-	err := json.Unmarshal(input, &temp)
+	err := util.UnmarshalJSON(input, &temp)
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	}
 
 	if IsScoreFusionRequested(r) {
-		if temp.Params == nil {
+		if len(temp.Params) == 0 {
 			// If params is not present and it is requires rescoring, assign
 			// default values
 			r.Params = NewDefaultParams(r.From, r.Size)
@@ -216,11 +217,10 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		r.KNN[i].VectorBase64 = temp.KNN[i].VectorBase64
 		r.KNN[i].K = temp.KNN[i].K
 		r.KNN[i].Boost = temp.KNN[i].Boost
-		r.KNN[i].Params = temp.KNN[i].Params
-		if len(knnReq.FilterQuery) == 0 {
-			// Setting this to nil to avoid ParseQuery() setting it to a match none
-			r.KNN[i].FilterQuery = nil
-		} else {
+		if len(temp.KNN[i].Params) > 0 {
+			r.KNN[i].Params = json.RawMessage(temp.KNN[i].Params)
+		}
+		if len(temp.KNN[i].FilterQuery) > 0 {
 			r.KNN[i].FilterQuery, err = query.ParseQuery(knnReq.FilterQuery)
 			if err != nil {
 				return err
@@ -232,7 +232,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		r.KNNOperator = knnOperatorOr
 	}
 
-	if temp.PreSearchData != nil {
+	if len(temp.PreSearchData) > 0 {
 		r.PreSearchData, err = query.ParsePreSearchData(temp.PreSearchData)
 		if err != nil {
 			return err

--- a/search_knn.go
+++ b/search_knn.go
@@ -194,7 +194,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	}
 
 	if IsScoreFusionRequested(r) {
-		if len(temp.Params) == 0 {
+		if temp.Params == nil {
 			// If params is not present and it is requires rescoring, assign
 			// default values
 			r.Params = NewDefaultParams(r.From, r.Size)
@@ -232,7 +232,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		r.KNNOperator = knnOperatorOr
 	}
 
-	if len(temp.PreSearchData) > 0 {
+	if temp.PreSearchData != nil {
 		r.PreSearchData, err = query.ParsePreSearchData(temp.PreSearchData)
 		if err != nil {
 			return err

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2936,3 +2936,26 @@ func TestHierarchicalNestedVectorSearch(t *testing.T) {
 		}
 	}
 }
+
+func TestKNNNullParams(t *testing.T) {
+	queries := []struct {
+		query []byte
+	}{
+		{query: []byte(`{"knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
+		{query: []byte(`{"knn": [{"field": "emb", "params": null, "vector": [1, 2], "k": 3}]}`)},
+	}
+
+	for _, q := range queries {
+		var searchReq SearchRequest
+		err := json.Unmarshal(q.query, &searchReq)
+		if err != nil {
+			t.Fatalf("failed to parse query: %v", err)
+		}
+		for _, req := range searchReq.KNN {
+			fmt.Println("Parsed KNN request:", req)
+			if len(req.Params) > 0 {
+				t.Fatalf("expected no params for query: %s, got %v", q.query, req.Params)
+			}
+		}
+	}
+}

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2944,6 +2944,9 @@ func TestKNNNullParams(t *testing.T) {
 		{query: []byte(`{"knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"knn": [{"field": "emb", "params": null, "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"knn": [{"field": "emb","vector": [1, 2], "k": 3, "filter": null}]}`)},
+		{query: []byte(`{"score": "rrf", "params": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
+		{query: []byte(`{"score": "rsf", "params": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
+		{query: []byte(`{"pre_search_data": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 	}
 
 	for _, q := range queries {
@@ -2951,6 +2954,12 @@ func TestKNNNullParams(t *testing.T) {
 		err := json.Unmarshal(q.query, &searchReq)
 		if err != nil {
 			t.Fatalf("failed to parse query: %v", err)
+		}
+		if len(searchReq.Params) > 0 {
+			t.Fatalf("expected no top-level params for query: %s, got %v", q.query, searchReq.Params)
+		}
+		if len(searchReq.PreSearchData) > 0 {
+			t.Fatalf("expected no pre_search_data for query: %s, got %v", q.query, searchReq.PreSearchData)
 		}
 		for _, req := range searchReq.KNN {
 			if len(req.Params) > 0 {
@@ -2968,6 +2977,12 @@ func TestKNNNullParams(t *testing.T) {
 		err = json.Unmarshal(marshalled, &unmarshalled)
 		if err != nil {
 			t.Fatalf("failed to unmarshal marshalled search request: %v", err)
+		}
+		if len(unmarshalled.Params) > 0 {
+			t.Fatalf("expected no top-level params after marshal/unmarshal for query: %s, got %v", q.query, unmarshalled.Params)
+		}
+		if len(unmarshalled.PreSearchData) > 0 {
+			t.Fatalf("expected no pre_search_data after marshal/unmarshal for query: %s, got %v", q.query, unmarshalled.PreSearchData)
 		}
 		for _, req := range unmarshalled.KNN {
 			if len(req.Params) > 0 {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2943,6 +2943,7 @@ func TestKNNNullParams(t *testing.T) {
 	}{
 		{query: []byte(`{"knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"knn": [{"field": "emb", "params": null, "vector": [1, 2], "k": 3}]}`)},
+		{query: []byte(`{"knn": [{"field": "emb","vector": [1, 2], "k": 3, "filter": null}]}`)},
 	}
 
 	for _, q := range queries {
@@ -2952,9 +2953,11 @@ func TestKNNNullParams(t *testing.T) {
 			t.Fatalf("failed to parse query: %v", err)
 		}
 		for _, req := range searchReq.KNN {
-			fmt.Println("Parsed KNN request:", req)
 			if len(req.Params) > 0 {
 				t.Fatalf("expected no params for query: %s, got %v", q.query, req.Params)
+			}
+			if req.FilterQuery != nil {
+				t.Fatalf("expected no filter for query: %s, got %v", q.query, req.FilterQuery)
 			}
 		}
 	}

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2955,7 +2955,7 @@ func TestKNNNullParams(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to parse query: %v", err)
 		}
-		if len(searchReq.Params) > 0 {
+		if searchReq.Params != nil {
 			t.Fatalf("expected no top-level params for query: %s, got %v", q.query, searchReq.Params)
 		}
 		if len(searchReq.PreSearchData) > 0 {
@@ -2978,7 +2978,7 @@ func TestKNNNullParams(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to unmarshal marshalled search request: %v", err)
 		}
-		if len(unmarshalled.Params) > 0 {
+		if unmarshalled.Params != nil {
 			t.Fatalf("expected no top-level params after marshal/unmarshal for query: %s, got %v", q.query, unmarshalled.Params)
 		}
 		if len(unmarshalled.PreSearchData) > 0 {

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2960,5 +2960,22 @@ func TestKNNNullParams(t *testing.T) {
 				t.Fatalf("expected no filter for query: %s, got %v", q.query, req.FilterQuery)
 			}
 		}
+		marshalled, err := json.Marshal(searchReq)
+		if err != nil {
+			t.Fatalf("failed to marshal search request: %v", err)
+		}
+		var unmarshalled SearchRequest
+		err = json.Unmarshal(marshalled, &unmarshalled)
+		if err != nil {
+			t.Fatalf("failed to unmarshal marshalled search request: %v", err)
+		}
+		for _, req := range unmarshalled.KNN {
+			if len(req.Params) > 0 {
+				t.Fatalf("expected no params after marshal/unmarshal for query: %s, got %v", q.query, req.Params)
+			}
+			if req.FilterQuery != nil {
+				t.Fatalf("expected no filter after marshal/unmarshal for query: %s, got %v", q.query, req.FilterQuery)
+			}
+		}
 	}
 }

--- a/search_knn_test.go
+++ b/search_knn_test.go
@@ -2944,8 +2944,6 @@ func TestKNNNullParams(t *testing.T) {
 		{query: []byte(`{"knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"knn": [{"field": "emb", "params": null, "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"knn": [{"field": "emb","vector": [1, 2], "k": 3, "filter": null}]}`)},
-		{query: []byte(`{"score": "rrf", "params": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
-		{query: []byte(`{"score": "rsf", "params": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 		{query: []byte(`{"pre_search_data": null, "knn": [{"field": "emb", "vector": [1, 2], "k": 3}]}`)},
 	}
 
@@ -2954,9 +2952,6 @@ func TestKNNNullParams(t *testing.T) {
 		err := json.Unmarshal(q.query, &searchReq)
 		if err != nil {
 			t.Fatalf("failed to parse query: %v", err)
-		}
-		if searchReq.Params != nil {
-			t.Fatalf("expected no top-level params for query: %s, got %v", q.query, searchReq.Params)
 		}
 		if len(searchReq.PreSearchData) > 0 {
 			t.Fatalf("expected no pre_search_data for query: %s, got %v", q.query, searchReq.PreSearchData)
@@ -2977,9 +2972,6 @@ func TestKNNNullParams(t *testing.T) {
 		err = json.Unmarshal(marshalled, &unmarshalled)
 		if err != nil {
 			t.Fatalf("failed to unmarshal marshalled search request: %v", err)
-		}
-		if unmarshalled.Params != nil {
-			t.Fatalf("expected no top-level params after marshal/unmarshal for query: %s, got %v", q.query, unmarshalled.Params)
 		}
 		if len(unmarshalled.PreSearchData) > 0 {
 			t.Fatalf("expected no pre_search_data after marshal/unmarshal for query: %s, got %v", q.query, unmarshalled.PreSearchData)

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -143,7 +143,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	}
 
 	if IsScoreFusionRequested(r) {
-		if len(temp.Params) == 0 {
+		if temp.Params == nil {
 			// If params is not present and it is requires rescoring, assign
 			// default values
 			r.Params = NewDefaultParams(r.From, r.Size)
@@ -158,7 +158,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		}
 	}
 
-	if len(temp.PreSearchData) > 0 {
+	if temp.PreSearchData != nil {
 		r.PreSearchData, err = query.ParsePreSearchData(temp.PreSearchData)
 		if err != nil {
 			return err

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/collector"
 	"github.com/blevesearch/bleve/v2/search/query"
+	"github.com/blevesearch/bleve/v2/util"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
@@ -102,7 +103,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		Params           OptionalRawMessage `json:"params"`
 	}
 
-	err := json.Unmarshal(input, &temp)
+	err := util.UnmarshalJSON(input, &temp)
 	if err != nil {
 		return err
 	}

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -86,20 +86,20 @@ type SearchRequest struct {
 // a SearchRequest
 func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	var temp struct {
-		Q                json.RawMessage   `json:"query"`
-		Size             *int              `json:"size"`
-		From             int               `json:"from"`
-		Highlight        *HighlightRequest `json:"highlight"`
-		Fields           []string          `json:"fields"`
-		Facets           FacetsRequest     `json:"facets"`
-		Explain          bool              `json:"explain"`
-		Sort             []json.RawMessage `json:"sort"`
-		IncludeLocations bool              `json:"includeLocations"`
-		Score            string            `json:"score"`
-		SearchAfter      []string          `json:"search_after"`
-		SearchBefore     []string          `json:"search_before"`
-		PreSearchData    json.RawMessage   `json:"pre_search_data"`
-		Params           json.RawMessage   `json:"params"`
+		Q                json.RawMessage    `json:"query"`
+		Size             *int               `json:"size"`
+		From             int                `json:"from"`
+		Highlight        *HighlightRequest  `json:"highlight"`
+		Fields           []string           `json:"fields"`
+		Facets           FacetsRequest      `json:"facets"`
+		Explain          bool               `json:"explain"`
+		Sort             []json.RawMessage  `json:"sort"`
+		IncludeLocations bool               `json:"includeLocations"`
+		Score            string             `json:"score"`
+		SearchAfter      []string           `json:"search_after"`
+		SearchBefore     []string           `json:"search_before"`
+		PreSearchData    OptionalRawMessage `json:"pre_search_data"`
+		Params           OptionalRawMessage `json:"params"`
 	}
 
 	err := json.Unmarshal(input, &temp)
@@ -142,7 +142,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 	}
 
 	if IsScoreFusionRequested(r) {
-		if temp.Params == nil {
+		if len(temp.Params) == 0 {
 			// If params is not present and it is requires rescoring, assign
 			// default values
 			r.Params = NewDefaultParams(r.From, r.Size)
@@ -157,7 +157,7 @@ func (r *SearchRequest) UnmarshalJSON(input []byte) error {
 		}
 	}
 
-	if temp.PreSearchData != nil {
+	if len(temp.PreSearchData) > 0 {
 		r.PreSearchData, err = query.ParsePreSearchData(temp.PreSearchData)
 		if err != nil {
 			return err

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -61,7 +61,7 @@ type SearchRequest struct {
 	Facets           FacetsRequest     `json:"facets,omitempty"`
 	Explain          bool              `json:"explain"`
 	Sort             search.SortOrder  `json:"sort"`
-	IncludeLocations bool              `json:"includeLocations,omitempty"`
+	IncludeLocations bool              `json:"includeLocations"`
 	Score            string            `json:"score,omitempty"`
 	SearchAfter      []string          `json:"search_after,omitempty"`
 	SearchBefore     []string          `json:"search_before,omitempty"`

--- a/search_no_knn.go
+++ b/search_no_knn.go
@@ -55,15 +55,15 @@ type SearchRequest struct {
 	Query            query.Query       `json:"query"`
 	Size             int               `json:"size"`
 	From             int               `json:"from"`
-	Highlight        *HighlightRequest `json:"highlight"`
-	Fields           []string          `json:"fields"`
-	Facets           FacetsRequest     `json:"facets"`
+	Highlight        *HighlightRequest `json:"highlight,omitempty"`
+	Fields           []string          `json:"fields,omitempty"`
+	Facets           FacetsRequest     `json:"facets,omitempty"`
 	Explain          bool              `json:"explain"`
 	Sort             search.SortOrder  `json:"sort"`
-	IncludeLocations bool              `json:"includeLocations"`
+	IncludeLocations bool              `json:"includeLocations,omitempty"`
 	Score            string            `json:"score,omitempty"`
-	SearchAfter      []string          `json:"search_after"`
-	SearchBefore     []string          `json:"search_before"`
+	SearchAfter      []string          `json:"search_after,omitempty"`
+	SearchBefore     []string          `json:"search_before,omitempty"`
 
 	// PreSearchData will be a  map that will be used
 	// in the second phase of any 2-phase search, to provide additional


### PR DESCRIPTION
- We allow parsing a few attributes of the search request as `json.RawMessage` like
    - `KNN Params`
    - `KNN Filter`
    - `PresearchData`
- It is possible for the JSON body to contain the keyword `null` for these attributes, especially after a marshal-unmarshal cycle.
- This `null` value is passed on downstream, causing every check for `len(attribute) > 0` to succeed and take the path for which the attribute is valid even if the attribute is actually `nil`.
- Fix this issue by adding a custom type that parses `null` specially and sets the attribute to `nil` when required.