### PR TITLE
MB-70770: [BP] Do not exclude segments from persistence

### DIFF
--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -303,7 +303,7 @@ func (o *Builder) Close() error {
 	}
 
 	// fill the root bolt with this fake index snapshot
-	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil, nil)
+	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil)
 	if err != nil {
 		_ = tx.Rollback()
 		_ = rootBolt.Close()

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -30,7 +30,6 @@ type segmentIntroduction struct {
 	obsoletes map[uint64]*roaring.Bitmap
 	ids       []string
 	internal  map[string][]byte
-	stats     *fieldStats
 
 	applied           chan error
 	persisted         chan error
@@ -193,10 +192,14 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 
 	// append new segment, if any, to end of the new index snapshot
 	if next.data != nil {
+		stats := newFieldStats()
+		if fsr, ok := next.data.(segment.FieldStatsReporter); ok {
+			fsr.UpdateFieldStats(stats)
+		}
 		newSegmentSnapshot := &SegmentSnapshot{
 			id:         next.id,
 			segment:    next.data, // take ownership of next.data's ref-count
-			stats:      next.stats,
+			stats:      stats,
 			cachedDocs: &cachedDocs{cache: nil},
 			cachedMeta: &cachedMeta{meta: nil},
 			creator:    "introduceSegment",

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -432,7 +432,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 		}
 	}
 
-	skipped := true
+	skipped := make([]bool, len(nextMerge.new))
 	// make the newly merged segments part of the newSnapshot being constructed
 	for i, newMergedSegment := range nextMerge.new {
 		// checking if this newly merged segment is worth keeping based on
@@ -465,14 +465,12 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				docsToPersistCount += newMergedSegment.Count() - newSegmentDeleted[i].GetCardinality()
 				memSegments++
 			}
-			skipped = false
+			atomic.AddUint64(&s.stats.TotIntroducedSegmentsMerge, 1)
+			skipped[i] = false
+		} else {
+			atomic.AddUint64(&s.stats.TotFileMergeIntroductionsObsoleted, 1)
+			skipped[i] = true
 		}
-	}
-
-	if skipped {
-		atomic.AddUint64(&s.stats.TotFileMergeIntroductionsObsoleted, 1)
-	} else {
-		atomic.AddUint64(&s.stats.TotIntroducedSegmentsMerge, uint64(len(nextMerge.new)))
 	}
 
 	atomic.StoreUint64(&s.stats.TotItemsToPersist, docsToPersistCount)

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -151,7 +151,6 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			cachedDocs: root.segment[i].cachedDocs,
 			cachedMeta: root.segment[i].cachedMeta,
 			creator:    root.segment[i].creator,
-			internal:   root.segment[i].internal,
 		}
 
 		// apply new obsoletions
@@ -200,7 +199,6 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			stats:      next.stats,
 			cachedDocs: &cachedDocs{cache: nil},
 			cachedMeta: &cachedMeta{meta: nil},
-			internal:   make(map[string][]byte),
 			creator:    "introduceSegment",
 		}
 		newSnapshot.segment = append(newSnapshot.segment, newSegmentSnapshot)
@@ -210,12 +208,6 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 		// queued for persistence.
 		atomic.AddUint64(&s.stats.TotIntroducedItems, newSegmentSnapshot.Count())
 		atomic.AddUint64(&s.stats.TotIntroducedSegmentsBatch, 1)
-
-		// track the internal values of this segment so that when we update the
-		// bolt we keep the internal values in sync with the segments on disk, and
-		// if this segment didn't get persisted we need to undo that info from the
-		// indexSnapshot's internal map as part of the bolt update.
-		newSegmentSnapshot.internal = next.internal
 	}
 	// copy old values
 	for key, oldVal := range root.internal {
@@ -404,7 +396,6 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				cachedDocs: root.segment[i].cachedDocs,
 				cachedMeta: root.segment[i].cachedMeta,
 				creator:    root.segment[i].creator,
-				internal:   root.segment[i].internal,
 			})
 			root.segment[i].segment.AddRef()
 			newSnapshot.offsets = append(newSnapshot.offsets, running)

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -377,7 +377,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				for deletedSinceItr.HasNext() {
 					oldDocNum := deletedSinceItr.Next()
 					newDocNum := segSnapAtMerge.oldNewDocIDs[oldDocNum]
-					newSegmentDeleted[segSnapAtMerge.workerID].Add(uint32(newDocNum))
+					newSegmentDeleted[segSnapAtMerge.flushID].Add(uint32(newDocNum))
 				}
 			}
 
@@ -424,7 +424,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 			for obsoletedIter.HasNext() {
 				oldDocNum := obsoletedIter.Next()
 				newDocNum := ss.oldNewDocIDs[oldDocNum]
-				newSegmentDeleted[ss.workerID].Add(uint32(newDocNum))
+				newSegmentDeleted[ss.flushID].Add(uint32(newDocNum))
 			}
 		}
 	}

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -317,7 +317,6 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 
 		atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegments, uint64(len(task.Segments)))
 
-		oldMap := make(map[uint64]*SegmentSnapshot, len(task.Segments))
 		newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
 		segmentsToMerge := make([]segment.Segment, 0, len(task.Segments))
 		docsToDrop := make([]*roaring.Bitmap, 0, len(task.Segments))
@@ -325,17 +324,14 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 
 		for _, planSegment := range task.Segments {
 			if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
-				oldMap[segSnapshot.id] = segSnapshot
-				mergedSegHistory[segSnapshot.id] = &mergedSegmentHistory{
-					workerID:   0,
-					oldSegment: segSnapshot,
-				}
 				if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
 					if segSnapshot.LiveSize() == 0 {
 						atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
-						oldMap[segSnapshot.id] = nil
-						delete(mergedSegHistory, segSnapshot.id)
 					} else {
+						mergedSegHistory[segSnapshot.id] = &mergedSegmentHistory{
+							flushID:    0,
+							oldSegment: segSnapshot,
+						}
 						segmentsToMerge = append(segmentsToMerge, segSnapshot.segment)
 						docsToDrop = append(docsToDrop, segSnapshot.deleted)
 					}
@@ -402,7 +398,6 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 			id:               []uint64{newSegmentID},
 			mergedSegHistory: mergedSegHistory,
 			new:              []segment.Segment{seg},
-			newCount:         seg.Count(),
 			notifyCh:         make(chan *mergeTaskIntroStatus),
 			mmaped:           1,
 		}
