### PR TITLE
search: add support for custom string sort ordering

### DIFF
--- a/search/sort.go
+++ b/search/sort.go
@@ -50,6 +50,10 @@ type SearchSort interface {
 	Copy() SearchSort
 }
 
+type SearchSortStringComparator interface {
+	CompareString(i, j string) int
+}
+
 func ParseSearchSortObj(input map[string]interface{}) (SearchSort, error) {
 	descending, ok := input["desc"].(bool)
 	if !ok {
@@ -250,10 +254,14 @@ func (so SortOrder) Compare(cachedScoring, cachedDesc []bool, i, j *DocumentMatc
 		} else {
 			iVal := i.Sort[x]
 			jVal := j.Sort[x]
-			if iVal < jVal {
-				c = -1
-			} else if iVal > jVal {
-				c = 1
+			if cmp, ok := so[x].(SearchSortStringComparator); ok {
+				c = cmp.CompareString(iVal, jVal)
+			} else {
+				if iVal < jVal {
+					c = -1
+				} else if iVal > jVal {
+					c = 1
+				}
 			}
 		}
 
@@ -368,13 +376,14 @@ const (
 //	Mode controls behavior for multi-values fields (default first)
 //	Missing controls behavior of missing values (default last)
 type SortField struct {
-	Field   string
-	Desc    bool
-	Type    SortFieldType
-	Mode    SortFieldMode
-	Missing SortFieldMissing
-	values  [][]byte
-	tmp     [][]byte
+	Field               string
+	Desc                bool
+	Type                SortFieldType
+	Mode                SortFieldMode
+	Missing             SortFieldMissing
+	CustomCompareString func(string, string) int `json:"-"`
+	values              [][]byte
+	tmp                 [][]byte
 }
 
 // UpdateVisitor notifies this sort field that in this document
@@ -417,6 +426,18 @@ func (s *SortField) DecodeValue(value string) string {
 // Descending determines the order of the sort
 func (s *SortField) Descending() bool {
 	return s.Desc
+}
+
+func (s *SortField) CompareString(i, j string) int {
+	if s.CustomCompareString != nil {
+		return s.CustomCompareString(i, j)
+	}
+	if i < j {
+		return -1
+	} else if i > j {
+		return 1
+	}
+	return 0
 }
 
 func (s *SortField) filterTermsByMode(terms [][]byte) string {

--- a/search/sort_test.go
+++ b/search/sort_test.go
@@ -336,3 +336,47 @@ func TestParseSearchSortObj(t *testing.T) {
 		})
 	}
 }
+
+func TestSortOrderCustomCompare(t *testing.T) {
+	// standard sort should evaluate "b" > "a", returning 1 for "b" vs "a"
+	// but with custom comparator, we can reverse it or change it
+
+	so := SortOrder{
+		&SortField{
+			Field: "title",
+			CustomCompareString: func(i, j string) int {
+				// reverse alphabetical
+				if i < j {
+					return 1
+				} else if i > j {
+					return -1
+				}
+				return 0
+			},
+		},
+	}
+
+	docA := &DocumentMatch{
+		Sort: []string{"a"},
+	}
+	docB := &DocumentMatch{
+		Sort: []string{"b"},
+	}
+
+	// Without custom comparator, docA < docB -> -1
+	// With custom comparator (reverse), docA "a" vs docB "b" -> returns 1
+	cmp := so.Compare([]bool{false}, []bool{false}, docA, docB)
+	if cmp != 1 {
+		t.Errorf("Expected custom compare to return 1, got %d", cmp)
+	}
+
+	cmpRev := so.Compare([]bool{false}, []bool{false}, docB, docA)
+	if cmpRev != -1 {
+		t.Errorf("Expected custom compare to return -1, got %d", cmpRev)
+	}
+
+	cmpEq := so.Compare([]bool{false}, []bool{false}, docA, docA)
+	if cmpEq != 0 {
+		t.Errorf("Expected custom compare to return 0, got %d", cmpEq)
+	}
+}


### PR DESCRIPTION
Fixes #2223

The custom sort func within `SearchRequest` only sorts the value after the collector picks up during phase 1, ie. Custom sort function only runs in phase 2 after the data has been sorted normally.


1. Added an Interface that `SearchSort` can implement
2. Added a custom function field to `search.SortField`
3. Implement the custom function interface on `SortField` which is json excluded for serialization
4. Update `sortOrder.Compare` to conditionally use the custom function if implemented
5. Added a new unit test `TestSortOrderCustomCompare` to existing `search/sort_test.go` file to verify the custom sort functionality

