### PR TITLE
MB-71968: Expand asterisk fields wildcard in script query

### DIFF
--- a/search/query/custom_filter.go
+++ b/search/query/custom_filter.go
@@ -76,13 +76,20 @@ func (q *CustomFilterQuery) Searcher(ctx context.Context, i index.IndexReader, m
 	var dvReader index.DocValueReader
 	var fieldTypes map[string]string
 	if len(q.Fields) > 0 {
-		var err2 error
-		dvReader, err2 = i.DocValueReader(q.Fields)
+		// Expand a "*" wildcard to the concrete field set; the doc-value
+		// reader matches field names literally and would otherwise load
+		// nothing, leaving d.Fields empty in the callback.
+		fields, err2 := expandFieldWildcard(q.Fields, i)
 		if err2 != nil {
 			_ = childSearcher.Close()
 			return nil, err2
 		}
-		fieldTypes = resolveFieldTypes(q.Fields, m)
+		dvReader, err2 = i.DocValueReader(fields)
+		if err2 != nil {
+			_ = childSearcher.Close()
+			return nil, err2
+		}
+		fieldTypes = resolveFieldTypes(fields, m)
 	}
 
 	return searcher.NewCustomFilterSearcher(ctx, childSearcher, q.filterFunc, dvReader, i, fieldTypes), nil

--- a/search/query/custom_payload.go
+++ b/search/query/custom_payload.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/util"
+	index "github.com/blevesearch/bleve_index_api"
 )
 
 func unmarshalCustomQueryPayload(data []byte, key string) (Query, []string, map[string]interface{}, error) {
@@ -93,4 +94,43 @@ func resolveFieldTypes(fields []string, m mapping.IndexMapping) map[string]strin
 		return nil
 	}
 	return types
+}
+
+// expandFieldWildcard replaces a "*" entry in the requested fields with the
+// concrete set of fields in the index, mirroring how the standard stored-field
+// loader treats "*" (see LoadAndHighlightFields). Custom-query callbacks read
+// field values via the doc-value reader, which matches field names literally
+// and has no wildcard handling of its own; without this expansion a request for
+// fields:["*"] resolves to a single field literally named "*", matches nothing,
+// and leaves d.Fields empty in the callback.
+//
+// The internal composite/identifier fields ("_all", "_id") are excluded so the
+// callback sees the same fields the stored-field "*" path would surface rather
+// than the tokenized _all blob or the document id (already available as the
+// hit's ID). When fields does not contain "*", it is returned unchanged.
+func expandFieldWildcard(fields []string, i index.IndexReader) ([]string, error) {
+	hasWildcard := false
+	for _, f := range fields {
+		if f == "*" {
+			hasWildcard = true
+			break
+		}
+	}
+	if !hasWildcard {
+		return fields, nil
+	}
+
+	allFields, err := i.Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	expanded := make([]string, 0, len(allFields))
+	for _, f := range allFields {
+		if f == "_all" || f == "_id" {
+			continue
+		}
+		expanded = append(expanded, f)
+	}
+	return expanded, nil
 }

--- a/search/query/custom_score.go
+++ b/search/query/custom_score.go
@@ -76,13 +76,20 @@ func (q *CustomScoreQuery) Searcher(ctx context.Context, i index.IndexReader, m 
 	var dvReader index.DocValueReader
 	var fieldTypes map[string]string
 	if len(q.Fields) > 0 {
-		var err2 error
-		dvReader, err2 = i.DocValueReader(q.Fields)
+		// Expand a "*" wildcard to the concrete field set; the doc-value
+		// reader matches field names literally and would otherwise load
+		// nothing, leaving d.Fields empty in the callback.
+		fields, err2 := expandFieldWildcard(q.Fields, i)
 		if err2 != nil {
 			_ = childSearcher.Close()
 			return nil, err2
 		}
-		fieldTypes = resolveFieldTypes(q.Fields, m)
+		dvReader, err2 = i.DocValueReader(fields)
+		if err2 != nil {
+			_ = childSearcher.Close()
+			return nil, err2
+		}
+		fieldTypes = resolveFieldTypes(fields, m)
 	}
 
 	return searcher.NewCustomScoreSearcher(ctx, childSearcher, q.scoreFunc, dvReader, i, fieldTypes, options.Explain), nil

--- a/search_test.go
+++ b/search_test.go
@@ -5197,6 +5197,88 @@ func TestCustomFilterQueryDateTimeDocValues(t *testing.T) {
 	}
 }
 