@@ -461,7 +456,7 @@ type mergeTaskIntroStatus struct {
 // single introducer channel push. That way there is a check to ensure that the
 // file count doesn't explode during the index's lifetime.
 type mergedSegmentHistory struct {
-	workerID     uint64
+	flushID      uint64
 	oldNewDocIDs []uint64
 	oldSegment   *SegmentSnapshot
 }
@@ -472,7 +467,6 @@ type segmentMerge struct {
 	mergedSegHistory map[uint64]*mergedSegmentHistory
 	notifyCh         chan *mergeTaskIntroStatus
 	mmaped           uint32
-	newCount         uint64
 }
 
 func cumulateBytesRead(sbs []segment.Segment) uint64 {
@@ -496,31 +490,36 @@ func closeNewMergedSegments(segs []segment.Segment) error {
 // which are merged and persisted to disk concurrently. These are then introduced as
 // the new root snapshot in one-shot.
 func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
-	flushableObjs []*flushable) (*IndexSnapshot, []uint64, error) {
+	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
 	memMergeZapStartTime := time.Now()
 
 	atomic.AddUint64(&s.stats.TotMemMergeZapBeg, 1)
 
-	var wg sync.WaitGroup
-	// we're tracking the merged segments and their doc number per worker
+	// we're tracking the merged segments and their doc number per batch
 	// to be able to introduce them all at once, so the first dimension of the
-	// slices here correspond to workerID
-	newDocIDsSet := make([][][]uint64, len(flushableObjs))
-	newMergedSegments := make([]segment.Segment, len(flushableObjs))
-	newMergedSegmentIDs := make([]uint64, len(flushableObjs))
-	numFlushes := len(flushableObjs)
+	// slices here correspond to flushID
+	numFlushes := len(flushes)
+	newDocIDsSet := make([][][]uint64, numFlushes)
+	newMergedSegmentIDs := make([]uint64, numFlushes)
+	newMergedSegments := make([]segment.Segment, numFlushes)
 	var numSegments, newMergedCount uint64
 	var em sync.Mutex
 	var errs []error
 
-	// deploy the workers to merge and flush the batches of segments concurrently
-	// and create a new file segment
-	for i := 0; i < numFlushes; i++ {
+	// create a semaphore of the number of configured persister workers
+	// and a waitgroup to wait for all the flushes to complete
+	sem := make(chan struct{}, po.NumPersisterWorkers)
+	var wg sync.WaitGroup
+	for flushID := 0; flushID < numFlushes; flushID++ {
 		wg.Add(1)
-		go func(segsBatch []segment.Segment, dropsBatch []*roaring.Bitmap, id int) {
-			defer wg.Done()
+		sem <- struct{}{}
+		go func(segsBatch []segment.Segment, dropsBatch []*roaring.Bitmap, flushID int) {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
 			newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
 			filename := zapFileName(newSegmentID)
 			path := s.path + string(os.PathSeparator) + filename
@@ -541,9 +540,10 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 			// is updated - which is valid, since the snapshot updated in bolt is
 			// cleaned up only if its zero ref'd (MB-66163 for more details)
 			s.markIneligibleForRemoval(filename)
-			newMergedSegmentIDs[id] = newSegmentID
-			newDocIDsSet[id] = newDocIDs
-			newMergedSegments[id], err = s.segPlugin.Open(path)
+
+			newDocIDsSet[flushID] = newDocIDs
+			newMergedSegmentIDs[flushID] = newSegmentID
+			newMergedSegments[flushID], err = s.segPlugin.Open(path)
 			if err != nil {
 				em.Lock()
 				errs = append(errs, err)
@@ -551,12 +551,14 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			atomic.AddUint64(&newMergedCount, newMergedSegments[id].Count())
+			atomic.AddUint64(&newMergedCount, newMergedSegments[flushID].Count())
 			atomic.AddUint64(&numSegments, uint64(len(segsBatch)))
-		}(flushableObjs[i].segments, flushableObjs[i].drops, i)
+		}(flushes[flushID].segments, flushes[flushID].drops, flushID)
 	}
 	wg.Wait()
+	close(sem)
 
+	// if any of the flushes failed, close the newly merged segments and return the error
 	if errs != nil {
 		// close the new merged segments
 		_ = closeNewMergedSegments(newMergedSegments)
@@ -588,20 +590,18 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 		new:              newMergedSegments,
 		mergedSegHistory: make(map[uint64]*mergedSegmentHistory, numSegments),
 		notifyCh:         make(chan *mergeTaskIntroStatus),
-		newCount:         newMergedCount,
 	}
 
 	// create a history map which maps the old in-memory segments with the specific
-	// persister worker (also the specific file segment its going to be part of)
-	// which flushed it out. This map will be used on the introducer side to out-ref
+	// flush it was part of (also the specific file segment its going to be part of).
+	//  This map will be used on the introducer side to out-ref
 	// the in-memory segments and also track the new tombstones if present.
-	for i, flushable := range flushableObjs {
-		for j, idx := range flushable.sbIdxs {
+	for flushID, flush := range flushes {
+		for j, idx := range flush.sbIdxs {
 			ss := snapshot.segment[idx]
-			// oldSegmentSnapshot.id -> {workerID, oldSegmentSnapshot, docIDs}
 			sm.mergedSegHistory[ss.id] = &mergedSegmentHistory{
-				workerID:     uint64(i),
-				oldNewDocIDs: newDocIDsSet[i][j],
+				flushID:      uint64(flushID),
+				oldNewDocIDs: newDocIDsSet[flushID][j],
 				oldSegment:   ss,
 			}
 		}
@@ -629,7 +629,13 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 		}
 	}
 
-	return newSnapshot, newMergedSegmentIDs, nil
+	// create a map of the newly merged segment IDs for the caller to use for tracking
+	newMergedSegmentIDsMap := make(map[uint64]struct{}, len(newMergedSegmentIDs))
+	for _, id := range newMergedSegmentIDs {
+		newMergedSegmentIDsMap[id] = struct{}{}
+	}
+
+	return newSnapshot, newMergedSegmentIDsMap, nil
 }
 
 func (s *Scorch) ReportBytesWritten(bytesWritten uint64) {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -508,7 +508,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	for flushID := 0; flushID < numFlushes; flushID++ {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(segsBatch []segment.Segment, dropsBatch []*roaring.Bitmap, flushID int) {
+		go func(flushID int) {
 			defer func() {
 				<-sem
 				wg.Done()
@@ -519,8 +519,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 
 			// the newly merged segment is already flushed out to disk, just needs
 			// to be opened using mmap.
-			newDocIDs, _, err :=
-				s.segPlugin.Merge(segsBatch, dropsBatch, path, s.closeCh, s)
+			newDocIDs, _, err := s.segPlugin.Merge(flushes[flushID].sbsBatch, flushes[flushID].sbsBatchDrops, path, s.closeCh, s)
 			if err != nil {
 				em.Lock()
 				errs = append(errs, err)
@@ -546,8 +545,8 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				return
 			}
 			atomic.AddUint64(&newMergedCount, newMergedSegments[flushID].Count())
-			atomic.AddUint64(&numSegments, uint64(len(segsBatch)))
-		}(flushes[flushID].segments, flushes[flushID].drops, flushID)
+			atomic.AddUint64(&numSegments, uint64(len(flushes[flushID].sbsBatch)))
+		}(flushID)
 	}
 	wg.Wait()
 	close(sem)
@@ -596,7 +595,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	//  This map will be used on the introducer side to out-ref
 	// the in-memory segments and also track the new tombstones if present.
 	for flushID, flush := range flushes {
-		for j, idx := range flush.sbIdxs {
+		for j, idx := range flush.sbsBatchIndexes {
 			ss := snapshot.segment[idx]
 			sm.mergedSegHistory[ss.id] = &mergedSegmentHistory{
 				flushID:      uint64(flushID),

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -517,6 +517,12 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 			filename := zapFileName(newSegmentID)
 			path := s.path + string(os.PathSeparator) + filename
 
+			// to prevent accidental cleanup of this newly created file, mark it
+			// as ineligible for removal. this will be flipped back when the bolt
+			// is updated - which is valid, since the snapshot updated in bolt is
+			// cleaned up only if its zero ref'd (MB-66163 for more details)
+			s.markIneligibleForRemoval(filename)
+
 			// the newly merged segment is already flushed out to disk, just needs
 			// to be opened using mmap.
 			newDocIDs, _, err := s.segPlugin.Merge(flushes[flushID].sbsBatch, flushes[flushID].sbsBatchDrops, path, s.closeCh, s)
@@ -527,12 +533,6 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			// to prevent accidental cleanup of this newly created file, mark it
-			// as ineligible for removal. this will be flipped back when the bolt
-			// is updated - which is valid, since the snapshot updated in bolt is
-			// cleaned up only if its zero ref'd (MB-66163 for more details)
-			s.markIneligibleForRemoval(filename)
-
 			newDocIDsSet[flushID] = newDocIDs
 			newMergedSegmentIDs[flushID] = newSegmentID
 			newMergedSegmentFileNames[flushID] = filename
@@ -574,7 +574,6 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	}
 
 	atomic.AddUint64(&s.stats.TotMemMergeZapEnd, 1)
-
 	memMergeZapTime := uint64(time.Since(memMergeZapStartTime))
 	atomic.AddUint64(&s.stats.TotMemMergeZapTime, memMergeZapTime)
 	if atomic.LoadUint64(&s.stats.MaxMemMergeZapTime) < memMergeZapTime {
@@ -635,6 +634,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 			introducedSegmentIDs[segID] = struct{}{}
 		}
 	}
+
 	// if we could not introduce all of the newly merged segments,
 	// then we cannot cannot persist a snapshot with any merged segments at all
 	if len(introducedSegmentIDs) != len(newMergedSegmentIDs) {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -504,6 +504,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	numFlushes := len(flushes)
 	newDocIDsSet := make([][][]uint64, numFlushes)
 	newMergedSegmentIDs := make([]uint64, numFlushes)
+	newMergedSegmentFileNames := make([]string, numFlushes)
 	newMergedSegments := make([]segment.Segment, numFlushes)
 	var numSegments, newMergedCount uint64
 	var em sync.Mutex
@@ -544,6 +545,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 
 			newDocIDsSet[flushID] = newDocIDs
 			newMergedSegmentIDs[flushID] = newSegmentID
+			newMergedSegmentFileNames[flushID] = filename
 			newMergedSegments[flushID], err = s.segPlugin.Open(path)
 			if err != nil {
 				em.Lock()
@@ -626,6 +628,11 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 			// close the segment on skipping introduction.
 			_ = newSnapshot.DecRef()
 			_ = closeNewMergedSegments(newMergedSegments)
+			// since we skipped the introduction, we need to flip the
+			// ineligibility for removal for the newly merged segments
+			for _, filename := range newMergedSegmentFileNames {
+				s.unmarkIneligibleForRemoval(filename)
+			}
 			newSnapshot = nil
 		}
 	}

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -426,10 +426,10 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 		atomic.AddUint64(&s.stats.TotFileMergeIntroductionsDone, 1)
 		if introStatus != nil && introStatus.indexSnapshot != nil {
 			_ = introStatus.indexSnapshot.DecRef()
-			if introStatus.skipped {
+			if introStatus.skipped[0] {
 				// close the segment on skipping introduction.
-				s.unmarkIneligibleForRemoval(filename)
 				_ = seg.Close()
+				s.unmarkIneligibleForRemoval(filename)
 			}
 		}
 
@@ -450,7 +450,7 @@ func (s *Scorch) planMergeAtSnapshot(ctx context.Context,
 
 type mergeTaskIntroStatus struct {
 	indexSnapshot *IndexSnapshot
-	skipped       bool
+	skipped       []bool
 }
 
 // this is important when it comes to introducing multiple merged segments in a
@@ -481,7 +481,7 @@ func cumulateBytesRead(sbs []segment.Segment) uint64 {
 func closeNewMergedSegments(segs []segment.Segment) error {
 	for _, seg := range segs {
 		if seg != nil {
-			_ = seg.DecRef()
+			_ = seg.Close()
 		}
 	}
 	return nil
@@ -491,7 +491,7 @@ func closeNewMergedSegments(segs []segment.Segment) error {
 // which are merged and persisted to disk concurrently. These are then introduced as
 // the new root snapshot in one-shot.
 func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
-	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, []uint64, error) {
+	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
 	memMergeZapStartTime := time.Now()
@@ -565,6 +565,11 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	if errs != nil {
 		// close the new merged segments
 		_ = closeNewMergedSegments(newMergedSegments)
+		// mark the newly merged segments as eligible
+		// for removal since they are not going to be introduced
+		for _, filename := range newMergedSegmentFileNames {
+			s.unmarkIneligibleForRemoval(filename)
+		}
 		var errf error
 		for _, err := range errs {
 			if err == segment.ErrClosed {
@@ -613,31 +618,38 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 	select { // send to introducer
 	case <-s.closeCh:
 		_ = closeNewMergedSegments(newMergedSegments)
+		for _, filename := range newMergedSegmentFileNames {
+			s.unmarkIneligibleForRemoval(filename)
+		}
 		return nil, nil, segment.ErrClosed
 	case s.merges <- sm:
 	}
 
 	// blockingly wait for the introduction to complete
-	var newSnapshot *IndexSnapshot
 	introStatus := <-sm.notifyCh
-	if introStatus != nil && introStatus.indexSnapshot != nil {
-		newSnapshot = introStatus.indexSnapshot
-		atomic.AddUint64(&s.stats.TotMemMergeSegments, uint64(numSegments))
-		atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
-		if introStatus.skipped {
-			// close the segment on skipping introduction.
-			_ = newSnapshot.DecRef()
-			_ = closeNewMergedSegments(newMergedSegments)
-			// since we skipped the introduction, we need to flip the
-			// ineligibility for removal for the newly merged segments
-			for _, filename := range newMergedSegmentFileNames {
-				s.unmarkIneligibleForRemoval(filename)
-			}
-			newSnapshot = nil
+	introducedSnapshot := introStatus.indexSnapshot
+	introducedSegmentIDs := make(map[uint64]struct{}, len(newMergedSegmentIDs))
+	atomic.AddUint64(&s.stats.TotMemMergeSegments, uint64(numSegments))
+	atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
+	for flushID, skipped := range introStatus.skipped {
+		seg := newMergedSegments[flushID]
+		segID := newMergedSegmentIDs[flushID]
+		segFileName := newMergedSegmentFileNames[flushID]
+		if skipped {
+			_ = seg.Close()
+			s.unmarkIneligibleForRemoval(segFileName)
+		} else {
+			introducedSegmentIDs[segID] = struct{}{}
 		}
 	}
+	if len(introducedSegmentIDs) == 0 {
+		// if all the newly merged segments were skipped
+		// do not persist the new snapshot at all
+		_ = introducedSnapshot.DecRef()
+		return nil, nil, nil
+	}
 
-	return newSnapshot, newMergedSegmentIDs, nil
+	return introducedSnapshot, introducedSegmentIDs, nil
 }
 
 func (s *Scorch) ReportBytesWritten(bytesWritten uint64) {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -16,6 +16,7 @@ package scorch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -570,7 +571,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				// so its safe to early exit the same error.
 				return nil, nil, err
 			}
-			errf = fmt.Errorf("%w; %v", errf, err)
+			errf = errors.Join(errf, err)
 		}
 		return nil, nil, errf
 	}

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -491,7 +491,7 @@ func closeNewMergedSegments(segs []segment.Segment) error {
 // which are merged and persisted to disk concurrently. These are then introduced as
 // the new root snapshot in one-shot.
 func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
-	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
+	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, []uint64, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
 	memMergeZapStartTime := time.Now()
@@ -637,13 +637,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 		}
 	}
 
-	// create a map of the newly merged segment IDs for the caller to use for tracking
-	newMergedSegmentIDsMap := make(map[uint64]struct{}, len(newMergedSegmentIDs))
-	for _, id := range newMergedSegmentIDs {
-		newMergedSegmentIDsMap[id] = struct{}{}
-	}
-
-	return newSnapshot, newMergedSegmentIDsMap, nil
+	return newSnapshot, newMergedSegmentIDs, nil
 }
 
 func (s *Scorch) ReportBytesWritten(bytesWritten uint64) {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -478,15 +478,6 @@ func cumulateBytesRead(sbs []segment.Segment) uint64 {
 	return rv
 }
 
-func closeNewMergedSegments(segs []segment.Segment) error {
-	for _, seg := range segs {
-		if seg != nil {
-			_ = seg.Close()
-		}
-	}
-	return nil
-}
-
 // mergeAndPersistInMemorySegments takes an IndexSnapshot and a list of in-memory segments,
 // which are merged and persisted to disk concurrently. These are then introduced as
 // the new root snapshot in one-shot.
@@ -563,12 +554,12 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 
 	// if any of the flushes failed, close the newly merged segments and return the error
 	if errs != nil {
-		// close the new merged segments
-		_ = closeNewMergedSegments(newMergedSegments)
-		// mark the newly merged segments as eligible
-		// for removal since they are not going to be introduced
-		for _, filename := range newMergedSegmentFileNames {
-			s.unmarkIneligibleForRemoval(filename)
+		// close all merged segments and flip their ineligible for removal flag
+		for flushID := 0; flushID < numFlushes; flushID++ {
+			if newMergedSegments[flushID] != nil {
+				_ = newMergedSegments[flushID].Close()
+			}
+			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
 		}
 		var errf error
 		for _, err := range errs {
@@ -617,9 +608,12 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 
 	select { // send to introducer
 	case <-s.closeCh:
-		_ = closeNewMergedSegments(newMergedSegments)
-		for _, filename := range newMergedSegmentFileNames {
-			s.unmarkIneligibleForRemoval(filename)
+		// close all merged segments and flip their ineligible for removal flag
+		for flushID := 0; flushID < numFlushes; flushID++ {
+			if newMergedSegments[flushID] != nil {
+				_ = newMergedSegments[flushID].Close()
+			}
+			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
 		}
 		return nil, nil, segment.ErrClosed
 	case s.merges <- sm:

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -642,9 +642,9 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 			introducedSegmentIDs[segID] = struct{}{}
 		}
 	}
-	if len(introducedSegmentIDs) == 0 {
-		// if all the newly merged segments were skipped
-		// do not persist the new snapshot at all
+	// if we could not introduce all of the newly merged segments,
+	// then we cannot cannot persist a snapshot with any merged segments at all
+	if len(introducedSegmentIDs) != len(newMergedSegmentIDs) {
 		_ = introducedSnapshot.DecRef()
 		return nil, nil, nil
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -38,29 +38,45 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// DefaultPersisterNapTimeMSec is kept to zero as this helps in direct
-// persistence of segments with the default safe batch option.
-// If the default safe batch option results in high number of
-// files on disk, then users may initialise this configuration parameter
-// with higher values so that the persister will nap a bit within it's
-// work loop to favour better in-memory merging of segments to result
-// in fewer segment files on disk. But that may come with an indexing
-// performance overhead.
-// Unsafe batch users are advised to override this to higher value
-// for better performance especially with high data density.
-var DefaultPersisterNapTimeMSec int = 0 // ms
+var (
+	// DefaultPersisterNapTimeMSec is kept to zero as this helps in direct
+	// persistence of segments with the default safe batch option.
+	// If the default safe batch option results in high number of
+	// files on disk, then users may initialise this configuration parameter
+	// with higher values so that the persister will nap a bit within it's
+	// work loop to favour better in-memory merging of segments to result
+	// in fewer segment files on disk. But that may come with an indexing
+	// performance overhead.
+	// Unsafe batch users are advised to override this to higher value
+	// for better performance especially with high data density.
+	DefaultPersisterNapTimeMSec int = 0 // ms
 
-// DefaultPersisterNapUnderNumFiles helps in controlling the pace of
-// persister. At times of a slow merger progress with heavy file merging
-// operations, its better to pace down the persister for letting the merger
-// to catch up within a range defined by this parameter.
-// Fewer files on disk (as per the merge plan) would result in keeping the
-// file handle usage under limit, faster disk merger and a healthier index.
-// Its been observed that such a loosely sync'ed introducer-persister-merger
-// trio results in better overall performance.
-var DefaultPersisterNapUnderNumFiles int = 1000
+	// DefaultPersisterNapUnderNumFiles helps in controlling the pace of
+	// persister. At times of a slow merger progress with heavy file merging
+	// operations, its better to pace down the persister for letting the merger
+	// to catch up within a range defined by this parameter.
+	// Fewer files on disk (as per the merge plan) would result in keeping the
+	// file handle usage under limit, faster disk merger and a healthier index.
+	// Its been observed that such a loosely sync'ed introducer-persister-merger
+	// trio results in better overall performance.
+	DefaultPersisterNapUnderNumFiles int = 1000
 
-var DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64
+	DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64
+
+	// DefaultMinSegmentsForInMemoryMerge represents the default number of
+	// in-memory zap segments that persistSnapshotMaybeMerge() needs to
+	// see in an IndexSnapshot before it decides to merge and persist
+	// those segments
+	DefaultMinSegmentsForInMemoryMerge int = 2
+
+	// number workers which parallely perform an in-memory merge of the segments
+	// followed by a flush operation.
+	DefaultNumPersisterWorkers int = 1
+
+	// maximum size of data that a single worker is allowed to perform the in-memory
+	// merge operation.
+	DefaultMaxSizeInMemoryMergePerWorker int = 0
+)
 
 type persisterOptions struct {
 	// PersisterNapTimeMSec controls the wait/delay injected into
@@ -370,32 +386,17 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
 		}
 	}
 
-	return s.persistSnapshotDirect(snapshot, nil)
+	return s.persistSnapshotDirect(snapshot)
 }
-
-// DefaultMinSegmentsForInMemoryMerge represents the default number of
-// in-memory zap segments that persistSnapshotMaybeMerge() needs to
-// see in an IndexSnapshot before it decides to merge and persist
-// those segments
-var DefaultMinSegmentsForInMemoryMerge = 2
 
 type flushable struct {
 	segments []segment.Segment
 	drops    []*roaring.Bitmap
 	sbIdxs   []int
-	totDocs  uint64
 }
 
-// number workers which parallely perform an in-memory merge of the segments
-// followed by a flush operation.
-var DefaultNumPersisterWorkers = 1
-
-// maximum size of data that a single worker is allowed to perform the in-memory
-// merge operation.
-var DefaultMaxSizeInMemoryMergePerWorker = 0
-
 func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int) bool {
-	// DefaultMaxSizeInMemoryMergePerWorker = 0 is a special value to preserve the leagcy
+	// DefaultMaxSizeInMemoryMergePerWorker = 0 is a special value to preserve the legacy
 	// one-shot in-memory merge + flush behaviour.
 	return maxSizeInMemoryMergePerWorker == 0 && numPersisterWorkers == 1
 }
@@ -404,155 +405,120 @@ func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int
 // persist the in-memory zap segments if there are enough of them
 func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persisterOptions) (
 	bool, error) {
-	// collect the in-memory zap segments (SegmentBase instances)
-	var sbs []segment.Segment
-	var sbsDrops []*roaring.Bitmap
-	var sbsIndexes []int
-	var oldSegIdxs []int
+	// split our segment snapshots into unpersisted and persisted segments
+	var persistedSegments []*SegmentSnapshot
+	var unpersistedSegments []*SegmentSnapshot
+	numSegments := len(snapshot.segment)
 
-	flushSet := make([]*flushable, 0)
-	var totSize int
-	var numSegsToFlushOut int
-	var totDocs uint64
-
-	// legacy behaviour of merge + flush of all in-memory segments in one-shot
-	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
-		val := &flushable{
-			segments: make([]segment.Segment, 0),
-			drops:    make([]*roaring.Bitmap, 0),
-			sbIdxs:   make([]int, 0),
-			totDocs:  totDocs,
-		}
-		for i, snapshot := range snapshot.segment {
-			if _, ok := snapshot.segment.(segment.PersistedSegment); !ok {
-				val.segments = append(val.segments, snapshot.segment)
-				val.drops = append(val.drops, snapshot.deleted)
-				val.sbIdxs = append(val.sbIdxs, i)
-				oldSegIdxs = append(oldSegIdxs, i)
-				val.totDocs += snapshot.segment.Count()
-				numSegsToFlushOut++
-			}
-		}
-
-		flushSet = append(flushSet, val)
-	} else {
-		// constructs a flushSet where each flushable object contains a set of segments
-		// to be merged and flushed out to disk.
-		for i, snapshot := range snapshot.segment {
-			if totSize >= po.MaxSizeInMemoryMergePerWorker &&
-				len(sbs) >= DefaultMinSegmentsForInMemoryMerge {
-				numSegsToFlushOut += len(sbs)
-				val := &flushable{
-					segments: slices.Clone(sbs),
-					drops:    slices.Clone(sbsDrops),
-					sbIdxs:   slices.Clone(sbsIndexes),
-					totDocs:  totDocs,
-				}
-				flushSet = append(flushSet, val)
-				oldSegIdxs = append(oldSegIdxs, sbsIndexes...)
-
-				sbs, sbsDrops, sbsIndexes = sbs[:0], sbsDrops[:0], sbsIndexes[:0]
-				totSize, totDocs = 0, 0
-			}
-
-			if len(flushSet) >= int(po.NumPersisterWorkers) {
-				break
-			}
-
-			if _, ok := snapshot.segment.(segment.PersistedSegment); !ok {
-				sbs = append(sbs, snapshot.segment)
-				sbsDrops = append(sbsDrops, snapshot.deleted)
-				sbsIndexes = append(sbsIndexes, i)
-				totDocs += snapshot.segment.Count()
-				totSize += snapshot.segment.Size()
-			}
-		}
-		// if there were too few segments just merge them all as part of a single worker
-		if len(flushSet) < po.NumPersisterWorkers {
-			numSegsToFlushOut += len(sbs)
-			val := &flushable{
-				segments: slices.Clone(sbs),
-				drops:    slices.Clone(sbsDrops),
-				sbIdxs:   slices.Clone(sbsIndexes),
-				totDocs:  totDocs,
-			}
-			flushSet = append(flushSet, val)
-			oldSegIdxs = append(oldSegIdxs, sbsIndexes...)
+	// collect details of the unpersisted segments
+	sbs := make([]segment.Segment, 0, numSegments)
+	sbsDrops := make([]*roaring.Bitmap, 0, numSegments)
+	sbsIndexes := make([]int, 0, numSegments)
+	sbsSizes := make([]int, 0, numSegments)
+	for idx, segmentSnapshot := range snapshot.segment {
+		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
+			persistedSegments = append(persistedSegments, segmentSnapshot)
+		} else {
+			unpersistedSegments = append(unpersistedSegments, segmentSnapshot)
+			sbs = append(sbs, segmentSnapshot.segment)
+			sbsDrops = append(sbsDrops, segmentSnapshot.deleted)
+			sbsIndexes = append(sbsIndexes, idx)
+			sbsSizes = append(sbsSizes, segmentSnapshot.Size())
 		}
 	}
+	numPersistedSegments := len(persistedSegments)
+	numUnpersistedSegments := len(unpersistedSegments)
 
-	if numSegsToFlushOut < DefaultMinSegmentsForInMemoryMerge {
+	// if we don't have enough segments to persist, then just return
+	if numUnpersistedSegments < DefaultMinSegmentsForInMemoryMerge {
 		return false, nil
 	}
 
-	// the newSnapshot at this point would contain the newly created file segments
-	// and updated with the root.
+	// create our flushSet, which will be an array of flushable objects,
+	// each of which will be a batch of segments to merge and persist.
+	// We are guaranteed that at least one flushable object will be created,
+	// since we have already ensured that at least one unpersisted segment is present.
+	var flushSet []*flushable
+	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
+		val := &flushable{
+			segments: slices.Clone(sbs),
+			drops:    slices.Clone(sbsDrops),
+			sbIdxs:   slices.Clone(sbsIndexes),
+		}
+		flushSet = append(flushSet, val)
+	} else {
+		sbsBatch := make([]segment.Segment, 0, numUnpersistedSegments)
+		sbsBatchDrops := make([]*roaring.Bitmap, 0, numUnpersistedSegments)
+		sbsBatchIndexes := make([]int, 0, numUnpersistedSegments)
+		runningSize := 0
+		for i := 0; i < numUnpersistedSegments; i++ {
+			sbsBatch = append(sbsBatch, sbs[i])
+			sbsBatchDrops = append(sbsBatchDrops, sbsDrops[i])
+			sbsBatchIndexes = append(sbsBatchIndexes, sbsIndexes[i])
+			runningSize += sbsSizes[i]
+			if runningSize >= po.MaxSizeInMemoryMergePerWorker && len(sbsBatch) >= DefaultMinSegmentsForInMemoryMerge {
+				flushSet = append(flushSet, &flushable{
+					segments: slices.Clone(sbsBatch),
+					drops:    slices.Clone(sbsBatchDrops),
+					sbIdxs:   slices.Clone(sbsBatchIndexes),
+				})
+				sbsBatch, sbsBatchDrops, sbsBatchIndexes = sbsBatch[:0], sbsBatchDrops[:0], sbsBatchIndexes[:0]
+				runningSize = 0
+			}
+		}
+		if len(sbsBatch) > 0 {
+			flushSet = append(flushSet, &flushable{
+				segments: slices.Clone(sbsBatch),
+				drops:    slices.Clone(sbsBatchDrops),
+				sbIdxs:   slices.Clone(sbsBatchIndexes),
+			})
+		}
+	}
+
+	// now merge each batch into a new segment, and persist all of them to disk,
+	// and construct a new snapshot with the merged segments
 	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet)
 	if err != nil {
 		return false, err
 	}
-
 	if newSnapshot == nil {
 		return false, nil
 	}
-
 	defer func() {
 		_ = newSnapshot.DecRef()
 	}()
-
-	mergedSegmentIDs := map[uint64]struct{}{}
-	for _, idx := range oldSegIdxs {
-		mergedSegmentIDs[snapshot.segment[idx].id] = struct{}{}
-	}
-
-	newMergedSegmentIDs := make(map[uint64]struct{}, len(newSegmentIDs))
-	for _, id := range newSegmentIDs {
-		newMergedSegmentIDs[id] = struct{}{}
-	}
 
 	// construct a snapshot that's logically equivalent to the input
 	// snapshot, but with merged segments replaced by the new segment
 	equiv := &IndexSnapshot{
 		parent:   snapshot.parent,
-		segment:  make([]*SegmentSnapshot, 0, len(snapshot.segment)),
+		segment:  make([]*SegmentSnapshot, 0, numPersistedSegments+len(newSegmentIDs)),
 		internal: snapshot.internal,
 		epoch:    snapshot.epoch,
 		creator:  "persistSnapshotMaybeMerge",
 	}
 
-	// to track which segments haven't participated in the in-memory merge
-	// they won't be flushed out to the disk yet, but in the next cycle will be
-	// merged in-memory and then flushed out - this is to keep the number of
-	// on-disk files in limit.
-	exclude := make(map[uint64]struct{})
-
-	// copy to the equiv the segments that weren't replaced
-	for _, ss := range snapshot.segment {
-		if _, wasMerged := mergedSegmentIDs[ss.id]; !wasMerged {
-			equiv.segment = append(equiv.segment, ss)
-			// this can be either in-memory or persisted segment, but while
-			// preparing the bolt snapshot we avoid the in-memory segments to be
-			// flushed out
-			if _, ok := ss.segment.(segment.PersistedSegment); !ok {
-				exclude[ss.id] = struct{}{}
-			}
-		}
+	// first add all the segments that were already persisted
+	// and did not participate in the merge
+	for _, segment := range persistedSegments {
+		equiv.segment = append(equiv.segment, segment)
 	}
 
-	// append to the equiv the newly merged segments
+	// next, add all the segments that were unpersisted and hence
+	// participated in the merge, from the merged snapshot
 	for _, segment := range newSnapshot.segment {
-		if _, ok := newMergedSegmentIDs[segment.id]; ok {
+		if _, ok := newSegmentIDs[segment.id]; ok {
 			equiv.segment = append(equiv.segment, &SegmentSnapshot{
-				id:       segment.id,
-				segment:  segment.segment,
-				deleted:  nil, // nil since merging handled deletions
-				stats:    nil,
-				internal: nil, // segment is persisted and equiv is already updated
+				id:      segment.id,
+				segment: segment.segment,
+				deleted: nil, // nil since merging handled deletions
+				stats:   nil,
 			})
 		}
 	}
 
-	err = s.persistSnapshotDirect(equiv, exclude)
+	// finally, persist the equivalent snapshot to disk
+	err = s.persistSnapshotDirect(equiv)
 	if err != nil {
 		return false, err
 	}
@@ -612,7 +578,7 @@ func persistToDirectory(seg segment.UnpersistedSegment, d index.Directory,
 }
 
 func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
-	segPlugin SegmentPlugin, exclude map[uint64]struct{}, d index.Directory) (
+	segPlugin SegmentPlugin, d index.Directory) (
 	[]string, map[uint64]string, error) {
 	snapshotsBucket, err := tx.CreateBucketIfNotExists(boltSnapshotsBucket)
 	if err != nil {
@@ -659,12 +625,11 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// deep copy the internal map since we'll be keeping only the persisted info
-	// in bolt and some of the information might be deleted
-	internal := make(map[string][]byte, len(snapshot.internal))
 	for k, v := range snapshot.internal {
-		internal[k] = v
+		err = internalBucket.Put([]byte(k), v)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if snapshot.parent != nil {
@@ -682,15 +647,13 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 
 	// first ensure that each segment in this snapshot has been persisted
 	for _, segmentSnapshot := range snapshot.segment {
-		var persistedSeg bool
-		var snapshotSegmentBucket *bolt.Bucket
+		snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
+		snapshotSegmentBucket, err := snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
+		if err != nil {
+			return nil, nil, err
+		}
 		switch seg := segmentSnapshot.segment.(type) {
 		case segment.PersistedSegment:
-			snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
-			snapshotSegmentBucket, err = snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
-			if err != nil {
-				return nil, nil, err
-			}
 			segPath := seg.Path()
 			_, err = copyToDirectory(segPath, d)
 			if err != nil {
@@ -702,86 +665,54 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *bolt.Tx, path string,
 				return nil, nil, err
 			}
 			filenames = append(filenames, filename)
-			persistedSeg = true
 		case segment.UnpersistedSegment:
-			// need to persist this to disk if its not part of exclude list (which
-			// restricts which in-memory segment to be persisted to disk)
-			if _, ok := exclude[segmentSnapshot.id]; !ok {
-				snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
-				snapshotSegmentBucket, err = snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
-				if err != nil {
-					return nil, nil, err
-				}
-				filename := zapFileName(segmentSnapshot.id)
-				path := filepath.Join(path, filename)
-				err = persistToDirectory(seg, d, path)
-				if err != nil {
-					return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
-				}
-				newSegmentPaths[segmentSnapshot.id] = path
-				err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
-				if err != nil {
-					return nil, nil, err
-				}
-				filenames = append(filenames, filename)
-				persistedSeg = true
-			} else {
-				// this segment is not going to be persisted in this cycle, so any
-				// of the corresponding internal values need to be removed since
-				// on recovery they shouldn't be loaded as part of the indexSnapshot
-				for k, v := range segmentSnapshot.internal {
-					if v != nil {
-						delete(internal, k)
-					}
-				}
+			// need to persist this to disk
+			filename := zapFileName(segmentSnapshot.id)
+			path := filepath.Join(path, filename)
+			err := persistToDirectory(seg, d, path)
+			if err != nil {
+				return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
 			}
+			newSegmentPaths[segmentSnapshot.id] = path
+			err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
+			if err != nil {
+				return nil, nil, err
+			}
+			filenames = append(filenames, filename)
 		default:
 			return nil, nil, fmt.Errorf("unknown segment type: %T", seg)
 		}
 
-		// if the segment was excluded from persistence, then skip updating the metadata
-		// or helper data corresponding to it - we need to keep things in-line with
-		// the on-disk information
-		if persistedSeg {
-			// store current deleted bits
-			var roaringBuf bytes.Buffer
-			if segmentSnapshot.deleted != nil {
-				_, err = segmentSnapshot.deleted.WriteTo(&roaringBuf)
-				if err != nil {
-					return nil, nil, fmt.Errorf("error persisting roaring bytes: %v", err)
-				}
-				err = snapshotSegmentBucket.Put(boltDeletedKey, roaringBuf.Bytes())
-				if err != nil {
-					return nil, nil, err
-				}
+		// store current deleted bits
+		var roaringBuf bytes.Buffer
+		if segmentSnapshot.deleted != nil {
+			_, err = segmentSnapshot.deleted.WriteTo(&roaringBuf)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error persisting roaring bytes: %v", err)
 			}
-
-			// store segment stats
-			if segmentSnapshot.stats != nil {
-				b, err := json.Marshal(segmentSnapshot.stats.Fetch())
-				if err != nil {
-					return nil, nil, err
-				}
-				err = snapshotSegmentBucket.Put(boltStatsKey, b)
-				if err != nil {
-					return nil, nil, err
-				}
+			err = snapshotSegmentBucket.Put(boltDeletedKey, roaringBuf.Bytes())
+			if err != nil {
+				return nil, nil, err
 			}
 		}
-	}
 
-	// now the internal values are reflective of the on-disk data, update in bolt
-	for k, v := range internal {
-		err = internalBucket.Put([]byte(k), v)
-		if err != nil {
-			return nil, nil, err
+		// store segment stats
+		if segmentSnapshot.stats != nil {
+			b, err := json.Marshal(segmentSnapshot.stats.Fetch())
+			if err != nil {
+				return nil, nil, err
+			}
+			err = snapshotSegmentBucket.Put(boltStatsKey, b)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 
 	return filenames, newSegmentPaths, nil
 }
 
-func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot, exclude map[uint64]struct{}) (err error) {
+func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 	// start a write transaction
 	tx, err := s.rootBolt.Begin(true)
 	if err != nil {
@@ -794,7 +725,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot, exclude map[uint
 		}
 	}()
 
-	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, exclude, nil)
+	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, nil)
 	if err != nil {
 		return err
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -511,6 +511,12 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		_ = newSnapshot.DecRef()
 	}()
 
+	// create a set of the newly merged segment IDs for easy lookup
+	newSegmentIDsSet := make(map[uint64]struct{}, len(newSegmentIDs))
+	for _, id := range newSegmentIDs {
+		newSegmentIDsSet[id] = struct{}{}
+	}
+
 	// construct a snapshot that's logically equivalent to the input
 	// snapshot, but with merged segments replaced by the new segment
 	equiv := &IndexSnapshot{
@@ -525,12 +531,6 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 	// and did not participate in the merge
 	for _, segment := range persistedSegments {
 		equiv.segment = append(equiv.segment, segment)
-	}
-
-	// create a set of the newly merged segment IDs for easy lookup
-	newSegmentIDsSet := make(map[uint64]struct{}, len(newSegmentIDs))
-	for _, id := range newSegmentIDs {
-		newSegmentIDsSet[id] = struct{}{}
 	}
 
 	// next, add all the segments that were unpersisted and hence

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -61,6 +61,11 @@ var (
 	// trio results in better overall performance.
 	DefaultPersisterNapUnderNumFiles int = 1000
 
+	// MemoryPressurePauseThreshold lets persister to have a better leeway
+	// for prudently performing the memory merge of segments on a memory
+	// pressure situation. Here the config value is an upper threshold
+	// for the number of paused application threads. The default value would
+	// be a very high number to always favour the merging of memory segments.
 	DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64
 
 	// DefaultMinSegmentsForInMemoryMerge represents the default number of
@@ -90,11 +95,10 @@ type persisterOptions struct {
 	// a healthier and heavier in-memory merging
 	PersisterNapUnderNumFiles int
 
-	// MemoryPressurePauseThreshold let persister to have a better leeway
+	// MemoryPressurePauseThreshold lets persister to have a better leeway
 	// for prudently performing the memory merge of segments on a memory
 	// pressure situation. Here the config value is an upper threshold
-	// for the number of paused application threads. The default value would
-	// be a very high number to always favour the merging of memory segments.
+	// for the number of paused application threads.
 	MemoryPressurePauseThreshold uint64
 
 	// NumPersisterWorkers decides the number of parallel workers that will

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -511,12 +511,6 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		_ = newSnapshot.DecRef()
 	}()
 
-	// create a set of the newly merged segment IDs for easy lookup
-	newSegmentIDsSet := make(map[uint64]struct{}, len(newSegmentIDs))
-	for _, id := range newSegmentIDs {
-		newSegmentIDsSet[id] = struct{}{}
-	}
-
 	// construct a snapshot that's logically equivalent to the input
 	// snapshot, but with merged segments replaced by the new segment
 	equiv := &IndexSnapshot{
@@ -536,7 +530,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 	// next, add all the segments that were unpersisted and hence
 	// participated in the merge, from the merged snapshot
 	for _, segment := range newSnapshot.segment {
-		if _, ok := newSegmentIDsSet[segment.id]; ok {
+		if _, ok := newSegmentIDs[segment.id]; ok {
 			equiv.segment = append(equiv.segment, &SegmentSnapshot{
 				id:      segment.id,
 				segment: segment.segment,

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -413,9 +413,9 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
 }
 
 type flushable struct {
-	segments []segment.Segment
-	drops    []*roaring.Bitmap
-	sbIdxs   []int
+	sbsBatch        []segment.Segment
+	sbsBatchDrops   []*roaring.Bitmap
+	sbsBatchIndexes []int
 }
 
 func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int) bool {
@@ -464,9 +464,9 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 	var flushSet []*flushable
 	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
 		val := &flushable{
-			segments: slices.Clone(sbs),
-			drops:    slices.Clone(sbsDrops),
-			sbIdxs:   slices.Clone(sbsIndexes),
+			sbsBatch:        slices.Clone(sbs),
+			sbsBatchDrops:   slices.Clone(sbsDrops),
+			sbsBatchIndexes: slices.Clone(sbsIndexes),
 		}
 		flushSet = append(flushSet, val)
 	} else {
@@ -481,9 +481,9 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 			runningSize += sbsSizes[i]
 			if runningSize >= po.MaxSizeInMemoryMergePerWorker && len(sbsBatch) >= DefaultMinSegmentsForInMemoryMerge {
 				flushSet = append(flushSet, &flushable{
-					segments: slices.Clone(sbsBatch),
-					drops:    slices.Clone(sbsBatchDrops),
-					sbIdxs:   slices.Clone(sbsBatchIndexes),
+					sbsBatch:        slices.Clone(sbsBatch),
+					sbsBatchDrops:   slices.Clone(sbsBatchDrops),
+					sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
 				})
 				sbsBatch, sbsBatchDrops, sbsBatchIndexes = sbsBatch[:0], sbsBatchDrops[:0], sbsBatchIndexes[:0]
 				runningSize = 0
@@ -491,9 +491,9 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		}
 		if len(sbsBatch) > 0 {
 			flushSet = append(flushSet, &flushable{
-				segments: slices.Clone(sbsBatch),
-				drops:    slices.Clone(sbsBatchDrops),
-				sbIdxs:   slices.Clone(sbsBatchIndexes),
+				sbsBatch:        slices.Clone(sbsBatch),
+				sbsBatchDrops:   slices.Clone(sbsBatchDrops),
+				sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
 			})
 		}
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -527,10 +527,16 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 		equiv.segment = append(equiv.segment, segment)
 	}
 
+	// create a set of the newly merged segment IDs for easy lookup
+	newSegmentIDsSet := make(map[uint64]struct{}, len(newSegmentIDs))
+	for _, id := range newSegmentIDs {
+		newSegmentIDsSet[id] = struct{}{}
+	}
+
 	// next, add all the segments that were unpersisted and hence
 	// participated in the merge, from the merged snapshot
 	for _, segment := range newSnapshot.segment {
-		if _, ok := newSegmentIDs[segment.id]; ok {
+		if _, ok := newSegmentIDsSet[segment.id]; ok {
 			equiv.segment = append(equiv.segment, &SegmentSnapshot{
 				id:      segment.id,
 				segment: segment.segment,

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -535,7 +535,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 				id:      segment.id,
 				segment: segment.segment,
 				deleted: nil, // nil since merging handled deletions
-				stats:   nil,
+				stats:   segment.stats,
 			})
 		}
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -367,7 +367,26 @@ func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
 			return &po, err
 		}
 	}
+	if err := validatePersisterOptions(&po); err != nil {
+		return nil, err
+	}
 	return &po, nil
+}
+
+// validatePersisterOptions validates the persister options
+func validatePersisterOptions(options *persisterOptions) error {
+	// P < 1 is an invalid case
+	if options.NumPersisterWorkers <= 0 {
+		return fmt.Errorf("NumPersisterWorkers must be greater than 0")
+	}
+	// P = 1 and M > 0 is a valid case where one worker will serially flush all batches
+	// P = 1 and M = 0 is a special case which preserves the legacy one-shot in-memory merge + flush behaviour
+	// P > 1 and M > 0 is a valid case where multiple workers will flush batches in parallel
+	// P > 1 and M = 0 is an invalid case
+	if options.NumPersisterWorkers > 1 && options.MaxSizeInMemoryMergePerWorker == 0 {
+		return fmt.Errorf("MaxSizeInMemoryMergePerWorker must be greater than 0 when NumPersisterWorkers > 1")
+	}
+	return nil
 }
 
 func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
@@ -477,7 +496,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 
 	// now merge each batch into a new segment, and persist all of them to disk,
 	// and construct a new snapshot with the merged segments
-	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet)
+	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet, po)
 	if err != nil {
 		return false, err
 	}

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -459,7 +459,6 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 
 	var newSegment segment.Segment
 	var bufBytes uint64
-	stats := newFieldStats()
 
 	if len(analysisResults) > 0 {
 		newSegment, bufBytes, err = s.segPlugin.New(analysisResults)
@@ -471,14 +470,11 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 				segB.BytesWritten())
 		}
 		atomic.AddUint64(&s.iStats.newSegBufBytesAdded, bufBytes)
-		if fsr, ok := newSegment.(segment.FieldStatsReporter); ok {
-			fsr.UpdateFieldStats(stats)
-		}
 	} else {
 		atomic.AddUint64(&s.stats.TotBatchesEmpty, 1)
 	}
 
-	err = s.prepareSegment(newSegment, ids, batch.InternalOps, batch.PersistedCallback(), stats)
+	err = s.prepareSegment(newSegment, ids, batch.InternalOps, batch.PersistedCallback())
 	if err != nil {
 		if newSegment != nil {
 			_ = newSegment.Close()
@@ -498,15 +494,13 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 }
 
 func (s *Scorch) prepareSegment(newSegment segment.Segment, ids []string,
-	internalOps map[string][]byte, persistedCallback index.BatchCallback, stats *fieldStats,
-) error {
+	internalOps map[string][]byte, persistedCallback index.BatchCallback) error {
 	// new introduction
 	introduction := &segmentIntroduction{
 		id:                atomic.AddUint64(&s.nextSegmentID, 1),
 		data:              newSegment,
 		ids:               ids,
 		internal:          internalOps,
-		stats:             stats,
 		applied:           make(chan error),
 		persistedCallback: persistedCallback,
 	}

--- a/index/scorch/scorch_knn_test.go
+++ b/index/scorch/scorch_knn_test.go
@@ -29,20 +29,20 @@ import (
 )
 
 const (
-	testVectorDims       = 3
-	testVectorSimilarity = "l2"
+	testVectorDims              = 3
+	testVectorSimilarity        = index.CosineSimilarity
+	testVectorIndexOptimizedFor = index.IndexOptimizedForRecall
 )
 
 func genVectorDoc(t *testing.T, fieldName string) index.Document {
 	t.Helper()
 	randNum := rand.Intn(1000000)
 	doc := document.NewDocument(fmt.Sprintf("vectest%d", randNum))
-	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
 	vector := make([]float32, testVectorDims)
 	for i := range vector {
 		vector[i] = float32(i+1) * float32(randNum+1)
 	}
-	doc.AddField(document.NewVectorField(fieldName, nil, vector, testVectorDims, testVectorSimilarity, ""))
+	doc.AddField(document.NewVectorField(fieldName, nil, vector, testVectorDims, testVectorSimilarity, testVectorIndexOptimizedFor))
 	doc.AddIDField()
 	doc.VisitFields(func(field index.Field) {
 		field.Analyze()
@@ -57,7 +57,6 @@ func TestFieldStatPersistence(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = DestroyTest(cfg) }()
-
 	dirPath := cfg["path"].(string)
 	if err = os.Mkdir(dirPath, 0o755); err != nil {
 		t.Fatal(err)
@@ -116,16 +115,13 @@ func TestFieldStatPersistence(t *testing.T) {
 		}
 		doneCh <- struct{}{}
 	}()
-
 	select {
 	case merge := <-s.merges:
 		s.introduceMerge(merge)
 	case err := <-errCh:
 		t.Fatalf("unexpected error during persist (merge phase): %v", err)
 	}
-
 	<-doneCh
-
 	snapshot := s.root
 	if len(snapshot.segment) != 1 {
 		t.Fatalf("expected 1 segment after introduce, got %d", len(snapshot.segment))
@@ -138,11 +134,9 @@ func TestFieldStatPersistence(t *testing.T) {
 	if numVecs != uint64(numSegments) {
 		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
 	}
-
 	if err = idx.Close(); err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
 	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to recreate Scorch: %v", err)
@@ -155,8 +149,6 @@ func TestFieldStatPersistence(t *testing.T) {
 	if err = s.openBolt(); err != nil {
 		t.Fatalf("failed to open bolt on reopen: %v", err)
 	}
-
-	// (3) Verify HasVector on the segment loaded from bolt.
 	snapshot = s.root
 	if len(snapshot.segment) != 1 {
 		t.Fatalf("expected 1 segment after reopen, got %d", len(snapshot.segment))
@@ -168,5 +160,9 @@ func TestFieldStatPersistence(t *testing.T) {
 	numVecs = scorchStats[statName].(uint64)
 	if numVecs != uint64(numSegments) {
 		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
+	}
+	err = idx.Close()
+	if err != nil {
+		t.Fatalf("failed to close index on reopen: %v", err)
 	}
 }

--- a/index/scorch/scorch_knn_test.go
+++ b/index/scorch/scorch_knn_test.go
@@ -1,0 +1,172 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package scorch
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/document"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+const (
+	testVectorDims       = 3
+	testVectorSimilarity = "l2"
+)
+
+func genVectorDoc(t *testing.T, fieldName string) index.Document {
+	t.Helper()
+	randNum := rand.Intn(1000000)
+	doc := document.NewDocument(fmt.Sprintf("vectest%d", randNum))
+	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
+	vector := make([]float32, testVectorDims)
+	for i := range vector {
+		vector[i] = float32(i+1) * float32(randNum+1)
+	}
+	doc.AddField(document.NewVectorField(fieldName, nil, vector, testVectorDims, testVectorSimilarity, ""))
+	doc.AddIDField()
+	doc.VisitFields(func(field index.Field) {
+		field.Analyze()
+	})
+	return doc
+}
+
+func TestFieldStatPersistence(t *testing.T) {
+	cfg := CreateConfig("TestFieldStatPersistence")
+	err := InitTest(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = DestroyTest(cfg) }()
+
+	dirPath := cfg["path"].(string)
+	if err = os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	analysisQueue := index.NewAnalysisQueue(1)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to create Scorch: %v", err)
+	}
+	s, ok := idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", idx)
+	}
+	s.path = dirPath
+	if err = s.openBolt(); err != nil {
+		t.Fatalf("failed to open bolt: %v", err)
+	}
+	const (
+		numSegments = 3
+		fieldName   = "vector"
+		statName    = "field:" + fieldName + ":num_vectors"
+	)
+	docs := make([]index.Document, numSegments)
+	ids := make([]string, numSegments)
+	for i := 0; i < numSegments; i++ {
+		docs[i] = genVectorDoc(t, fieldName)
+		ids[i] = docs[i].ID()
+		seg, _, err := s.segPlugin.New([]index.Document{docs[i]})
+		if err != nil {
+			t.Fatalf("failed to create segment %d: %v", i, err)
+		}
+		intro := &segmentIntroduction{
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    seg,
+			ids:     []string{ids[i]},
+			applied: make(chan error),
+		}
+		if err = s.introduceSegment(intro); err != nil {
+			t.Fatalf("introduceSegment %d failed: %v", i, err)
+		}
+	}
+
+	errCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
+		}
+		if persistErr := s.persistSnapshot(s.root, &po); persistErr != nil {
+			errCh <- persistErr
+			return
+		}
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case merge := <-s.merges:
+		s.introduceMerge(merge)
+	case err := <-errCh:
+		t.Fatalf("unexpected error during persist (merge phase): %v", err)
+	}
+
+	<-doneCh
+
+	snapshot := s.root
+	if len(snapshot.segment) != 1 {
+		t.Fatalf("expected 1 segment after introduce, got %d", len(snapshot.segment))
+	}
+	if !snapshot.segment[0].HasVector() {
+		t.Fatalf("expected HasVector() == true after index persist")
+	}
+	scorchStats := s.StatsMap()
+	numVecs := scorchStats[statName].(uint64)
+	if numVecs != uint64(numSegments) {
+		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
+	}
+
+	if err = idx.Close(); err != nil {
+		t.Fatalf("failed to close index: %v", err)
+	}
+
+	idx, err = NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to recreate Scorch: %v", err)
+	}
+	s, ok = idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", idx)
+	}
+	s.path = dirPath
+	if err = s.openBolt(); err != nil {
+		t.Fatalf("failed to open bolt on reopen: %v", err)
+	}
+
+	// (3) Verify HasVector on the segment loaded from bolt.
+	snapshot = s.root
+	if len(snapshot.segment) != 1 {
+		t.Fatalf("expected 1 segment after reopen, got %d", len(snapshot.segment))
+	}
+	if !snapshot.segment[0].HasVector() {
+		t.Fatalf("reopened segment: expected HasVector() == true after index reopen")
+	}
+	scorchStats = s.StatsMap()
+	numVecs = scorchStats[statName].(uint64)
+	if numVecs != uint64(numSegments) {
+		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
+	}
+}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2928,7 +2929,14 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
-		err := s.persistSnapshotDirect(snapshot)
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
+		}
+		err := s.persistSnapshot(snapshot, &po)
 		if err != nil {
 			errCh <- err
 			return
@@ -2937,6 +2945,8 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	}()
 
 	select {
+	case merge := <-s.merges:
+		s.introduceMerge(merge)
 	case persist := <-s.persists:
 		s.introducePersist(persist)
 	case err := <-errCh:
@@ -3027,57 +3037,248 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
+
 	// ------------------------------------------------------
 	// reopen the index and verify that the persisted state is correct
-	idx2, err := NewScorch(Name, cfg, analysisQueue)
+	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
 	}
-	s2, ok := idx2.(*Scorch)
+	s, ok = idx.(*Scorch)
 	if !ok {
-		t.Fatalf("expected *Scorch, got %T", s2)
+		t.Fatalf("expected *Scorch, got %T", s)
 	}
-	s2.path = cfg["path"].(string)
-	err = s2.openBolt()
+	s.path = cfg["path"].(string)
+	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-	if len(s2.root.segment) != 5 {
-		t.Fatalf("expected 5 segments in root after reopen, got %d", len(s2.root.segment))
+	if len(s.root.segment) != 1 {
+		t.Fatalf("expected 1 segment in root after reopen, got %d", len(s.root.segment))
 	}
-	reader2, err := idx2.Reader()
+	reader, err = idx.Reader()
 	if err != nil {
 		t.Fatalf("failed to get reader after reopen: %v", err)
 	}
+
 	// ------------------------------------------------------
 	// Verify the Bolt Snapshot's VB-seqMax mappings.
-	expectedMappings2 := make([]uint64, numVBs)
+	expectedMappings = make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {
-		expectedMappings2[i] = 4
+		expectedMappings[i] = 4
 	}
-	actualMappings2 := make([]uint64, numVBs)
+	actualMappings = make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {
 		vbKey := []byte(strconv.Itoa(i))
-		val, err := reader2.GetInternal(vbKey)
+		val, err := reader.GetInternal(vbKey)
 		if err != nil {
 			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
 		}
 		if val == nil {
-			actualMappings2[i] = 0
+			actualMappings[i] = 0
 		} else {
-			actualMappings2[i] = binary.BigEndian.Uint64(val)
+			actualMappings[i] = binary.BigEndian.Uint64(val)
 		}
 	}
-	if !slices.Equal(expectedMappings2, actualMappings2) {
-		t.Fatalf("expected Bolt snapshot VB-seqMax mappings %v, got %v", expectedMappings2, actualMappings2)
+	if !slices.Equal(expectedMappings, actualMappings) {
+		t.Fatalf("expected Bolt snapshot VB-seqMax mappings %v, got %v", expectedMappings, actualMappings)
 	}
-	err = reader2.Close()
+	err = reader.Close()
 	if err != nil {
 		t.Fatalf("failed to close reader: %v", err)
 	}
-	err = idx2.Close()
+	err = idx.Close()
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-	// ------------------------------------------------------
+}
+
+func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
+	cfg := CreateConfig("TestIneligibleForRemovalOnSkippedMerge")
+	err := InitTest(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = DestroyTest(cfg) }()
+	dirPath := cfg["path"].(string)
+	if err = os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	analysisQueue := index.NewAnalysisQueue(1)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to create Scorch: %v", err)
+	}
+	s := idx.(*Scorch)
+	s, ok := idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", s)
+	}
+	s.path = dirPath
+	err = s.openBolt()
+	if err != nil {
+		t.Fatalf("failed to open bolt: %v", err)
+	}
+
+	// create 2 docs
+	doc1 := genDoc(t)
+	doc2 := genDoc(t)
+	doc3 := genDoc(t)
+	docs := []index.Document{doc1, doc2, doc3}
+	ids := []string{doc1.ID(), doc2.ID(), doc3.ID()}
+
+	// introduce 3 segments with 1 doc each
+	for i := 0; i < 3; i++ {
+		doc := docs[i]
+		id := ids[i]
+		seg, _, err := s.segPlugin.New([]index.Document{doc})
+		if err != nil {
+			t.Fatalf("failed to create segment: %v", err)
+		}
+		intro := &segmentIntroduction{
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    seg,
+			ids:     []string{id},
+			applied: make(chan error),
+		}
+		if err = s.introduceSegment(intro); err != nil {
+			t.Fatalf("introduceSegment: %v", err)
+		}
+	}
+	snapshot := s.root
+	if len(snapshot.segment) != 3 {
+		t.Fatalf("expected %d segments, got %d", 3, len(snapshot.segment))
+	}
+	for _, seg := range snapshot.segment {
+		if seg.Count() != 1 {
+			t.Fatalf("expected %d docs, got %d", 1, seg.Count())
+		}
+	}
+
+	// persist the snapshot
+	var errCh = make(chan error, 1)
+	var doneCh = make(chan struct{})
+	go func() {
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
+		}
+		err := s.persistSnapshot(snapshot, &po)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case merge := <-s.merges:
+		// introduce another batch deleting the 3 docs, resulting in a skipped merge
+		intro2 := &segmentIntroduction{
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    nil,
+			ids:     ids,
+			applied: make(chan error),
+		}
+		if err = s.introduceSegment(intro2); err != nil {
+			t.Fatalf("introduceSegment: %v", err)
+		}
+		snapshot = s.root
+		if len(snapshot.segment) != 0 {
+			t.Fatalf("expected %d segments, got %d", 0, len(snapshot.segment))
+		}
+		docCount, err := snapshot.DocCount()
+		if err != nil {
+			t.Fatalf("failed to get doc count: %v", err)
+		}
+		if docCount != 0 {
+			t.Fatalf("expected %d docs, got %d", 0, docCount)
+		}
+		// now we allow the merge to happen, which will result in a skipped merge
+		s.introduceMerge(merge)
+	case err := <-errCh:
+		t.Fatalf("unexpected error during persist: %v", err)
+	}
+
+	select {
+	case persist := <-s.persists:
+		s.introducePersist(persist)
+	case err := <-errCh:
+		t.Fatalf("unexpected error during persist: %v", err)
+	}
+	<-doneCh
+
+	// verify that the root now contains 0 segments
+	snapshot = s.root
+	if len(snapshot.segment) != 0 {
+		t.Errorf("expected %d segments, got %d", 0, len(snapshot.segment))
+	}
+	docCount, err := snapshot.DocCount()
+	if err != nil {
+		t.Errorf("failed to get doc count: %v", err)
+	}
+	if docCount != 0 {
+		t.Errorf("expected %d docs, got %d", 0, docCount)
+	}
+	s.removeOldData()
+	files, err := os.ReadDir(dirPath)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
+	var numZapFiles int
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".zap") {
+			numZapFiles++
+		}
+	}
+	if numZapFiles != 3 {
+		t.Errorf("expected %d zap files, got %d", 3, numZapFiles)
+	}
+
+	// close the index now, and reopen it to verify that the persisted state is correct
+	err = idx.Close()
+	if err != nil {
+		t.Fatalf("failed to close index: %v", err)
+	}
+
+	idx, err = NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to create Scorch: %v", err)
+	}
+	s, ok = idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", s)
+	}
+	s.path = dirPath
+	err = s.openBolt()
+	if err != nil {
+		t.Fatalf("failed to open bolt: %v", err)
+	}
+	snapshot = s.root
+	if len(snapshot.segment) != 3 {
+		t.Errorf("expected %d segments, got %d", 0, len(snapshot.segment))
+	}
+	docCount, err = snapshot.DocCount()
+	if err != nil {
+		t.Errorf("failed to get doc count: %v", err)
+	}
+	if docCount != 3 {
+		t.Errorf("expected %d docs, got %d", 0, docCount)
+	}
+	files, err = os.ReadDir(dirPath)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
+	numZapFiles = 0
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".zap") {
+			numZapFiles++
+		}
+	}
+	if numZapFiles != 3 {
+		t.Errorf("expected %d zap files, got %d", 3, numZapFiles)
+	}
 }

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -2862,12 +2862,9 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = DestroyTest(cfg)
-	}()
-
-	os.Mkdir(cfg["path"].(string), 0o755)
-
+	defer func() { _ = DestroyTest(cfg) }()
+	idxPath := cfg["path"].(string)
+	os.Mkdir(idxPath, 0o755)
 	analysisQueue := index.NewAnalysisQueue(1)
 	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
@@ -2877,37 +2874,28 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *Scorch, got %T", s)
 	}
-
-	s.path = cfg["path"].(string)
+	s.path = idxPath
 	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
 	const (
 		numSegments = 5
 		numVBs      = 5
 	)
-
 	batches := getBatches(t, numVBs, numSegments)
-
 	for i := 0; i < numSegments; i++ {
 		batch := batches[i]
-
 		var docs []index.Document
 		var ids []string
 		for _, doc := range batch.IndexOps {
-			if doc != nil {
-				docs = append(docs, doc)
-			}
+			docs = append(docs, doc)
 			ids = append(ids, doc.ID())
 		}
-
 		seg, _, err := s.segPlugin.New(docs)
 		if err != nil {
 			t.Fatalf("failed to create segment %d: %v", i, err)
 		}
-
 		intro := &segmentIntroduction{
 			id:       atomic.AddUint64(&s.nextSegmentID, 1),
 			data:     seg,
@@ -2920,12 +2908,10 @@ func TestPersistenceMergedBatches(t *testing.T) {
 			t.Fatalf("introduceSegment %d failed: %v", i, err)
 		}
 	}
-
 	snapshot := s.root
 	if len(snapshot.segment) != numSegments {
 		t.Fatalf("expected %d segments, got %d", numSegments, len(snapshot.segment))
 	}
-
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
@@ -2943,18 +2929,13 @@ func TestPersistenceMergedBatches(t *testing.T) {
 		}
 		doneCh <- struct{}{}
 	}()
-
 	select {
 	case merge := <-s.merges:
 		s.introduceMerge(merge)
-	case persist := <-s.persists:
-		s.introducePersist(persist)
 	case err := <-errCh:
 		t.Fatalf("unexpected error during persist: %v", err)
 	}
-
 	<-doneCh
-
 	// validate our snapshot's VB-seqMax mappings.
 	/*
 		Each Merged Batch has the following VB-seqMax mappings:
@@ -3006,16 +2987,13 @@ func TestPersistenceMergedBatches(t *testing.T) {
 		    - In-memory snapshot and Persisted snapshot are in sync with each other.
 			- The VB-seqMax mappings always pick the highest sequence number for each VB.
 	*/
-
-	// ------------------------------------------------------
-	// Verify the in-memory snapshot's VB-seqMax mappings.
-	expectedMappings := make([]uint64, numVBs)
-	for i := 0; i < numVBs; i++ {
-		expectedMappings[i] = 4
-	}
 	reader, err := idx.Reader()
 	if err != nil {
 		t.Fatalf("failed to get reader: %v", err)
+	}
+	expectedMappings := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		expectedMappings[i] = 4
 	}
 	actualMappings := make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {
@@ -3024,7 +3002,11 @@ func TestPersistenceMergedBatches(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
 		}
-		actualMappings[i] = binary.BigEndian.Uint64(val)
+		if val == nil {
+			actualMappings[i] = 0
+		} else {
+			actualMappings[i] = binary.BigEndian.Uint64(val)
+		}
 	}
 	if !slices.Equal(expectedMappings, actualMappings) {
 		t.Fatalf("expected in-memory snapshot VB-seqMax mappings %v, got %v", expectedMappings, actualMappings)
@@ -3037,9 +3019,6 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
-	// ------------------------------------------------------
-	// reopen the index and verify that the persisted state is correct
 	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
@@ -3048,7 +3027,7 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *Scorch, got %T", s)
 	}
-	s.path = cfg["path"].(string)
+	s.path = idxPath
 	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
@@ -3060,9 +3039,6 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get reader after reopen: %v", err)
 	}
-
-	// ------------------------------------------------------
-	// Verify the Bolt Snapshot's VB-seqMax mappings.
 	expectedMappings = make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {
 		expectedMappings[i] = 4
@@ -3109,7 +3085,6 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
 	}
-	s := idx.(*Scorch)
 	s, ok := idx.(*Scorch)
 	if !ok {
 		t.Fatalf("expected *Scorch, got %T", s)
@@ -3119,16 +3094,17 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	// create 2 docs
-	doc1 := genDoc(t)
-	doc2 := genDoc(t)
-	doc3 := genDoc(t)
-	docs := []index.Document{doc1, doc2, doc3}
-	ids := []string{doc1.ID(), doc2.ID(), doc3.ID()}
-
-	// introduce 3 segments with 1 doc each
-	for i := 0; i < 3; i++ {
+	const (
+		numDocs = 3
+	)
+	docs := make([]index.Document, numDocs)
+	ids := make([]string, numDocs)
+	for i := 0; i < numDocs; i++ {
+		doc := genDoc(t)
+		docs[i] = doc
+		ids[i] = doc.ID()
+	}
+	for i := 0; i < numDocs; i++ {
 		doc := docs[i]
 		id := ids[i]
 		seg, _, err := s.segPlugin.New([]index.Document{doc})
@@ -3146,16 +3122,14 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 		}
 	}
 	snapshot := s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected %d segments, got %d", 3, len(snapshot.segment))
+	if len(snapshot.segment) != numDocs {
+		t.Fatalf("expected %d segments, got %d", numDocs, len(snapshot.segment))
 	}
 	for _, seg := range snapshot.segment {
 		if seg.Count() != 1 {
 			t.Fatalf("expected %d docs, got %d", 1, seg.Count())
 		}
 	}
-
-	// persist the snapshot
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
@@ -3173,17 +3147,15 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 		}
 		doneCh <- struct{}{}
 	}()
-
 	select {
 	case merge := <-s.merges:
-		// introduce another batch deleting the 3 docs, resulting in a skipped merge
-		intro2 := &segmentIntroduction{
+		intro := &segmentIntroduction{
 			id:      atomic.AddUint64(&s.nextSegmentID, 1),
 			data:    nil,
 			ids:     ids,
 			applied: make(chan error),
 		}
-		if err = s.introduceSegment(intro2); err != nil {
+		if err = s.introduceSegment(intro); err != nil {
 			t.Fatalf("introduceSegment: %v", err)
 		}
 		snapshot = s.root
@@ -3197,12 +3169,10 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 		if docCount != 0 {
 			t.Fatalf("expected %d docs, got %d", 0, docCount)
 		}
-		// now we allow the merge to happen, which will result in a skipped merge
 		s.introduceMerge(merge)
 	case err := <-errCh:
 		t.Fatalf("unexpected error during persist: %v", err)
 	}
-
 	select {
 	case persist := <-s.persists:
 		s.introducePersist(persist)
@@ -3210,18 +3180,16 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 		t.Fatalf("unexpected error during persist: %v", err)
 	}
 	<-doneCh
-
-	// verify that the root now contains 0 segments
 	snapshot = s.root
 	if len(snapshot.segment) != 0 {
-		t.Errorf("expected %d segments, got %d", 0, len(snapshot.segment))
+		t.Fatalf("expected %d segments, got %d", 0, len(snapshot.segment))
 	}
 	docCount, err := snapshot.DocCount()
 	if err != nil {
-		t.Errorf("failed to get doc count: %v", err)
+		t.Fatalf("failed to get doc count: %v", err)
 	}
 	if docCount != 0 {
-		t.Errorf("expected %d docs, got %d", 0, docCount)
+		t.Fatalf("expected %d docs, got %d", 0, docCount)
 	}
 	s.removeOldData()
 	files, err := os.ReadDir(dirPath)
@@ -3234,16 +3202,13 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 			numZapFiles++
 		}
 	}
-	if numZapFiles != 3 {
-		t.Errorf("expected %d zap files, got %d", 3, numZapFiles)
+	if numZapFiles != numDocs {
+		t.Fatalf("expected %d zap files, got %d", numDocs, numZapFiles)
 	}
-
-	// close the index now, and reopen it to verify that the persisted state is correct
 	err = idx.Close()
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
 	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
@@ -3258,15 +3223,15 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
 	snapshot = s.root
-	if len(snapshot.segment) != 3 {
-		t.Errorf("expected %d segments, got %d", 0, len(snapshot.segment))
+	if len(snapshot.segment) != numDocs {
+		t.Fatalf("expected %d segments, got %d", numDocs, len(snapshot.segment))
 	}
 	docCount, err = snapshot.DocCount()
 	if err != nil {
-		t.Errorf("failed to get doc count: %v", err)
+		t.Fatalf("failed to get doc count: %v", err)
 	}
-	if docCount != 3 {
-		t.Errorf("expected %d docs, got %d", 0, docCount)
+	if docCount != numDocs {
+		t.Fatalf("expected %d docs, got %d", numDocs, docCount)
 	}
 	files, err = os.ReadDir(dirPath)
 	if err != nil {
@@ -3278,7 +3243,11 @@ func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
 			numZapFiles++
 		}
 	}
-	if numZapFiles != 3 {
-		t.Errorf("expected %d zap files, got %d", 3, numZapFiles)
+	if numZapFiles != numDocs {
+		t.Fatalf("expected %d zap files, got %d", numDocs, numZapFiles)
+	}
+	err = idx.Close()
+	if err != nil {
+		t.Fatalf("failed to close index: %v", err)
 	}
 }

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -15,8 +15,8 @@
 package scorch
 
 import (
-	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -2812,244 +2813,50 @@ func TestPersistorMergerOptions(t *testing.T) {
 	}
 }
 
-// TestPersistenceExclude tests that when we persist a snapshot, and exclude a
-// segment from being persisted, this means that any close and reopen of the index
-// will not retain the excluded segment since it was volatile and not updated in
-// the bolt storage. On reopen we check whether the addtional data associated with
-// the segment like the internal values are also not retained, since they're also
-// volatile.
-func TestPersistenceExclude(t *testing.T) {
-	// Setup config and analysis queue
-	cfg := CreateConfig("TestPersistenceExclude")
-	err := InitTest(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = DestroyTest(cfg)
-	}()
-
-	os.Mkdir(cfg["path"].(string), 0o755)
-
-	analysisQueue := index.NewAnalysisQueue(1)
-	idx, err := NewScorch(Name, cfg, analysisQueue)
-	if err != nil {
-		t.Fatalf("failed to create Scorch: %v", err)
-	}
-	s, ok := idx.(*Scorch)
-	if !ok {
-		t.Fatalf("expected *Scorch, got %T", s)
-	}
-
-	s.path = cfg["path"].(string)
-	err = s.openBolt()
-	if err != nil {
-		t.Fatalf("failed to open bolt: %v", err)
-	}
-
-	testDocs := [][]string{
-		{"doc1", "doc2"},
-		{"doc3", "doc4"},
-		{"doc5", "doc6"},
-	}
-
-	internalTestVals := []map[string][]byte{
-		{
-			"i1": []byte("v1"),
-			"i2": []byte("v2"),
-		},
-		{
-			"i3": []byte("v3"),
-			"i4": []byte("v4"),
-		},
-		{
-			"i5": []byte("v5"),
-			"i6": []byte("v6"),
-		},
-	}
-
-	// introduce 3 segments with 2 documents each, and no deletions
-	for i := 0; i < 3; i++ {
-		docs := make([]index.Document, 0, len(testDocs[i]))
-		for _, docID := range testDocs[i] {
-			doc := document.NewDocument(docID)
-			doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-			doc.AddIDField()
-			// analyze the document to create a segment
-			doc.VisitFields(func(field index.Field) {
-				field.Analyze()
-			})
-			docs = append(docs, doc)
-		}
-		seg, _, err := s.segPlugin.New(docs)
-		if err != nil {
-			t.Fatalf("failed to create segment: %v", err)
-		}
-		// Prepare segmentIntroduction
-		intro := &segmentIntroduction{
-			id:       atomic.AddUint64(&s.nextSegmentID, 1),
-			data:     seg,
-			ids:      testDocs[i],
-			internal: internalTestVals[i],
-			applied:  make(chan error),
-		}
-
-		err = s.introduceSegment(intro)
-		if err != nil {
-			t.Fatalf("introduceSegment failed: %v", err)
-		}
-	}
-
-	// current snapshot should have 3 segments, each with 2 documents, and no deletions
-	snapshot := s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
-	}
-	for i, seg := range snapshot.segment {
-		if seg.Count() != 2 {
-			t.Fatalf("expected 2 documents in segment, got %d", seg.Count())
-		}
-
-		dict, err := seg.segment.Dictionary("_id")
-		if err != nil {
-			t.Fatalf("failed to get dictionary: %v", err)
-		}
-		// verify the _id field has the correct docID
-		for _, docID := range testDocs[i] {
-			cont, err := dict.Contains([]byte(docID))
-			if err != nil {
-				t.Fatalf("failed to check dictionary for docID %s: %v", docID, err)
-			}
-			if !cont {
-				t.Fatalf("expected to find docID %s in segment, but not found", docID)
-			}
-		}
-	}
-	// persist the snapshot, which will create a new snapshot with 2 persisted segments
-	// listen to persists channel and update root with the new snapshot
-	var errCh = make(chan error, 1)
-	var doneCh = make(chan struct{})
-	go func() {
-		// avoid persisting the last segment
-		exclude := map[uint64]struct{}{
-			snapshot.segment[2].id: {},
-		}
-		err := s.persistSnapshotDirect(snapshot, exclude)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		doneCh <- struct{}{}
-	}()
-
-	select {
-	case persist := <-s.persists:
-		s.introducePersist(persist)
-	case err := <-errCh:
-		t.Fatalf("unexpected error during persist: %v", err)
-	}
-
-	<-doneCh
-
-	snapshot = s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
-	}
-
-	// doc5, doc6
-	lastSeg := snapshot.segment[2]
-	if lastSeg.Count() != 2 {
-		t.Fatalf("expected 2 documents in last segment, got %d", lastSeg.Count())
-	}
-
-	reader, err := idx.Reader()
-	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
-	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err := reader.GetInternal([]byte("i1"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// check the last segment's internal value
-	val, err = reader.GetInternal([]byte("i5"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if !bytes.Equal(val, internalTestVals[2]["i5"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[2]["i5"], val)
-	}
-
-	// close the index, the last segment data shouldn't be persisted
-	err = idx.Close()
-	if err != nil {
-		t.Fatalf("failed to close index: %v", err)
-	}
-
-	// open it back up, the index loaded doesn't have the last segment in it
-	idx2, err := NewScorch(Name, cfg, analysisQueue)
-	if err != nil {
-		t.Fatalf("failed to create Scorch: %v", err)
-	}
-	defer idx2.Close()
-
-	s2, ok := idx2.(*Scorch)
-	if !ok {
-		t.Fatalf("expected *Scorch, got %T", s2)
-	}
-	s2.path = cfg["path"].(string)
-	err = s2.openBolt()
-	if err != nil {
-		t.Fatalf("failed to open bolt: %v", err)
-	}
-
-	// only 2 segments were persisted
-	if len(s2.root.segment) != 2 {
-		t.Fatalf("expected 2 segments in root, got %d", len(s2.root.segment))
-	}
-
-	reader, err = idx2.Reader()
-	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
-	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err = reader.GetInternal([]byte("i1"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// last segment's internal value shouldn't be there since it was never persisted
-	val, err = reader.GetInternal([]byte("i5"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if val != nil {
-		t.Fatalf("expected internal value to be nil, got %s", val)
-	}
+// genDoc generates a random document with a random ID and a single field "name" with value "test".
+func genDoc(t *testing.T) index.Document {
+	t.Helper()
+	randNum := rand.Intn(1000000)
+	doc := document.NewDocument(fmt.Sprintf("test%d", randNum))
+	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
+	doc.AddIDField()
+	doc.VisitFields(func(field index.Field) {
+		field.Analyze()
+	})
+	return doc
 }
 
-// TestPersistenceWithoutExclude is homologous to TestPersistenceExclude but tests
-// persistence without excluding any segments and introducing another segment after
-// persistence works as expected, in the sense that we don't retain the volatile segment
-// since the next persister cycle never ran
-func TestPersistenceWithoutExclude(t *testing.T) {
-	// Setup config and analysis queue
-	cfg := CreateConfig("TestPersistenceWithoutExclude")
+// getBatches generates a list of index.Batches.
+// 1. for each VB, create a batch with a random doc
+// 2. merge all the batches into a single batch
+// 3. repeat until numBatches is reached
+func getBatches(t *testing.T, numVB int, numBatches int) []*index.Batch {
+	t.Helper()
+	batches := make([]*index.Batch, 0, numBatches)
+	vbSeqNumbers := make([]uint64, numVB)
+	for i := 0; i < numVB; i++ {
+		vbSeqNumbers[i] = 0
+	}
+	for i := 0; i < numBatches; i++ {
+		mergedBatch := index.NewBatch()
+		for j := 0; j < numVB; j++ {
+			vbBatch := index.NewBatch()
+			doc := genDoc(t)
+			vbBatch.Update(doc)
+			vbKey := fmt.Sprintf("%d", j)
+			vbValue := make([]byte, 8)
+			binary.BigEndian.PutUint64(vbValue, vbSeqNumbers[j])
+			vbBatch.SetInternal([]byte(vbKey), vbValue)
+			vbSeqNumbers[j]++
+			mergedBatch.Merge(vbBatch)
+		}
+		batches = append(batches, mergedBatch)
+	}
+	return batches
+}
+
+func TestPersistenceMergedBatches(t *testing.T) {
+	cfg := CreateConfig("TestPersistenceMergedBatches")
 	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -3076,90 +2883,53 @@ func TestPersistenceWithoutExclude(t *testing.T) {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
 
-	testDocs := [][]string{
-		{"doc1", "doc2"},
-		{"doc3", "doc4"},
-		{"doc5", "doc6"},
-	}
+	const (
+		numSegments = 5
+		numVBs      = 5
+	)
 
-	internalTestVals := []map[string][]byte{
-		{
-			"i1": []byte("v1"),
-			"i2": []byte("v2"),
-		},
-		{
-			"i3": []byte("v3"),
-			"i4": []byte("v4"),
-		},
-		{
-			"i5": []byte("v5"),
-			"i6": []byte("v6"),
-		},
-	}
+	batches := getBatches(t, numVBs, numSegments)
 
-	// introduce 2 segments with 2 documents each, and no deletions
-	for i := 0; i < 2; i++ {
-		docs := make([]index.Document, 0, len(testDocs[i]))
-		for _, docID := range testDocs[i] {
-			doc := document.NewDocument(docID)
-			doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-			doc.AddIDField()
-			// analyze the document to create a segment
-			doc.VisitFields(func(field index.Field) {
-				field.Analyze()
-			})
-			docs = append(docs, doc)
+	for i := 0; i < numSegments; i++ {
+		batch := batches[i]
+
+		var docs []index.Document
+		var ids []string
+		for _, doc := range batch.IndexOps {
+			if doc != nil {
+				docs = append(docs, doc)
+			}
+			ids = append(ids, doc.ID())
 		}
+
 		seg, _, err := s.segPlugin.New(docs)
 		if err != nil {
-			t.Fatalf("failed to create segment: %v", err)
+			t.Fatalf("failed to create segment %d: %v", i, err)
 		}
-		// Prepare segmentIntroduction
+
 		intro := &segmentIntroduction{
 			id:       atomic.AddUint64(&s.nextSegmentID, 1),
 			data:     seg,
-			ids:      testDocs[i],
-			internal: internalTestVals[i],
-			applied:  make(chan error, 1),
+			ids:      ids,
+			internal: batch.InternalOps,
+			applied:  make(chan error),
 		}
-
 		err = s.introduceSegment(intro)
 		if err != nil {
-			t.Fatalf("introduceSegment failed: %v", err)
+			t.Fatalf("introduceSegment %d failed: %v", i, err)
 		}
 	}
 
-	// current snapshot should have 2 segments, each with 2 documents, and no deletions
 	snapshot := s.root
-	if len(snapshot.segment) != 2 {
-		t.Fatalf("expected 2 segments, got %d", len(snapshot.segment))
+	if len(snapshot.segment) != numSegments {
+		t.Fatalf("expected %d segments, got %d", numSegments, len(snapshot.segment))
 	}
-	for i, seg := range snapshot.segment {
-		if seg.Count() != 2 {
-			t.Fatalf("expected 2 documents in segment, got %d", seg.Count())
-		}
 
-		dict, err := seg.segment.Dictionary("_id")
-		if err != nil {
-			t.Fatalf("failed to get dictionary: %v", err)
-		}
-		// verify the _id field has the correct docID
-		for _, docID := range testDocs[i] {
-			cont, err := dict.Contains([]byte(docID))
-			if err != nil {
-				t.Fatalf("failed to check dictionary for docID %s: %v", docID, err)
-			}
-			if !cont {
-				t.Fatalf("expected to find docID %s in segment, but not found", docID)
-			}
-		}
-	}
-	// persist the snapshot, which will create a new snapshot with 2 persisted segments
-	// listen to persists channel and update root with the new snapshot
+	// persist only the first 2 segments, and exclude the last 3 segments from being persisted.
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
-		err := s.persistSnapshotDirect(snapshot, nil)
+		err := s.persistSnapshotDirect(snapshot)
 		if err != nil {
 			errCh <- err
 			return
@@ -3176,79 +2946,90 @@ func TestPersistenceWithoutExclude(t *testing.T) {
 
 	<-doneCh
 
-	docs := make([]index.Document, 0, 2)
-	for _, docID := range testDocs[2] {
-		doc := document.NewDocument(docID)
-		doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-		doc.AddIDField()
-		// analyze the document to create a segment
-		doc.VisitFields(func(field index.Field) {
-			field.Analyze()
-		})
-		docs = append(docs, doc)
-	}
+	// validate our snapshot's VB-seqMax mappings.
+	/*
+		Each Merged Batch has the following VB-seqMax mappings:
+		Each VB has its own batch, and when flushed to scorch, all 5 batches are merged into a single batch.
+			Batch 0:
+				0 - 0
+				1 - 0
+				2 - 0
+				3 - 0
+				4 - 0
+			Batch 1:
+				0 - 1
+				1 - 1
+				2 - 1
+				3 - 1
+				4 - 1
+			Batch 2:
+				0 - 2
+				1 - 2
+				2 - 2
+				3 - 2
+				4 - 2
+			Batch 3:
+				0 - 3
+				1 - 3
+				2 - 3
+				3 - 3
+				4 - 3
+			Batch 4:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		We expect that after persistance, the VB-seqMax mappings will be as follows:
+		1. In the Bolt Snapshot:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		2. In the in-memory snapshot:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		This is because we MUST ensure that the
+		    - In-memory snapshot and Persisted snapshot are in sync with each other.
+			- The VB-seqMax mappings always pick the highest sequence number for each VB.
+	*/
 
-	seg, _, err := s.segPlugin.New(docs)
-	if err != nil {
-		t.Fatalf("failed to create segment: %v", err)
+	// ------------------------------------------------------
+	// Verify the in-memory snapshot's VB-seqMax mappings.
+	expectedMappings := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		expectedMappings[i] = 4
 	}
-	intro := &segmentIntroduction{
-		id:       atomic.AddUint64(&s.nextSegmentID, 1),
-		data:     seg,
-		ids:      testDocs[2],
-		internal: internalTestVals[2],
-		applied:  make(chan error, 1),
-	}
-
-	err = s.introduceSegment(intro)
-	if err != nil {
-		t.Fatalf("introduceSegment failed: %v", err)
-	}
-
-	snapshot = s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
-	}
-
-	// doc5, doc6
-	lastSeg := snapshot.segment[2]
-	if lastSeg.Count() != 2 {
-		t.Fatalf("expected 2 documents in last segment, got %d", lastSeg.Count())
-	}
-
 	reader, err := idx.Reader()
 	if err != nil {
 		t.Fatalf("failed to get reader: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err := reader.GetInternal([]byte("i1"))
+	actualMappings := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		vbKey := []byte(strconv.Itoa(i))
+		val, err := reader.GetInternal(vbKey)
+		if err != nil {
+			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
+		}
+		actualMappings[i] = binary.BigEndian.Uint64(val)
+	}
+	if !slices.Equal(expectedMappings, actualMappings) {
+		t.Fatalf("expected in-memory snapshot VB-seqMax mappings %v, got %v", expectedMappings, actualMappings)
+	}
+	err = reader.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to close reader: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// check the last segment's internal value
-	val, err = reader.GetInternal([]byte("i5"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if !bytes.Equal(val, internalTestVals[2]["i5"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[2]["i5"], val)
-	}
-
-	// close the index, the last segment data shouldn't be persisted
 	err = idx.Close()
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
-	// open it back up, the index loaded doesn't have the last segment in it
+	// ------------------------------------------------------
+	// reopen the index and verify that the persisted state is correct
 	idx2, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
@@ -3262,35 +3043,42 @@ func TestPersistenceWithoutExclude(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	// only 2 segments were persisted
 	if len(s2.root.segment) != 2 {
-		t.Fatalf("expected 2 segments in root, got %d", len(s2.root.segment))
+		t.Fatalf("expected 2 segments in root after reopen, got %d", len(s2.root.segment))
 	}
-
-	reader, err = idx2.Reader()
+	reader2, err := idx2.Reader()
 	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
+		t.Fatalf("failed to get reader after reopen: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err = reader.GetInternal([]byte("i1"))
+	// ------------------------------------------------------
+	// Verify the Bolt Snapshot's VB-seqMax mappings.
+	expectedMappings2 := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		expectedMappings2[i] = 1
+	}
+	actualMappings2 := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		vbKey := []byte(strconv.Itoa(i))
+		val, err := reader2.GetInternal(vbKey)
+		if err != nil {
+			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
+		}
+		if val == nil {
+			actualMappings2[i] = 0
+		} else {
+			actualMappings2[i] = binary.BigEndian.Uint64(val)
+		}
+	}
+	if !slices.Equal(expectedMappings2, actualMappings2) {
+		t.Fatalf("expected Bolt snapshot VB-seqMax mappings %v, got %v", expectedMappings2, actualMappings2)
+	}
+	err = reader2.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to close reader: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// last segment's internal value shouldn't be there since it was never persisted
-	val, err = reader.GetInternal([]byte("i5"))
+	err = idx2.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to close index: %v", err)
 	}
-
-	if val != nil {
-		t.Fatalf("expected internal value to be nil, got %s", val)
-	}
+	// ------------------------------------------------------
 }

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -2925,7 +2925,6 @@ func TestPersistenceMergedBatches(t *testing.T) {
 		t.Fatalf("expected %d segments, got %d", numSegments, len(snapshot.segment))
 	}
 
-	// persist only the first 2 segments, and exclude the last 3 segments from being persisted.
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -3043,8 +3043,8 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-	if len(s2.root.segment) != 2 {
-		t.Fatalf("expected 2 segments in root after reopen, got %d", len(s2.root.segment))
+	if len(s2.root.segment) != 5 {
+		t.Fatalf("expected 5 segments in root after reopen, got %d", len(s2.root.segment))
 	}
 	reader2, err := idx2.Reader()
 	if err != nil {
@@ -3054,7 +3054,7 @@ func TestPersistenceMergedBatches(t *testing.T) {
 	// Verify the Bolt Snapshot's VB-seqMax mappings.
 	expectedMappings2 := make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {
-		expectedMappings2[i] = 1
+		expectedMappings2[i] = 4
 	}
 	actualMappings2 := make([]uint64, numVBs)
 	for i := 0; i < numVBs; i++ {

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -956,7 +956,7 @@ func (is *IndexSnapshot) CopyTo(d index.Directory) error {
 		return err
 	}
 
-	_, _, err = prepareBoltSnapshot(is, tx, "", is.parent.segPlugin, nil, d)
+	_, _, err = prepareBoltSnapshot(is, tx, "", is.parent.segPlugin, d)
 	if err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("error backing up index snapshot: %v", err)

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -42,11 +42,6 @@ type SegmentSnapshot struct {
 	creator string
 	stats   *fieldStats
 
-	// if this segment is in-memory then we'll try to undo the internal values
-	// in the indexSnapshot internal map before updating the bolt, since its
-	// supposed to be reflective of the on-disk data.
-	internal map[string][]byte
-
 	cachedMeta *cachedMeta
 
 	cachedDocs *cachedDocs


### PR DESCRIPTION
- In the current batch flush architecture, we employ a fixed number of persister workers each operating on a fixed number of segments based on the total size of the batch.
- Current algorithm:

>    **Inputs:** $N$ unpersisted segments, $P$ persister workers, $M$ max bytes per batch.
>   
>    **Partition:** Greedily assign segments to $P$ batches such that $dataSize(batch_i) \leq M$,
>    yielding batches with $K_1, K_2, \ldots, K_P$ segments where $\sum_{i=1}^{P} K_i \leq N$.
>    
>    **Merge:** Concurrently merge each batch, producing $P$ merged segments.
>    
>    **Persist:** Persist the $P$ merged segments; exclude the remaining
>    $N - \sum_{i=1}^{P} K_i$ segments from this persistence round.

- This breaks an invariant as we will persist the index snapshot which has the VB-SeqMax mapping of the unpersisted segments as well, leading to data loss if the index is reopened.
- An attempt to fix this issue was done in https://github.com/blevesearch/bleve/pull/2296, but this was not a complete fix, as it would completely erase the VB-SeqMax mapping from the persisted bolt snapshot based on the excluded unpersisted segment's vbucket, leading to bolt corruption, as we merge batches before dispatching them to scorch. 
- It must be noted that the index snapshot stores the max sequence number for each vbucket based on the overall set of segment snapshots, allowing us to have multiple batches contributing to the same vbucket.
- This PR, first off, reverts https://github.com/blevesearch/bleve/pull/2296.
- Second, we introduce a new algorithm for batch flush.

> **Inputs:** $N$ unpersisted segments, $P$ persister workers, $M$ max bytes per batch.
>
> **Partition:** Greedily assign all $N$ segments into $Q$ batches such that $dataSize(batch_i) \leq M$,
> yielding batches with $K_1, K_2, \ldots, K_{Q}$ segments where $\sum_{i=1}^{Q} K_i = N$
>
> **Merge:** Concurrently merge all $Q$ batches using a semaphore of size $P$,
> producing $Q$ merged segments.
>
> **Persist:** Persist all $Q$ merged segments; no segments are excluded.

- The main difference here is that we do NOT exclude any segment from persistence, ensuring that the persisted segment snapshots and the bolt store always remain in sync, eliminating index corruption, as the VB-SeqMax mapping will always be valid now.
- Add missing validation for persister worker config.
- Fixed a bug where we leak files when we skip introducing segments when performing in-memory segments.
- Fixed a bug where the field stats was not being persisted post merging in-memory segments, leading to loss of the stat upon reopening the index.
- Fixed a bug where the merger could remove a file which was being used by the persister to merge and persist in-memory segments.