### PR TITLE
MB-70770: Backport some fixes for hierarchy search

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -158,11 +158,7 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 		if root.segment[i].deleted == nil {
 			newss.deleted = delta
 		} else {
-			if delta.IsEmpty() {
-				newss.deleted = root.segment[i].deleted
-			} else {
-				newss.deleted = roaring.Or(root.segment[i].deleted, delta)
-			}
+			newss.deleted = roaring.Or(root.segment[i].deleted, delta)
 		}
 		if newss.deleted.IsEmpty() {
 			newss.deleted = nil

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -50,6 +50,9 @@ type SegmentSnapshot struct {
 	cachedMeta *cachedMeta
 
 	cachedDocs *cachedDocs
+
+	rootCountOnce sync.Once
+	rootCount     uint64
 }
 
 func (s *SegmentSnapshot) Segment() segment.Segment {
@@ -121,13 +124,14 @@ func (s *SegmentSnapshot) Count() uint64 {
 // Count() counts all live documents including nested children, whereas this method
 // counts only root live documents
 func (s *SegmentSnapshot) CountRoot() uint64 {
-	var rv uint64
-	if nsb, ok := s.segment.(segment.NestedSegment); ok {
-		rv = nsb.CountRoot(s.deleted)
-	} else {
-		rv = s.Count()
-	}
-	return rv
+	s.rootCountOnce.Do(func() {
+		if nsb, ok := s.segment.(segment.NestedSegment); ok {
+			s.rootCount = nsb.CountRoot(s.deleted)
+		} else {
+			s.rootCount = s.Count()
+		}
+	})
+	return s.rootCount
 }
 
 func (s *SegmentSnapshot) DocNumbers(docIDs []string) (*roaring.Bitmap, error) {


### PR DESCRIPTION
- Backport the fix for shared deleted bitmap across snapshots.
- Backport the fix for caching the document count value in the snapshot.