### PR TITLE
Upgrade faiss in `docs/vectors.md`

### DIFF
--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -20,7 +20,7 @@
     | `v2.5.0`, `v2.5.1` | [blevesearch/faiss@352484e](https://github.com/blevesearch/faiss/tree/352484e0fc9d1f8f46737841efe5f26e0f383f71) (modified v1.10.0) |
     | `v2.5.2`, `v2.5.3`, `v2.5.4` | [blevesearch/faiss@b3d4e00](https://github.com/blevesearch/faiss/tree/b3d4e00a69425b95e0b283da7801efc9f66b580d) (modified v1.11.0) |
     | `v2.5.5`, `v2.5.6`, `v2.5.7` | [blevesearch/faiss@8a59a0c](https://github.com/blevesearch/faiss/tree/8a59a0c552fa2d14fa871f6b6bc793de1d277f5e) (modified v1.12.0) |
-    | `v2.6.0` | [blevesearch/faiss@ffd910a](https://github.com/blevesearch/faiss/tree/ffd910a91f1acf49b9898a7e514e462db89ee7b3) (modified v1.13.2) |
+    | `v2.6.0` | [blevesearch/faiss@fff814d](https://github.com/blevesearch/faiss/tree/fff814dea2bdda020363506904979b204ee201aa) (modified v1.13.2) |
 
 ## Features
 


### PR DESCRIPTION
- Upgrade the version of faiss to use for bleve@v2.6.0