### PR TITLE
MB-71607: Fixed data corruption in bolt

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1232,9 +1232,10 @@ func (s *Scorch) removeBoltFileWriterIDs(ids map[string]struct{}) error {
 				if err != nil {
 					return fmt.Errorf("unable to load correct reader: %v", err)
 				}
-				c := snapshots.Cursor()
-				for kk, _ := c.First(); kk != nil; kk, _ = c.Next() {
-					if k[0] == util.BoltInternalKey[0] {
+
+				cc := snapshot.Cursor()
+				for kk, _ := cc.First(); kk != nil; kk, _ = cc.Next() {
+					if kk[0] == util.BoltInternalKey[0] {
 						internalBucket := snapshot.GetBucket(kk)
 						if internalBucket == nil {
 							continue

--- a/util/bolt.go
+++ b/util/bolt.go
@@ -118,6 +118,7 @@ func (b *BoltBucketImpl) CreateBucketIfNotExists(name []byte) (*BoltBucketImpl, 
 func (b *BoltBucketImpl) ForEach(fn func(key []byte, value []byte) error, reader FileReader) error {
 	_, ok1 := boltKeysProcessed[b.name]
 	return b.Bucket.ForEach(func(k, v []byte) error {
+		v = append([]byte(nil), v...)
 		if _, ok2 := boltKeysProcessed[string(k)]; ok1 || ok2 {
 			if reader == nil {
 				return fmt.Errorf("reader callback is required for bucket %s", b.name)
@@ -136,6 +137,7 @@ func (b *BoltBucketImpl) ForEach(fn func(key []byte, value []byte) error, reader
 func (b *BoltBucketImpl) Put(key []byte, value []byte, writer FileWriter) error {
 	_, ok1 := boltKeysProcessed[string(key)]
 	_, ok2 := boltKeysProcessed[b.name]
+	value = append([]byte(nil), value...)
 	if ok1 || ok2 {
 		if writer == nil {
 			return fmt.Errorf("writer callback is required for key %s", string(key))


### PR DESCRIPTION
 - Added a guardrail to copy data instead of reusing slices
 - Fixed bug in drop writer ids