### PR TITLE
Regression fix: Cache the vector index size

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -202,7 +202,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			segment:    next.data, // take ownership of next.data's ref-count
 			stats:      next.stats,
 			cachedDocs: &cachedDocs{cache: nil},
-			cachedMeta: &cachedMeta{meta: nil},
+			cachedMeta: newCachedMeta(),
 			internal:   make(map[string][]byte),
 			creator:    "introduceSegment",
 		}
@@ -460,7 +460,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				deleted:    newSegmentDeleted[i],
 				stats:      stats,
 				cachedDocs: &cachedDocs{cache: nil},
-				cachedMeta: &cachedMeta{meta: nil},
+				cachedMeta: newCachedMeta(),
 				creator:    "introduceMerge",
 				mmaped:     nextMerge.mmaped,
 			})

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
@@ -54,87 +53,81 @@ func (o *OptimizeVR) invokeSearcherEndCallback() {
 	}
 }
 
+// executeSearchOnSegment runs the configured kNN searches for every vector
+// reader against a single segment, populating the per-segment postings and
+// iterators on each reader.
+func (o *OptimizeVR) searchOnSegment(segIdx int) error {
+	seg := o.snapshot.segment[segIdx]
+	vecSeg, ok := seg.segment.(segment_api.VectorSegment)
+	if !ok {
+		return nil
+	}
+	for field, vrs := range o.vrs {
+		if info, ok := o.snapshot.updatedFields[field]; ok && (info.Deleted || info.Index) {
+			continue
+		}
+		vecIndex, err := vecSeg.InterpretVectorIndex(field, seg.deleted)
+		if err != nil {
+			return err
+		}
+		seg.cachedMeta.storeMeta(field, vecIndex.Size())
+		for _, vr := range vrs {
+			var pl segment_api.VecPostingsList
+			var searchErr error
+			if vr.eligibleSelector != nil {
+				pl, searchErr = vecIndex.SearchWithFilter(
+					vr.vector,
+					vr.k,
+					vr.eligibleSelector.SegmentEligibleDocuments(segIdx),
+					vr.searchParams,
+				)
+			} else {
+				pl, searchErr = vecIndex.Search(
+					vr.vector,
+					vr.k,
+					vr.searchParams,
+				)
+			}
+			if searchErr != nil {
+				vecIndex.Close()
+				return searchErr
+			}
+			vr.postings[segIdx] = pl
+			vr.iterators[segIdx] = pl.Iterator(vr.iterators[segIdx])
+		}
+		vecIndex.Close()
+	}
+	return nil
+}
+
 func (o *OptimizeVR) Finish() error {
 	// for each field, get the vector index --> invoke the zap func.
 	// for each VR, populate postings list and iterators
 	// by passing the obtained vector index and getting similar vectors.
-	// defer close index - just once.
-	var errorsM sync.Mutex
-	var errors []error
-
 	defer o.invokeSearcherEndCallback()
 
-	wg := sync.WaitGroup{}
-	semaphore := make(chan struct{}, BleveMaxKNNConcurrency)
-	// Launch goroutines to get vector index for each segment
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(o.snapshot.segment))
+
 	for i, seg := range o.snapshot.segment {
-		if sv, ok := seg.segment.(segment_api.VectorSegment); ok {
-			wg.Add(1)
-			semaphore <- struct{}{} // Acquire a semaphore slot
-			go func(index int, segment segment_api.VectorSegment, origSeg *SegmentSnapshot) {
-				defer func() {
-					<-semaphore // Release the semaphore slot
-					wg.Done()
-				}()
-				for field, vrs := range o.vrs {
-					// Early exit if the field is supposed to be completely deleted or
-					// if it's index data has been deleted
-					if info, ok := o.snapshot.updatedFields[field]; ok && (info.Deleted || info.Index) {
-						continue
-					}
-
-					vecIndex, err := segment.InterpretVectorIndex(field, origSeg.deleted)
-					if err != nil {
-						errorsM.Lock()
-						errors = append(errors, err)
-						errorsM.Unlock()
-						return
-					}
-
-					// cache the vector index size for memory accounting
-					vectorIndexSize := vecIndex.Size()
-					origSeg.cachedMeta.storeMeta(field, vectorIndexSize)
-					for _, vr := range vrs {
-						var pl segment_api.VecPostingsList
-						var err error
-
-						// for each VR, populate postings list and iterators
-						// by passing the obtained vector index and getting similar vectors.
-
-						// check if the vector reader is configured to use a pre-filter
-						// to filter out ineligible documents before performing
-						// kNN search.
-						if vr.eligibleSelector != nil {
-							pl, err = vecIndex.SearchWithFilter(vr.vector, vr.k,
-								vr.eligibleSelector.SegmentEligibleDocuments(index), vr.searchParams)
-						} else {
-							pl, err = vecIndex.Search(vr.vector, vr.k, vr.searchParams)
-						}
-
-						if err != nil {
-							errorsM.Lock()
-							errors = append(errors, err)
-							errorsM.Unlock()
-							go vecIndex.Close()
-							return
-						}
-
-						atomic.AddUint64(&o.snapshot.parent.stats.TotKNNSearches, uint64(1))
-
-						// postings and iterators are already alloc'ed when
-						// IndexSnapshotVectorReader is created
-						vr.postings[index] = pl
-						vr.iterators[index] = pl.Iterator(vr.iterators[index])
-					}
-					go vecIndex.Close()
-				}
-			}(i, sv, seg)
+		if _, ok := seg.segment.(segment_api.VectorSegment); !ok {
+			continue
 		}
+		wg.Add(1)
+		go func(segIdx int) {
+			defer wg.Done()
+			if err := o.searchOnSegment(segIdx); err != nil {
+				errCh <- err
+			}
+		}(i)
 	}
 	wg.Wait()
-	close(semaphore)
-	if len(errors) > 0 {
-		return errors[0]
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -35,9 +35,6 @@ type OptimizeVR struct {
 	vrs map[string][]*IndexSnapshotVectorReader
 }
 
-// This setting _MUST_ only be changed during init and not after.
-var BleveMaxKNNConcurrency = 10
-
 func (o *OptimizeVR) invokeSearcherEndCallback() {
 	if o.ctx != nil {
 		if cb := o.ctx.Value(search.SearcherEndCallbackKey); cb != nil {
@@ -53,21 +50,21 @@ func (o *OptimizeVR) invokeSearcherEndCallback() {
 	}
 }
 
-// searchSegment runs the configured kNN searches for every vector
+// search runs the configured kNN searches for every vector
 // reader against a single segment, populating the per-segment postings and
 // iterators on each reader.
-func (o *OptimizeVR) searchSegment(segIdx int) error {
-	seg := o.snapshot.segment[segIdx]
-	vecSeg, ok := seg.segment.(segment_api.VectorSegment)
+func (o *OptimizeVR) search(segID int) error {
+	snapshot := o.snapshot.segment[segID]
+	vecSeg, ok := snapshot.segment.(segment_api.VectorSegment)
 	if !ok {
 		return nil
 	}
-	meta := seg.cachedMeta
+	meta := snapshot.cachedMeta
 	for field, vrs := range o.vrs {
 		if info, ok := o.snapshot.updatedFields[field]; ok && (info.Deleted || info.Index) {
 			continue
 		}
-		vecIndex, err := vecSeg.InterpretVectorIndex(field, seg.deleted)
+		vecIndex, err := vecSeg.InterpretVectorIndex(field, snapshot.deleted)
 		if err != nil {
 			return err
 		}
@@ -81,7 +78,7 @@ func (o *OptimizeVR) searchSegment(segIdx int) error {
 				pl, searchErr = vecIndex.SearchWithFilter(
 					vr.vector,
 					vr.k,
-					vr.eligibleSelector.SegmentEligibleDocuments(segIdx),
+					vr.eligibleSelector.SegmentEligibleDocuments(segID),
 					vr.searchParams,
 				)
 			} else {
@@ -95,8 +92,8 @@ func (o *OptimizeVR) searchSegment(segIdx int) error {
 				vecIndex.Close()
 				return searchErr
 			}
-			vr.postings[segIdx] = pl
-			vr.iterators[segIdx] = pl.Iterator(vr.iterators[segIdx])
+			vr.postings[segID] = pl
+			vr.iterators[segID] = pl.Iterator(vr.iterators[segID])
 		}
 		go vecIndex.Close()
 	}
@@ -109,21 +106,22 @@ func (o *OptimizeVR) Finish() error {
 	// by passing the obtained vector index and getting similar vectors.
 	defer o.invokeSearcherEndCallback()
 
-	var wg sync.WaitGroup
-	errCh := make(chan error, len(o.snapshot.segment))
+	numSegments := len(o.snapshot.segment)
 
-	for i, seg := range o.snapshot.segment {
-		if _, ok := seg.segment.(segment_api.VectorSegment); !ok {
-			continue
-		}
-		wg.Add(1)
-		go func(segIdx int) {
+	var wg sync.WaitGroup
+	wg.Add(numSegments)
+
+	errCh := make(chan error, numSegments)
+
+	for i := range o.snapshot.segment {
+		go func(segID int) {
 			defer wg.Done()
-			if err := o.searchSegment(segIdx); err != nil {
+			if err := o.search(segID); err != nil {
 				errCh <- err
 			}
 		}(i)
 	}
+
 	wg.Wait()
 	close(errCh)
 
@@ -132,6 +130,7 @@ func (o *OptimizeVR) Finish() error {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -92,7 +92,7 @@ func (o *OptimizeVR) searchSegment(segIdx int) error {
 				)
 			}
 			if searchErr != nil {
-				go vecIndex.Close()
+				vecIndex.Close()
 				return searchErr
 			}
 			vr.postings[segIdx] = pl

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -122,24 +122,24 @@ func (o *OptimizeVR) Finish() error {
 
 	var wg sync.WaitGroup
 	wg.Add(numSegments)
-	errCh := make(chan error, numSegments)
+	var errM sync.Mutex
+	var searchErr error
 	// launch goroutines to search the vector index for each segment
 	for i := 0; i < numSegments; i++ {
 		go func(segID int) {
 			defer wg.Done()
 			if err := o.search(segID); err != nil {
-				errCh <- err
+				errM.Lock()
+				searchErr = err
+				errM.Unlock()
 			}
 		}(i)
 	}
 	// wait until all the launched goroutines finish and collect errors if any
 	wg.Wait()
-	close(errCh)
-	// report the first error, if any
-	for err := range errCh {
-		if err != nil {
-			return err
-		}
+	// report the error, if any
+	if searchErr != nil {
+		return searchErr
 	}
 
 	return nil

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -137,12 +137,7 @@ func (o *OptimizeVR) Finish() error {
 	}
 	// wait until all the launched goroutines finish and collect errors if any
 	wg.Wait()
-	// report the error, if any
-	if searchErr != nil {
-		return searchErr
-	}
-
-	return nil
+	return searchErr
 }
 
 func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -53,10 +53,10 @@ func (o *OptimizeVR) invokeSearcherEndCallback() {
 	}
 }
 
-// executeSearchOnSegment runs the configured kNN searches for every vector
+// searchSegment runs the configured kNN searches for every vector
 // reader against a single segment, populating the per-segment postings and
 // iterators on each reader.
-func (o *OptimizeVR) searchOnSegment(segIdx int) error {
+func (o *OptimizeVR) searchSegment(segIdx int) error {
 	seg := o.snapshot.segment[segIdx]
 	vecSeg, ok := seg.segment.(segment_api.VectorSegment)
 	if !ok {
@@ -119,7 +119,7 @@ func (o *OptimizeVR) Finish() error {
 		wg.Add(1)
 		go func(segIdx int) {
 			defer wg.Done()
-			if err := o.searchOnSegment(segIdx); err != nil {
+			if err := o.searchSegment(segIdx); err != nil {
 				errCh <- err
 			}
 		}(i)

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -62,6 +62,7 @@ func (o *OptimizeVR) searchOnSegment(segIdx int) error {
 	if !ok {
 		return nil
 	}
+	meta := seg.cachedMeta
 	for field, vrs := range o.vrs {
 		if info, ok := o.snapshot.updatedFields[field]; ok && (info.Deleted || info.Index) {
 			continue
@@ -70,7 +71,9 @@ func (o *OptimizeVR) searchOnSegment(segIdx int) error {
 		if err != nil {
 			return err
 		}
-		seg.cachedMeta.storeMeta(field, vecIndex.Size())
+		if !meta.contains(field) {
+			meta.store(field, vecIndex.Size())
+		}
 		for _, vr := range vrs {
 			var pl segment_api.VecPostingsList
 			var searchErr error
@@ -166,7 +169,7 @@ func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,
 	// Finish() logic to even occur or not.
 	var sumVectorIndexSize uint64
 	for _, seg := range o.snapshot.segment {
-		vecIndexSize := seg.cachedMeta.fetchMeta(s.field)
+		vecIndexSize := seg.cachedMeta.load(s.field)
 		if vecIndexSize != nil {
 			sumVectorIndexSize += vecIndexSize.(uint64)
 		}

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -91,9 +91,9 @@ func (o *OptimizeVR) Finish() error {
 						return
 					}
 
-					// update the vector index size as a meta value in the segment snapshot
+					// cache the vector index size for memory accounting
 					vectorIndexSize := vecIndex.Size()
-					origSeg.cachedMeta.updateMeta(field, vectorIndexSize)
+					origSeg.cachedMeta.storeMeta(field, vectorIndexSize)
 					for _, vr := range vrs {
 						var pl segment_api.VecPostingsList
 						var err error

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -92,13 +92,13 @@ func (o *OptimizeVR) searchSegment(segIdx int) error {
 				)
 			}
 			if searchErr != nil {
-				vecIndex.Close()
+				go vecIndex.Close()
 				return searchErr
 			}
 			vr.postings[segIdx] = pl
 			vr.iterators[segIdx] = pl.Iterator(vr.iterators[segIdx])
 		}
-		vecIndex.Close()
+		go vecIndex.Close()
 	}
 	return nil
 }

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -169,8 +169,7 @@ func (s *IndexSnapshotVectorReader) VectorOptimize(ctx context.Context,
 	// Finish() logic to even occur or not.
 	var sumVectorIndexSize uint64
 	for _, seg := range o.snapshot.segment {
-		vecIndexSize := seg.cachedMeta.load(s.field)
-		if vecIndexSize != nil {
+		if vecIndexSize, ok := seg.cachedMeta.load(s.field); ok {
 			sumVectorIndexSize += vecIndexSize.(uint64)
 		}
 	}

--- a/index/scorch/optimize_knn.go
+++ b/index/scorch/optimize_knn.go
@@ -60,7 +60,12 @@ func (o *OptimizeVR) search(segID int) error {
 		return nil
 	}
 	meta := snapshot.cachedMeta
+	// for each field, get the vector index --> invoke the zap func.
+	// for each VR, populate postings list and iterators
+	// by passing the obtained vector index and getting similar vectors.
 	for field, vrs := range o.vrs {
+		// Early exit if the field is supposed to be completely deleted or
+		// if it's index data has been deleted
 		if info, ok := o.snapshot.updatedFields[field]; ok && (info.Deleted || info.Index) {
 			continue
 		}
@@ -68,30 +73,41 @@ func (o *OptimizeVR) search(segID int) error {
 		if err != nil {
 			return err
 		}
+		// update the vector index size as a meta value in the segment snapshot
+		// if not already present
 		if !meta.contains(field) {
 			meta.store(field, vecIndex.Size())
 		}
 		for _, vr := range vrs {
 			var pl segment_api.VecPostingsList
-			var searchErr error
+			var err error
+			// for each VR, populate postings list and iterators
+			// by passing the obtained vector index and getting similar vectors.
+
+			// check if the vector reader is configured to use a pre-filter
+			// to filter out ineligible documents before performing
+			// kNN search.
 			if vr.eligibleSelector != nil {
-				pl, searchErr = vecIndex.SearchWithFilter(
+				pl, err = vecIndex.SearchWithFilter(
 					vr.vector,
 					vr.k,
 					vr.eligibleSelector.SegmentEligibleDocuments(segID),
 					vr.searchParams,
 				)
 			} else {
-				pl, searchErr = vecIndex.Search(
+				pl, err = vecIndex.Search(
 					vr.vector,
 					vr.k,
 					vr.searchParams,
 				)
 			}
-			if searchErr != nil {
+			if err != nil {
 				vecIndex.Close()
-				return searchErr
+				return err
 			}
+			// postings and iterators are already alloc'ed when
+			// IndexSnapshotVectorReader is created, here we are just
+			// populating them with the obtained postings list.
 			vr.postings[segID] = pl
 			vr.iterators[segID] = pl.Iterator(vr.iterators[segID])
 		}
@@ -101,19 +117,14 @@ func (o *OptimizeVR) search(segID int) error {
 }
 
 func (o *OptimizeVR) Finish() error {
-	// for each field, get the vector index --> invoke the zap func.
-	// for each VR, populate postings list and iterators
-	// by passing the obtained vector index and getting similar vectors.
 	defer o.invokeSearcherEndCallback()
-
 	numSegments := len(o.snapshot.segment)
 
 	var wg sync.WaitGroup
 	wg.Add(numSegments)
-
 	errCh := make(chan error, numSegments)
-
-	for i := range o.snapshot.segment {
+	// launch goroutines to search the vector index for each segment
+	for i := 0; i < numSegments; i++ {
 		go func(segID int) {
 			defer wg.Done()
 			if err := o.search(segID); err != nil {
@@ -121,10 +132,10 @@ func (o *OptimizeVR) Finish() error {
 			}
 		}(i)
 	}
-
+	// wait until all the launched goroutines finish and collect errors if any
 	wg.Wait()
 	close(errCh)
-
+	// report the first error, if any
 	for err := range errCh {
 		if err != nil {
 			return err

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -1112,7 +1112,7 @@ func (s *Scorch) loadSegment(segmentBucket *util.BoltBucketImpl, reader util.Fil
 	rv := &SegmentSnapshot{
 		segment:    seg,
 		cachedDocs: &cachedDocs{cache: nil},
-		cachedMeta: &cachedMeta{meta: nil},
+		cachedMeta: newCachedMeta(),
 	}
 	deletedBytes, err := segmentBucket.Get(util.BoltDeletedKey, reader)
 	if err != nil {

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -3571,7 +3571,7 @@ func makeSegmentSnapshot(id uint64, seg segment.Segment) *SegmentSnapshot {
 		id:         id,
 		segment:    seg,
 		cachedDocs: &cachedDocs{cache: nil},
-		cachedMeta: &cachedMeta{meta: nil},
+		cachedMeta: newCachedMeta(),
 	}
 }
 

--- a/index/scorch/snapshot_index_vr.go
+++ b/index/scorch/snapshot_index_vr.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync/atomic"
 
 	"github.com/blevesearch/bleve/v2/size"
 	index "github.com/blevesearch/bleve_index_api"
@@ -164,7 +165,7 @@ func (i *IndexSnapshotVectorReader) Count() uint64 {
 }
 
 func (i *IndexSnapshotVectorReader) Close() error {
-	// TODO Consider if any scope of recycling here.
+	atomic.AddUint64(&i.snapshot.parent.stats.TotKNNSearches, 1)
 	return nil
 }
 

--- a/index/scorch/snapshot_index_vr.go
+++ b/index/scorch/snapshot_index_vr.go
@@ -165,7 +165,9 @@ func (i *IndexSnapshotVectorReader) Count() uint64 {
 }
 
 func (i *IndexSnapshotVectorReader) Close() error {
-	atomic.AddUint64(&i.snapshot.parent.stats.TotKNNSearches, 1)
+	if i.snapshot != nil {
+		atomic.AddUint64(&i.snapshot.parent.stats.TotKNNSearches, 1)
+	}
 	return nil
 }
 

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -350,34 +350,29 @@ func (c *cachedDocs) visitDoc(localDocNum uint64,
 	c.m.RUnlock()
 }
 
-// the purpose of the cachedMeta is to simply allow the user of this type to record
-// and cache certain meta data information (specific to the segment) that can be
-// used across calls to save compute on the same.
-// for example searcher creations on the same index snapshot can use this struct
-// to help and fetch the backing index size information which can be used in
-// memory usage calculation thereby deciding whether to allow a query or not.
+// cachedMeta is a simple wrapper around sync.Map to provide typed
+// access to cached metadata values for segments.
 type cachedMeta struct {
-	m    sync.RWMutex
-	meta map[string]interface{}
+	meta sync.Map
 }
 
-func (c *cachedMeta) updateMeta(field string, val interface{}) {
-	c.m.Lock()
-	if c.meta == nil {
-		c.meta = make(map[string]interface{})
+func newCachedMeta() *cachedMeta {
+	return &cachedMeta{
+		meta: sync.Map{},
 	}
-	c.meta[field] = val
-	c.m.Unlock()
 }
 
+// store the value for a field if the field is not already present in the cache.
+func (c *cachedMeta) storeMeta(field string, val interface{}) {
+	c.meta.LoadOrStore(field, val)
+}
+
+// fetch the value for a field from the cache, returns nil if the field is not present in the cache.
 func (c *cachedMeta) fetchMeta(field string) (rv interface{}) {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	if c.meta == nil {
-		return nil
+	if val, ok := c.meta.Load(field); ok {
+		return val
 	}
-	rv = c.meta[field]
-	return rv
+	return nil
 }
 
 func (s *SegmentSnapshot) Ancestors(docNum uint64, prealloc []index.AncestorID) []index.AncestorID {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -367,7 +367,8 @@ func (c *cachedMeta) store(field string, val interface{}) {
 	c.meta.Store(field, val)
 }
 
-// fetch the value for a field from the cache, returns nil if the field is not present in the cache.
+// load the value for a field from the cache, returning the value
+// and a boolean indicating whether the value was present.
 func (c *cachedMeta) load(field string) (rv interface{}, ok bool) {
 	return c.meta.Load(field)
 }

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -362,17 +362,23 @@ func newCachedMeta() *cachedMeta {
 	}
 }
 
-// store the value for a field if the field is not already present in the cache.
-func (c *cachedMeta) storeMeta(field string, val interface{}) {
-	c.meta.LoadOrStore(field, val)
+// store the value for a field in the cache, overwriting any existing value.
+func (c *cachedMeta) store(field string, val interface{}) {
+	c.meta.Store(field, val)
 }
 
 // fetch the value for a field from the cache, returns nil if the field is not present in the cache.
-func (c *cachedMeta) fetchMeta(field string) (rv interface{}) {
+func (c *cachedMeta) load(field string) (rv interface{}) {
 	if val, ok := c.meta.Load(field); ok {
 		return val
 	}
 	return nil
+}
+
+// contains reports whether the cache has an entry for the given field.
+func (c *cachedMeta) contains(field string) bool {
+	_, ok := c.meta.Load(field)
+	return ok
 }
 
 func (s *SegmentSnapshot) Ancestors(docNum uint64, prealloc []index.AncestorID) []index.AncestorID {

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -368,11 +368,8 @@ func (c *cachedMeta) store(field string, val interface{}) {
 }
 
 // fetch the value for a field from the cache, returns nil if the field is not present in the cache.
-func (c *cachedMeta) load(field string) (rv interface{}) {
-	if val, ok := c.meta.Load(field); ok {
-		return val
-	}
-	return nil
+func (c *cachedMeta) load(field string) (rv interface{}, ok bool) {
+	return c.meta.Load(field)
 }
 
 // contains reports whether the cache has an entry for the given field.


### PR DESCRIPTION
- Currently we always compute the vector index size, irrespective of whether this size was cached in the snapshot's `cachedMeta` or not. We use the cached value when triggering the searcher start callback, but do not check if it exists in the `cachedMeta` before calling the `Size()` API.
- Due to recent changes, the output of the `Size()` API was fixed but at the cost of additional computation to get a precise estimate. This results in a perf regression due to the aforementioned point.
- Fix this issue by performing a `LoadOrStore` operation for the size instead, where we perform a read to check if the size was cached, and only compute it if not cached.
- Refactor `cachedMeta` to use a `sync.Map` instead of a map with a RW mutex as its more suited for the `write-once-read-many` style of usage which we use it for in this perspective.
- Fix the  `TotKNNSearches` to be equal to the number of KNN searchers created, which mirrors the FTS equivalent `TotTermSearchersFinished`, currently this stat is equal to `N` * `X` where `N` is the number of segments, refactor it to report just `X`.