### PR TITLE
Fix #2274: update NewMemOnly to use DefaultIndexType; added regression test for change

### DIFF
--- a/index.go
+++ b/index.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/blevesearch/bleve/v2/index/upsidedown"
+	// "github.com/blevesearch/bleve/v2/index/upsidedown"
 
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -298,7 +298,7 @@ func New(path string, mapping mapping.IndexMapping) (Index, error) {
 // The provided mapping will be used for all
 // Index/Search operations.
 func NewMemOnly(mapping mapping.IndexMapping) (Index, error) {
-	return newIndexUsing("", mapping, upsidedown.Name, Config.DefaultMemKVStore, nil)
+	return newIndexUsing("", mapping, Config.DefaultIndexType, Config.DefaultMemKVStore, nil)
 }
 
 // NewUsing creates index at the specified path,

--- a/synonym_mem_test.go
+++ b/synonym_mem_test.go
@@ -1,0 +1,64 @@
+package bleve
+
+import (
+	"testing"
+)
+
+func TestSynonymInMem(t *testing.T) {
+	doc := struct {
+		Text string `json:"text"`
+	}{
+		Text: "hardworking employee",
+	}
+
+	synDef := &SynonymDefinition{
+		Synonyms: []string{"hardworking", "industrious", "conscientious", "persistent"},
+	}
+
+	bleveMapping := NewIndexMapping()
+	err := bleveMapping.AddSynonymSource("english", map[string]interface{}{
+		"collection": "collection1",
+		"analyzer":   "en",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	textFieldMapping := NewTextFieldMapping()
+	textFieldMapping.Analyzer = "en"
+	textFieldMapping.SynonymSource = "english"
+	bleveMapping.DefaultMapping.AddFieldMappingsAt("text", textFieldMapping)
+
+	// HERE IS THE FAILURE: Using NewMemOnly instead of New()
+	index, err := NewMemOnly(bleveMapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer index.Close()
+
+	err = index.Index("doc1", doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if synIndex, ok := index.(SynonymIndex); ok {
+		err = synIndex.IndexSynonym("synDoc1", "collection1", synDef)
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("expected synonym index support")
+	}
+
+	query := NewMatchQuery("persistent")
+	query.SetField("text")
+	searchRequest := NewSearchRequest(query)
+	searchResult, err := index.Search(searchRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if searchResult.Total != 1 {
+		t.Errorf("Expected 1 match, got %d", searchResult.Total)
+	}
+}


### PR DESCRIPTION
Fixes 2274

## Description:
`bleve.NewMemOnly()` was using the older `upside_down` index format, which does not support features like Synonym Search. I updated it to use `Config.DefaultIndexType` instead so it defaults to `scorch` and supports in-memory usage.

## Testing Performed:
As requested in the issue thread, I wanted to make sure switching `NewMemOnly` to use `scorch` wouldn't break anything. 
1. Ran `go test ./...` across the entire workspace. All tests passed successfully.
2. Verified that the `TestSynonymInMem` test cases now successfully pass with the new in-memory `scorch` index behavior.