+// TestCustomFilterQueryWildcardFields verifies that fields:["*"] inside a
+// custom_filter query exposes all doc-value fields to the callback. The
+// doc-value reader matches field names literally, so before the wildcard was
+// expanded "*" matched nothing, d.Fields stayed empty, and every candidate was
+// filtered out (total_hits == 0).
+func TestCustomFilterQueryWildcardFields(t *testing.T) {
+	idx := newCustomQueryDocValueTestIndex(t)
+	defer func() {
+		if err := idx.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	fictionQuery := NewTermQuery("fiction")
+	fictionQuery.SetField("genre")
+
+	// The callback inspects multiple fields and keeps the hit only if all are
+	// present, so with "*" the reader must surface both the numeric "rating"
+	// and the keyword "genre" (and resolve their types correctly).
+	q := query.NewCustomFilterQueryWithFilter(fictionQuery, func(d *search.DocumentMatch) (bool, error) {
+		rating, hasRating := d.Fields["rating"].(float64)
+		genre, hasGenre := d.Fields["genre"].(string)
+		return hasRating && hasGenre && genre == "fiction" && rating > 0, nil
+	}, []string{"*"}, nil)
+
+	req := NewSearchRequest(q)
+	req.Size = 10
+
+	res, err := idx.SearchInContext(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both fiction docs carry rating + genre, so both must pass the filter.
+	if res.Total != 2 {
+		t.Fatalf("expected 2 hits with fields:[\"*\"], got %d (doc.Fields likely empty)", res.Total)
+	}
+}
+
+// TestCustomScoreQueryWildcardFields is the custom_score counterpart: fields:["*"]
+// must expose doc-value fields to the scorer just like an explicit field list.
+func TestCustomScoreQueryWildcardFields(t *testing.T) {
+	idx := newCustomQueryDocValueTestIndex(t)
+	defer func() {
+		if err := idx.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	fictionQuery := NewTermQuery("fiction")
+	fictionQuery.SetField("genre")
+
+	q := query.NewCustomScoreQueryWithScorer(fictionQuery, func(d *search.DocumentMatch) (float64, error) {
+		if rating, ok := d.Fields["rating"].(float64); ok && rating >= 9 {
+			return d.Score + 100, nil
+		}
+		return d.Score, nil
+	}, []string{"*"}, nil)
+
+	req := NewSearchRequest(q)
+	req.Size = 4
+
+	res, err := idx.SearchInContext(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(res.Hits))
+	}
+	// Doc "1" (rating 9) is boosted by +100; the top hit must be doc "1" AND
+	// carry that boost in its score. Without "*" expansion d.Fields["rating"]
+	// is absent, the boost never applies, and the score stays below 1 — so the
+	// magnitude check (not just ordering) is what proves the field was read.
+	if res.Hits[0].ID != "1" {
+		t.Fatalf("expected boosted hit 1 first, got %s", res.Hits[0].ID)
+	}
+	if res.Hits[0].Score < 100 {
+		t.Fatalf("expected top hit score >= 100 from boost, got %f (doc.Fields likely empty)", res.Hits[0].Score)
+	}
+}
+
 func TestGeoDistanceInSortAlias(t *testing.T) {
 	tmpIndexPath1 := createTmpIndexPath(t)
 	defer cleanupTmpIndexPath(t, tmpIndexPath1)


### PR DESCRIPTION
custom_filter and custom_score now expand a fields:["*"] request to the index's concrete fields (excluding the _all/_id composites) before loading doc-values for the per-hit callback, so the callback sees every stored field via doc.fields, instead of "*" being matched literally by the doc-value reader, which matched no field, left doc.fields empty, and caused every hit to be dropped (total_hits = 0).