### PR TITLE
Fix metrics involving NestedDocuments

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -69,6 +69,12 @@ func (d *Document) Size() int {
 		sizeInBytes += entry.Size()
 	}
 
+	for _, entry := range d.NestedDocuments {
+		if entry != nil {
+			sizeInBytes += entry.Size()
+		}
+	}
+
 	return sizeInBytes
 }
 
@@ -110,6 +116,11 @@ func (d *Document) NumPlainTextBytes() uint64 {
 			if compositeField.includesField(field.Name()) {
 				rv += field.NumPlainTextBytes()
 			}
+		}
+	}
+	for _, nestedDoc := range d.NestedDocuments {
+		if nestedDoc != nil {
+			rv += nestedDoc.NumPlainTextBytes()
 		}
 	}
 	return rv


### PR DESCRIPTION
- Fix `Size` calculation to include size of `NestedDocuments` as well.