### PR TITLE
MB-70770: Do not exclude segments from persistence

### DIFF
--- a/index/scorch/builder.go
+++ b/index/scorch/builder.go
@@ -303,7 +303,7 @@ func (o *Builder) Close() error {
 	}
 
 	// fill the root bolt with this fake index snapshot
-	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil, nil)
+	_, _, err = prepareBoltSnapshot(is, tx, o.path, o.segPlugin, nil)
 	if err != nil {
 		_ = tx.Rollback()
 		_ = rootBolt.Close()

--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -32,7 +32,6 @@ type segmentIntroduction struct {
 	obsoletes map[uint64]*roaring.Bitmap
 	ids       []string
 	internal  map[string][]byte
-	stats     *fieldStats
 
 	applied           chan error
 	persisted         chan error
@@ -154,7 +153,6 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 			cachedDocs: root.segment[i].cachedDocs,
 			cachedMeta: root.segment[i].cachedMeta,
 			creator:    root.segment[i].creator,
-			internal:   root.segment[i].internal,
 		}
 
 		// apply new obsoletions
@@ -197,13 +195,16 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 
 	// append new segment, if any, to end of the new index snapshot
 	if next.data != nil {
+		stats := newFieldStats()
+		if fsr, ok := next.data.(segment.FieldStatsReporter); ok {
+			fsr.UpdateFieldStats(stats)
+		}
 		newSegmentSnapshot := &SegmentSnapshot{
 			id:         next.id,
 			segment:    next.data, // take ownership of next.data's ref-count
-			stats:      next.stats,
+			stats:      stats,
 			cachedDocs: &cachedDocs{cache: nil},
 			cachedMeta: newCachedMeta(),
-			internal:   make(map[string][]byte),
 			creator:    "introduceSegment",
 		}
 		newSnapshot.segment = append(newSnapshot.segment, newSegmentSnapshot)
@@ -213,12 +214,6 @@ func (s *Scorch) introduceSegment(next *segmentIntroduction) error {
 		// queued for persistence.
 		atomic.AddUint64(&s.stats.TotIntroducedItems, newSegmentSnapshot.Count())
 		atomic.AddUint64(&s.stats.TotIntroducedSegmentsBatch, 1)
-
-		// track the internal values of this segment so that when we update the
-		// bolt we keep the internal values in sync with the segments on disk, and
-		// if this segment didn't get persisted we need to undo that info from the
-		// indexSnapshot's internal map as part of the bolt update.
-		newSegmentSnapshot.internal = next.internal
 	}
 	// copy old values
 	for key, oldVal := range root.internal {
@@ -388,7 +383,7 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				for deletedSinceItr.HasNext() {
 					oldDocNum := deletedSinceItr.Next()
 					newDocNum := segSnapAtMerge.oldNewDocIDs[oldDocNum]
-					newSegmentDeleted[segSnapAtMerge.workerID].Add(uint32(newDocNum))
+					newSegmentDeleted[segSnapAtMerge.flushID].Add(uint32(newDocNum))
 				}
 			}
 
@@ -407,7 +402,6 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				cachedDocs: root.segment[i].cachedDocs,
 				cachedMeta: root.segment[i].cachedMeta,
 				creator:    root.segment[i].creator,
-				internal:   root.segment[i].internal,
 			})
 			root.segment[i].segment.AddRef()
 			newSnapshot.offsets = append(newSnapshot.offsets, running)
@@ -436,12 +430,12 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 			for obsoletedIter.HasNext() {
 				oldDocNum := obsoletedIter.Next()
 				newDocNum := ss.oldNewDocIDs[oldDocNum]
-				newSegmentDeleted[ss.workerID].Add(uint32(newDocNum))
+				newSegmentDeleted[ss.flushID].Add(uint32(newDocNum))
 			}
 		}
 	}
 
-	skipped := true
+	skipped := make([]bool, len(nextMerge.new))
 	// make the newly merged segments part of the newSnapshot being constructed
 	for i, newMergedSegment := range nextMerge.new {
 		// checking if this newly merged segment is worth keeping based on
@@ -474,14 +468,12 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 				docsToPersistCount += newMergedSegment.Count() - newSegmentDeleted[i].GetCardinality()
 				memSegments++
 			}
-			skipped = false
+			atomic.AddUint64(&s.stats.TotIntroducedSegmentsMerge, 1)
+			skipped[i] = false
+		} else {
+			atomic.AddUint64(&s.stats.TotFileMergeIntroductionsObsoleted, 1)
+			skipped[i] = true
 		}
-	}
-
-	if skipped {
-		atomic.AddUint64(&s.stats.TotFileMergeIntroductionsObsoleted, 1)
-	} else {
-		atomic.AddUint64(&s.stats.TotIntroducedSegmentsMerge, uint64(len(nextMerge.new)))
 	}
 
 	atomic.StoreUint64(&s.stats.TotItemsToPersist, docsToPersistCount)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -16,6 +16,7 @@ package scorch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -369,15 +370,14 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 
 		for _, planSegment := range task.Segments {
 			if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
-				mergedSegHistory[segSnapshot.id] = &mergedSegmentHistory{
-					workerID:   0,
-					oldSegment: segSnapshot,
-				}
 				if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
 					if segSnapshot.LiveSize() == 0 {
 						atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
-						delete(mergedSegHistory, segSnapshot.id)
 					} else {
+						mergedSegHistory[segSnapshot.id] = &mergedSegmentHistory{
+							flushID:    0,
+							oldSegment: segSnapshot,
+						}
 						segmentsToMerge = append(segmentsToMerge, segSnapshot.segment)
 						docsToDrop = append(docsToDrop, segSnapshot.deleted)
 					}
@@ -445,7 +445,6 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 			id:               []uint64{newSegmentID},
 			mergedSegHistory: mergedSegHistory,
 			new:              []segment.Segment{seg},
-			newCount:         seg.Count(),
 			notifyCh:         make(chan *mergeTaskIntroStatus),
 			mmaped:           1,
 		}
@@ -474,10 +473,10 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 		atomic.AddUint64(&s.stats.TotFileMergeIntroductionsDone, 1)
 		if introStatus != nil && introStatus.indexSnapshot != nil {
 			_ = introStatus.indexSnapshot.DecRef()
-			if introStatus.skipped {
+			if introStatus.skipped[0] {
 				// close the segment on skipping introduction.
-				s.unmarkIneligibleForRemoval(filename)
 				_ = seg.Close()
+				s.unmarkIneligibleForRemoval(filename)
 			}
 		}
 
@@ -498,14 +497,14 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 
 type mergeTaskIntroStatus struct {
 	indexSnapshot *IndexSnapshot
-	skipped       bool
+	skipped       []bool
 }
 
 // this is important when it comes to introducing multiple merged segments in a
 // single introducer channel push. That way there is a check to ensure that the
 // file count doesn't explode during the index's lifetime.
 type mergedSegmentHistory struct {
-	workerID     uint64
+	flushID      uint64
 	oldNewDocIDs []uint64
 	oldSegment   *SegmentSnapshot
 }
@@ -516,7 +515,6 @@ type segmentMerge struct {
 	mergedSegHistory map[uint64]*mergedSegmentHistory
 	notifyCh         chan *mergeTaskIntroStatus
 	mmaped           uint32
-	newCount         uint64
 }
 
 func cumulateBytesRead(sbs []segment.Segment) uint64 {
@@ -527,67 +525,54 @@ func cumulateBytesRead(sbs []segment.Segment) uint64 {
 	return rv
 }
 
-func closeNewMergedSegments(segs []segment.Segment) error {
-	for _, seg := range segs {
-		if seg != nil {
-			_ = seg.DecRef()
-		}
-	}
-	return nil
-}
-
 // mergeAndPersistInMemorySegments takes an IndexSnapshot and a list of in-memory segments,
 // which are merged and persisted to disk concurrently. These are then introduced as
 // the new root snapshot in one-shot.
 func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
-	flushableObjs []*flushable) (*IndexSnapshot, []uint64, error) {
+	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
 	memMergeZapStartTime := time.Now()
 
 	atomic.AddUint64(&s.stats.TotMemMergeZapBeg, 1)
 
-	var wg sync.WaitGroup
-	// we're tracking the merged segments and their doc number per worker
+	// we're tracking the merged segments and their doc number per batch
 	// to be able to introduce them all at once, so the first dimension of the
-	// slices here correspond to workerID
-	newDocIDsSet := make([][][]uint64, len(flushableObjs))
-	newMergedSegments := make([]segment.Segment, len(flushableObjs))
-	newMergedSegmentIDs := make([]uint64, len(flushableObjs))
-	numFlushes := len(flushableObjs)
+	// slices here correspond to flushID
+	numFlushes := len(flushes)
+	newDocIDsSet := make([][][]uint64, numFlushes)
+	newMergedSegmentIDs := make([]uint64, numFlushes)
+	newMergedSegmentFileNames := make([]string, numFlushes)
+	newMergedSegments := make([]segment.Segment, numFlushes)
 	var numSegments, newMergedCount uint64
 	var em sync.Mutex
 	var errs []error
 
-	// deploy the workers to merge and flush the batches of segments concurrently
-	// and create a new file segment
-	for i := 0; i < numFlushes; i++ {
+	// create a semaphore of the number of configured persister workers
+	// and a waitgroup to wait for all the flushes to complete
+	sem := make(chan struct{}, po.NumPersisterWorkers)
+	var wg sync.WaitGroup
+	for flushID := 0; flushID < numFlushes; flushID++ {
 		wg.Add(1)
-		go func(segsBatch []segment.Segment, dropsBatch []*roaring.Bitmap, id int) {
-			defer wg.Done()
+		sem <- struct{}{}
+		go func(flushID int) {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
 			newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
 			filename := zapFileName(newSegmentID)
 			path := s.path + string(os.PathSeparator) + filename
 
-			// the newly merged segment is already flushed out to disk, just needs
-			// to be opened using mmap.
-			newDocIDs, _, err :=
-				s.segPlugin.MergeUsing(segsBatch, dropsBatch, path, s.closeCh, s, s.segmentConfig)
-			if err != nil {
-				em.Lock()
-				errs = append(errs, err)
-				em.Unlock()
-				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
-				return
-			}
 			// to prevent accidental cleanup of this newly created file, mark it
 			// as ineligible for removal. this will be flipped back when the bolt
 			// is updated - which is valid, since the snapshot updated in bolt is
 			// cleaned up only if its zero ref'd (MB-66163 for more details)
 			s.markIneligibleForRemoval(filename)
-			newMergedSegmentIDs[id] = newSegmentID
-			newDocIDsSet[id] = newDocIDs
-			newMergedSegments[id], err = s.segPlugin.OpenUsing(path, s.segmentConfig)
+
+			// the newly merged segment is already flushed out to disk, just needs
+			// to be opened using mmap.
+			newDocIDs, _, err := s.segPlugin.MergeUsing(flushes[flushID].sbsBatch, flushes[flushID].sbsBatchDrops, path, s.closeCh, s, s.segmentConfig)
 			if err != nil {
 				em.Lock()
 				errs = append(errs, err)
@@ -595,15 +580,33 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			atomic.AddUint64(&newMergedCount, newMergedSegments[id].Count())
-			atomic.AddUint64(&numSegments, uint64(len(segsBatch)))
-		}(flushableObjs[i].segments, flushableObjs[i].drops, i)
+			newDocIDsSet[flushID] = newDocIDs
+			newMergedSegmentIDs[flushID] = newSegmentID
+			newMergedSegmentFileNames[flushID] = filename
+			newMergedSegments[flushID], err = s.segPlugin.OpenUsing(path, s.segmentConfig)
+			if err != nil {
+				em.Lock()
+				errs = append(errs, err)
+				em.Unlock()
+				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
+				return
+			}
+			atomic.AddUint64(&newMergedCount, newMergedSegments[flushID].Count())
+			atomic.AddUint64(&numSegments, uint64(len(flushes[flushID].sbsBatch)))
+		}(flushID)
 	}
 	wg.Wait()
+	close(sem)
 
+	// if any of the flushes failed, close the newly merged segments and return the error
 	if errs != nil {
-		// close the new merged segments
-		_ = closeNewMergedSegments(newMergedSegments)
+		// close all merged segments and flip their ineligible for removal flag
+		for flushID := 0; flushID < numFlushes; flushID++ {
+			if newMergedSegments[flushID] != nil {
+				_ = newMergedSegments[flushID].Close()
+			}
+			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
+		}
 		var errf error
 		for _, err := range errs {
 			if err == segment.ErrClosed {
@@ -612,13 +615,12 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 				// so its safe to early exit the same error.
 				return nil, nil, err
 			}
-			errf = fmt.Errorf("%w; %v", errf, err)
+			errf = errors.Join(errf, err)
 		}
 		return nil, nil, errf
 	}
 
 	atomic.AddUint64(&s.stats.TotMemMergeZapEnd, 1)
-
 	memMergeZapTime := uint64(time.Since(memMergeZapStartTime))
 	atomic.AddUint64(&s.stats.TotMemMergeZapTime, memMergeZapTime)
 	if atomic.LoadUint64(&s.stats.MaxMemMergeZapTime) < memMergeZapTime {
@@ -632,20 +634,18 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 		new:              newMergedSegments,
 		mergedSegHistory: make(map[uint64]*mergedSegmentHistory, numSegments),
 		notifyCh:         make(chan *mergeTaskIntroStatus),
-		newCount:         newMergedCount,
 	}
 
 	// create a history map which maps the old in-memory segments with the specific
-	// persister worker (also the specific file segment its going to be part of)
-	// which flushed it out. This map will be used on the introducer side to out-ref
+	// flush it was part of (also the specific file segment its going to be part of).
+	//  This map will be used on the introducer side to out-ref
 	// the in-memory segments and also track the new tombstones if present.
-	for i, flushable := range flushableObjs {
-		for j, idx := range flushable.sbIdxs {
+	for flushID, flush := range flushes {
+		for j, idx := range flush.sbsBatchIndexes {
 			ss := snapshot.segment[idx]
-			// oldSegmentSnapshot.id -> {workerID, oldSegmentSnapshot, docIDs}
 			sm.mergedSegHistory[ss.id] = &mergedSegmentHistory{
-				workerID:     uint64(i),
-				oldNewDocIDs: newDocIDsSet[i][j],
+				flushID:      uint64(flushID),
+				oldNewDocIDs: newDocIDsSet[flushID][j],
 				oldSegment:   ss,
 			}
 		}
@@ -653,27 +653,43 @@ func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
 
 	select { // send to introducer
 	case <-s.closeCh:
-		_ = closeNewMergedSegments(newMergedSegments)
+		// close all merged segments and flip their ineligible for removal flag
+		for flushID := 0; flushID < numFlushes; flushID++ {
+			if newMergedSegments[flushID] != nil {
+				_ = newMergedSegments[flushID].Close()
+			}
+			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
+		}
 		return nil, nil, segment.ErrClosed
 	case s.merges <- sm:
 	}
 
 	// blockingly wait for the introduction to complete
-	var newSnapshot *IndexSnapshot
 	introStatus := <-sm.notifyCh
-	if introStatus != nil && introStatus.indexSnapshot != nil {
-		newSnapshot = introStatus.indexSnapshot
-		atomic.AddUint64(&s.stats.TotMemMergeSegments, uint64(numSegments))
-		atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
-		if introStatus.skipped {
-			// close the segment on skipping introduction.
-			_ = newSnapshot.DecRef()
-			_ = closeNewMergedSegments(newMergedSegments)
-			newSnapshot = nil
+	introducedSnapshot := introStatus.indexSnapshot
+	introducedSegmentIDs := make(map[uint64]struct{}, len(newMergedSegmentIDs))
+	atomic.AddUint64(&s.stats.TotMemMergeSegments, uint64(numSegments))
+	atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
+	for flushID, skipped := range introStatus.skipped {
+		seg := newMergedSegments[flushID]
+		segID := newMergedSegmentIDs[flushID]
+		segFileName := newMergedSegmentFileNames[flushID]
+		if skipped {
+			_ = seg.Close()
+			s.unmarkIneligibleForRemoval(segFileName)
+		} else {
+			introducedSegmentIDs[segID] = struct{}{}
 		}
 	}
 
-	return newSnapshot, newMergedSegmentIDs, nil
+	// if we could not introduce all of the newly merged segments,
+	// then we cannot cannot persist a snapshot with any merged segments at all
+	if len(introducedSegmentIDs) != len(newMergedSegmentIDs) {
+		_ = introducedSnapshot.DecRef()
+		return nil, nil, nil
+	}
+
+	return introducedSnapshot, introducedSegmentIDs, nil
 }
 
 func (s *Scorch) ReportBytesWritten(bytesWritten uint64) {

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -727,7 +727,7 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path stri
 				return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
 			}
 			newSegmentPaths[segmentSnapshot.id] = path
-			err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), writer)
+			err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), nil)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -40,29 +40,50 @@ import (
 
 const persister = "persister"
 
-// DefaultPersisterNapTimeMSec is kept to zero as this helps in direct
-// persistence of segments with the default safe batch option.
-// If the default safe batch option results in high number of
-// files on disk, then users may initialise this configuration parameter
-// with higher values so that the persister will nap a bit within it's
-// work loop to favour better in-memory merging of segments to result
-// in fewer segment files on disk. But that may come with an indexing
-// performance overhead.
-// Unsafe batch users are advised to override this to higher value
-// for better performance especially with high data density.
-var DefaultPersisterNapTimeMSec int = 0 // ms
+var (
+	// DefaultPersisterNapTimeMSec is kept to zero as this helps in direct
+	// persistence of segments with the default safe batch option.
+	// If the default safe batch option results in high number of
+	// files on disk, then users may initialise this configuration parameter
+	// with higher values so that the persister will nap a bit within it's
+	// work loop to favour better in-memory merging of segments to result
+	// in fewer segment files on disk. But that may come with an indexing
+	// performance overhead.
+	// Unsafe batch users are advised to override this to higher value
+	// for better performance especially with high data density.
+	DefaultPersisterNapTimeMSec int = 0 // ms
 
-// DefaultPersisterNapUnderNumFiles helps in controlling the pace of
-// persister. At times of a slow merger progress with heavy file merging
-// operations, its better to pace down the persister for letting the merger
-// to catch up within a range defined by this parameter.
-// Fewer files on disk (as per the merge plan) would result in keeping the
-// file handle usage under limit, faster disk merger and a healthier index.
-// Its been observed that such a loosely sync'ed introducer-persister-merger
-// trio results in better overall performance.
-var DefaultPersisterNapUnderNumFiles int = 1000
+	// DefaultPersisterNapUnderNumFiles helps in controlling the pace of
+	// persister. At times of a slow merger progress with heavy file merging
+	// operations, its better to pace down the persister for letting the merger
+	// to catch up within a range defined by this parameter.
+	// Fewer files on disk (as per the merge plan) would result in keeping the
+	// file handle usage under limit, faster disk merger and a healthier index.
+	// Its been observed that such a loosely sync'ed introducer-persister-merger
+	// trio results in better overall performance.
+	DefaultPersisterNapUnderNumFiles int = 1000
 
-var DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64
+	// MemoryPressurePauseThreshold lets persister to have a better leeway
+	// for prudently performing the memory merge of segments on a memory
+	// pressure situation. Here the config value is an upper threshold
+	// for the number of paused application threads. The default value would
+	// be a very high number to always favour the merging of memory segments.
+	DefaultMemoryPressurePauseThreshold uint64 = math.MaxUint64
+
+	// DefaultMinSegmentsForInMemoryMerge represents the default number of
+	// in-memory zap segments that persistSnapshotMaybeMerge() needs to
+	// see in an IndexSnapshot before it decides to merge and persist
+	// those segments
+	DefaultMinSegmentsForInMemoryMerge int = 2
+
+	// number workers which parallely perform an in-memory merge of the segments
+	// followed by a flush operation.
+	DefaultNumPersisterWorkers int = 1
+
+	// maximum size of data that a single worker is allowed to perform the in-memory
+	// merge operation.
+	DefaultMaxSizeInMemoryMergePerWorker int = 0
+)
 
 type persisterOptions struct {
 	// PersisterNapTimeMSec controls the wait/delay injected into
@@ -76,11 +97,10 @@ type persisterOptions struct {
 	// a healthier and heavier in-memory merging
 	PersisterNapUnderNumFiles int
 
-	// MemoryPressurePauseThreshold let persister to have a better leeway
+	// MemoryPressurePauseThreshold lets persister to have a better leeway
 	// for prudently performing the memory merge of segments on a memory
 	// pressure situation. Here the config value is an upper threshold
-	// for the number of paused application threads. The default value would
-	// be a very high number to always favour the merging of memory segments.
+	// for the number of paused application threads.
 	MemoryPressurePauseThreshold uint64
 
 	// NumPersisterWorkers decides the number of parallel workers that will
@@ -362,7 +382,26 @@ func (s *Scorch) parsePersisterOptions() (*persisterOptions, error) {
 			return &po, err
 		}
 	}
+	if err := validatePersisterOptions(&po); err != nil {
+		return nil, err
+	}
 	return &po, nil
+}
+
+// validatePersisterOptions validates the persister options
+func validatePersisterOptions(options *persisterOptions) error {
+	// P < 1 is an invalid case
+	if options.NumPersisterWorkers <= 0 {
+		return fmt.Errorf("NumPersisterWorkers must be greater than 0")
+	}
+	// P = 1 and M > 0 is a valid case where one worker will serially flush all batches
+	// P = 1 and M = 0 is a special case which preserves the legacy one-shot in-memory merge + flush behaviour
+	// P > 1 and M > 0 is a valid case where multiple workers will flush batches in parallel
+	// P > 1 and M = 0 is an invalid case
+	if options.NumPersisterWorkers > 1 && options.MaxSizeInMemoryMergePerWorker == 0 {
+		return fmt.Errorf("MaxSizeInMemoryMergePerWorker must be greater than 0 when NumPersisterWorkers > 1")
+	}
+	return nil
 }
 
 func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
@@ -381,29 +420,14 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
 		}
 	}
 
-	return s.persistSnapshotDirect(snapshot, nil)
+	return s.persistSnapshotDirect(snapshot)
 }
-
-// DefaultMinSegmentsForInMemoryMerge represents the default number of
-// in-memory zap segments that persistSnapshotMaybeMerge() needs to
-// see in an IndexSnapshot before it decides to merge and persist
-// those segments
-var DefaultMinSegmentsForInMemoryMerge = 2
 
 type flushable struct {
-	segments []segment.Segment
-	drops    []*roaring.Bitmap
-	sbIdxs   []int
-	totDocs  uint64
+	sbsBatch        []segment.Segment
+	sbsBatchDrops   []*roaring.Bitmap
+	sbsBatchIndexes []int
 }
-
-// number workers which parallelly perform an in-memory merge of the segments
-// followed by a flush operation.
-var DefaultNumPersisterWorkers = 1
-
-// maximum size of data that a single worker is allowed to perform the in-memory
-// merge operation.
-var DefaultMaxSizeInMemoryMergePerWorker = 0
 
 func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int) bool {
 	// DefaultMaxSizeInMemoryMergePerWorker = 0 is a special value to preserve the legacy
@@ -415,154 +439,120 @@ func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int
 // persist the in-memory zap segments if there are enough of them
 func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persisterOptions) (
 	bool, error) {
-	// collect the in-memory zap segments (SegmentBase instances)
-	var sbs []segment.Segment
-	var sbsDrops []*roaring.Bitmap
-	var sbsIndexes []int
-	var oldSegIdxs []int
+	// split our segment snapshots into unpersisted and persisted segments
+	var persistedSegments []*SegmentSnapshot
+	var unpersistedSegments []*SegmentSnapshot
+	numSegments := len(snapshot.segment)
 
-	flushSet := make([]*flushable, 0)
-	var totSize int
-	var numSegsToFlushOut int
-	var totDocs uint64
-	// legacy behaviour of merge + flush of all in-memory segments in one-shot
-	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
-		val := &flushable{
-			segments: make([]segment.Segment, 0),
-			drops:    make([]*roaring.Bitmap, 0),
-			sbIdxs:   make([]int, 0),
-			totDocs:  totDocs,
-		}
-		for i, snapshot := range snapshot.segment {
-			if _, ok := snapshot.segment.(segment.PersistedSegment); !ok {
-				val.segments = append(val.segments, snapshot.segment)
-				val.drops = append(val.drops, snapshot.deleted)
-				val.sbIdxs = append(val.sbIdxs, i)
-				oldSegIdxs = append(oldSegIdxs, i)
-				val.totDocs += snapshot.segment.Count()
-				numSegsToFlushOut++
-			}
-		}
-
-		flushSet = append(flushSet, val)
-	} else {
-		// constructs a flushSet where each flushable object contains a set of segments
-		// to be merged and flushed out to disk.
-		for i, snapshot := range snapshot.segment {
-			if totSize >= po.MaxSizeInMemoryMergePerWorker &&
-				len(sbs) >= DefaultMinSegmentsForInMemoryMerge {
-				numSegsToFlushOut += len(sbs)
-				val := &flushable{
-					segments: slices.Clone(sbs),
-					drops:    slices.Clone(sbsDrops),
-					sbIdxs:   slices.Clone(sbsIndexes),
-					totDocs:  totDocs,
-				}
-				flushSet = append(flushSet, val)
-				oldSegIdxs = append(oldSegIdxs, sbsIndexes...)
-
-				sbs, sbsDrops, sbsIndexes = sbs[:0], sbsDrops[:0], sbsIndexes[:0]
-				totSize, totDocs = 0, 0
-			}
-
-			if len(flushSet) >= int(po.NumPersisterWorkers) {
-				break
-			}
-
-			if _, ok := snapshot.segment.(segment.PersistedSegment); !ok {
-				sbs = append(sbs, snapshot.segment)
-				sbsDrops = append(sbsDrops, snapshot.deleted)
-				sbsIndexes = append(sbsIndexes, i)
-				totDocs += snapshot.segment.Count()
-				totSize += snapshot.segment.Size()
-			}
-		}
-		// if there were too few segments just merge them all as part of a single worker
-		if len(flushSet) < po.NumPersisterWorkers {
-			numSegsToFlushOut += len(sbs)
-			val := &flushable{
-				segments: slices.Clone(sbs),
-				drops:    slices.Clone(sbsDrops),
-				sbIdxs:   slices.Clone(sbsIndexes),
-				totDocs:  totDocs,
-			}
-			flushSet = append(flushSet, val)
-			oldSegIdxs = append(oldSegIdxs, sbsIndexes...)
+	// collect details of the unpersisted segments
+	sbs := make([]segment.Segment, 0, numSegments)
+	sbsDrops := make([]*roaring.Bitmap, 0, numSegments)
+	sbsIndexes := make([]int, 0, numSegments)
+	sbsSizes := make([]int, 0, numSegments)
+	for idx, segmentSnapshot := range snapshot.segment {
+		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
+			persistedSegments = append(persistedSegments, segmentSnapshot)
+		} else {
+			unpersistedSegments = append(unpersistedSegments, segmentSnapshot)
+			sbs = append(sbs, segmentSnapshot.segment)
+			sbsDrops = append(sbsDrops, segmentSnapshot.deleted)
+			sbsIndexes = append(sbsIndexes, idx)
+			sbsSizes = append(sbsSizes, segmentSnapshot.Size())
 		}
 	}
+	numPersistedSegments := len(persistedSegments)
+	numUnpersistedSegments := len(unpersistedSegments)
 
-	if numSegsToFlushOut < DefaultMinSegmentsForInMemoryMerge {
+	// if we don't have enough segments to persist, then just return
+	if numUnpersistedSegments < DefaultMinSegmentsForInMemoryMerge {
 		return false, nil
 	}
 
-	// the newSnapshot at this point would contain the newly created file segments
-	// and updated with the root.
-	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet)
+	// create our flushSet, which will be an array of flushable objects,
+	// each of which will be a batch of segments to merge and persist.
+	// We are guaranteed that at least one flushable object will be created,
+	// since we have already ensured that at least one unpersisted segment is present.
+	var flushSet []*flushable
+	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
+		val := &flushable{
+			sbsBatch:        slices.Clone(sbs),
+			sbsBatchDrops:   slices.Clone(sbsDrops),
+			sbsBatchIndexes: slices.Clone(sbsIndexes),
+		}
+		flushSet = append(flushSet, val)
+	} else {
+		sbsBatch := make([]segment.Segment, 0, numUnpersistedSegments)
+		sbsBatchDrops := make([]*roaring.Bitmap, 0, numUnpersistedSegments)
+		sbsBatchIndexes := make([]int, 0, numUnpersistedSegments)
+		runningSize := 0
+		for i := 0; i < numUnpersistedSegments; i++ {
+			sbsBatch = append(sbsBatch, sbs[i])
+			sbsBatchDrops = append(sbsBatchDrops, sbsDrops[i])
+			sbsBatchIndexes = append(sbsBatchIndexes, sbsIndexes[i])
+			runningSize += sbsSizes[i]
+			if runningSize >= po.MaxSizeInMemoryMergePerWorker && len(sbsBatch) >= DefaultMinSegmentsForInMemoryMerge {
+				flushSet = append(flushSet, &flushable{
+					sbsBatch:        slices.Clone(sbsBatch),
+					sbsBatchDrops:   slices.Clone(sbsBatchDrops),
+					sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
+				})
+				sbsBatch, sbsBatchDrops, sbsBatchIndexes = sbsBatch[:0], sbsBatchDrops[:0], sbsBatchIndexes[:0]
+				runningSize = 0
+			}
+		}
+		if len(sbsBatch) > 0 {
+			flushSet = append(flushSet, &flushable{
+				sbsBatch:        slices.Clone(sbsBatch),
+				sbsBatchDrops:   slices.Clone(sbsBatchDrops),
+				sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
+			})
+		}
+	}
+
+	// now merge each batch into a new segment, and persist all of them to disk,
+	// and construct a new snapshot with the merged segments
+	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet, po)
 	if err != nil {
 		return false, err
 	}
-
 	if newSnapshot == nil {
 		return false, nil
 	}
-
 	defer func() {
 		_ = newSnapshot.DecRef()
 	}()
-
-	mergedSegmentIDs := map[uint64]struct{}{}
-	for _, idx := range oldSegIdxs {
-		mergedSegmentIDs[snapshot.segment[idx].id] = struct{}{}
-	}
-
-	newMergedSegmentIDs := make(map[uint64]struct{}, len(newSegmentIDs))
-	for _, id := range newSegmentIDs {
-		newMergedSegmentIDs[id] = struct{}{}
-	}
 
 	// construct a snapshot that's logically equivalent to the input
 	// snapshot, but with merged segments replaced by the new segment
 	equiv := &IndexSnapshot{
 		parent:   snapshot.parent,
-		segment:  make([]*SegmentSnapshot, 0, len(snapshot.segment)),
+		segment:  make([]*SegmentSnapshot, 0, numPersistedSegments+len(newSegmentIDs)),
 		internal: snapshot.internal,
 		epoch:    snapshot.epoch,
 		creator:  "persistSnapshotMaybeMerge",
 	}
 
-	// to track which segments haven't participated in the in-memory merge
-	// they won't be flushed out to the disk yet, but in the next cycle will be
-	// merged in-memory and then flushed out - this is to keep the number of
-	// on-disk files in limit.
-	exclude := make(map[uint64]struct{})
-
-	// copy to the equiv the segments that weren't replaced
-	for _, ss := range snapshot.segment {
-		if _, wasMerged := mergedSegmentIDs[ss.id]; !wasMerged {
-			equiv.segment = append(equiv.segment, ss)
-			// this can be either in-memory or persisted segment, but while
-			// preparing the bolt snapshot we avoid the in-memory segments to be
-			// flushed out
-			if _, ok := ss.segment.(segment.PersistedSegment); !ok {
-				exclude[ss.id] = struct{}{}
-			}
-		}
+	// first add all the segments that were already persisted
+	// and did not participate in the merge
+	for _, segment := range persistedSegments {
+		equiv.segment = append(equiv.segment, segment)
 	}
 
-	// append to the equiv the newly merged segments
+	// next, add all the segments that were unpersisted and hence
+	// participated in the merge, from the merged snapshot
 	for _, segment := range newSnapshot.segment {
-		if _, ok := newMergedSegmentIDs[segment.id]; ok {
+		if _, ok := newSegmentIDs[segment.id]; ok {
 			equiv.segment = append(equiv.segment, &SegmentSnapshot{
-				id:       segment.id,
-				segment:  segment.segment,
-				deleted:  nil, // nil since merging handled deletions
-				stats:    nil,
-				internal: nil, // segment is persisted and equiv is already updated
+				id:      segment.id,
+				segment: segment.segment,
+				deleted: nil, // nil since merging handled deletions
+				stats:   segment.stats,
 			})
 		}
 	}
 
-	err = s.persistSnapshotDirect(equiv, exclude)
+	// finally, persist the equivalent snapshot to disk
+	err = s.persistSnapshotDirect(equiv)
 	if err != nil {
 		return false, err
 	}
@@ -626,8 +616,7 @@ func persistToDirectory(seg segment.UnpersistedSegment, d index.Directory,
 	return err
 }
 
-func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path string, segPlugin SegmentPlugin,
-	exclude map[uint64]struct{}, d index.Directory) ([]string, map[uint64]string, error) {
+func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path string, segPlugin SegmentPlugin, d index.Directory) ([]string, map[uint64]string, error) {
 	snapshotsBucket, err := tx.CreateBucketIfNotExists(util.BoltSnapshotsBucket)
 	if err != nil {
 		return nil, nil, err
@@ -689,12 +678,11 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path stri
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// deep copy the internal map since we'll be keeping only the persisted info
-	// in bolt and some of the information might be deleted
-	internal := make(map[string][]byte, len(snapshot.internal))
 	for k, v := range snapshot.internal {
-		internal[k] = v
+		err = internalBucket.Put([]byte(k), v, writer)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if snapshot.parent != nil {
@@ -712,15 +700,13 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path stri
 
 	// first ensure that each segment in this snapshot has been persisted
 	for _, segmentSnapshot := range snapshot.segment {
-		var persistedSeg bool
-		var snapshotSegmentBucket *util.BoltBucketImpl
+		snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
+		snapshotSegmentBucket, err := snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
+		if err != nil {
+			return nil, nil, err
+		}
 		switch seg := segmentSnapshot.segment.(type) {
 		case segment.PersistedSegment:
-			snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
-			snapshotSegmentBucket, err = snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
-			if err != nil {
-				return nil, nil, err
-			}
 			segPath := seg.Path()
 			_, err = copyToDirectory(segPath, d)
 			if err != nil {
@@ -732,99 +718,67 @@ func prepareBoltSnapshot(snapshot *IndexSnapshot, tx *util.BoltTxImpl, path stri
 				return nil, nil, err
 			}
 			filenames = append(filenames, filename)
-			persistedSeg = true
 		case segment.UnpersistedSegment:
-			// need to persist this to disk if its not part of exclude list (which
-			// restricts which in-memory segment to be persisted to disk)
-			if _, ok := exclude[segmentSnapshot.id]; !ok {
-				snapshotSegmentKey := encodeUvarintAscending(nil, segmentSnapshot.id)
-				snapshotSegmentBucket, err = snapshotBucket.CreateBucketIfNotExists(snapshotSegmentKey)
-				if err != nil {
-					return nil, nil, err
-				}
-				filename := zapFileName(segmentSnapshot.id)
-				path := filepath.Join(path, filename)
-				err = persistToDirectory(seg, d, path)
-				if err != nil {
-					return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
-				}
-				newSegmentPaths[segmentSnapshot.id] = path
-				err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), nil)
-				if err != nil {
-					return nil, nil, err
-				}
-				filenames = append(filenames, filename)
-				persistedSeg = true
-			} else {
-				// this segment is not going to be persisted in this cycle, so any
-				// of the corresponding internal values need to be removed since
-				// on recovery they shouldn't be loaded as part of the indexSnapshot
-				for k, v := range segmentSnapshot.internal {
-					if v != nil {
-						delete(internal, k)
-					}
-				}
+			// need to persist this to disk
+			filename := zapFileName(segmentSnapshot.id)
+			path := filepath.Join(path, filename)
+			err := persistToDirectory(seg, d, path)
+			if err != nil {
+				return nil, nil, fmt.Errorf("segment: %s persist err: %v", path, err)
 			}
+			newSegmentPaths[segmentSnapshot.id] = path
+			err = snapshotSegmentBucket.Put(util.BoltPathKey, []byte(filename), writer)
+			if err != nil {
+				return nil, nil, err
+			}
+			filenames = append(filenames, filename)
 		default:
 			return nil, nil, fmt.Errorf("unknown segment type: %T", seg)
 		}
 
-		// if the segment was excluded from persistence, then skip updating the metadata
-		// or helper data corresponding to it - we need to keep things in-line with
-		// the on-disk information
-		if persistedSeg {
-			// store current deleted bits
-			var roaringBuf bytes.Buffer
-			if segmentSnapshot.deleted != nil {
-				_, err = segmentSnapshot.deleted.WriteTo(&roaringBuf)
-				if err != nil {
-					return nil, nil, fmt.Errorf("error persisting roaring bytes: %v", err)
-				}
-				err = snapshotSegmentBucket.Put(util.BoltDeletedKey, roaringBuf.Bytes(), writer)
-				if err != nil {
-					return nil, nil, err
-				}
+		// store current deleted bits
+		var roaringBuf bytes.Buffer
+		if segmentSnapshot.deleted != nil {
+			_, err = segmentSnapshot.deleted.WriteTo(&roaringBuf)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error persisting roaring bytes: %v", err)
 			}
-
-			// store segment stats
-			if segmentSnapshot.stats != nil {
-				statsBytes, err := json.Marshal(segmentSnapshot.stats.Fetch())
-				if err != nil {
-					return nil, nil, err
-				}
-				err = snapshotSegmentBucket.Put(util.BoltStatsKey, statsBytes, writer)
-				if err != nil {
-					return nil, nil, err
-				}
-			}
-
-			// store updated field info
-			if segmentSnapshot.updatedFields != nil {
-				updatedFieldsBytes, err := json.Marshal(segmentSnapshot.updatedFields)
-				if err != nil {
-					return nil, nil, err
-				}
-				err = snapshotSegmentBucket.Put(
-					util.BoltUpdatedFieldsKey, updatedFieldsBytes, writer)
-				if err != nil {
-					return nil, nil, err
-				}
+			err = snapshotSegmentBucket.Put(util.BoltDeletedKey, roaringBuf.Bytes(), writer)
+			if err != nil {
+				return nil, nil, err
 			}
 		}
-	}
 
-	// now the internal values are reflective of the on-disk data, update in bolt
-	for k, v := range internal {
-		err = internalBucket.Put([]byte(k), v, writer)
-		if err != nil {
-			return nil, nil, err
+		// store segment stats
+		if segmentSnapshot.stats != nil {
+			statsBytes, err := json.Marshal(segmentSnapshot.stats.Fetch())
+			if err != nil {
+				return nil, nil, err
+			}
+			err = snapshotSegmentBucket.Put(util.BoltStatsKey, statsBytes, writer)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// store updated field info
+		if segmentSnapshot.updatedFields != nil {
+			updatedFieldsBytes, err := json.Marshal(segmentSnapshot.updatedFields)
+			if err != nil {
+				return nil, nil, err
+			}
+			err = snapshotSegmentBucket.Put(
+				util.BoltUpdatedFieldsKey, updatedFieldsBytes, writer)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 
 	return filenames, newSegmentPaths, nil
 }
 
-func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot, exclude map[uint64]struct{}) (err error) {
+func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 	// start a write transaction
 	tx, err := s.rootBolt.Begin(true)
 	if err != nil {
@@ -837,7 +791,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot, exclude map[uint
 		}
 	}()
 
-	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, exclude, nil)
+	filenames, newSegmentPaths, err := prepareBoltSnapshot(snapshot, tx, s.path, s.segPlugin, nil)
 	if err != nil {
 		return err
 	}

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -570,7 +570,6 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 
 	var newSegment segment.Segment
 	var bufBytes uint64
-	stats := newFieldStats()
 
 	if len(analysisResults) > 0 {
 		newSegment, bufBytes, err = s.segPlugin.NewUsing(analysisResults, s.segmentConfig)
@@ -582,14 +581,11 @@ func (s *Scorch) Batch(batch *index.Batch) (err error) {
 				segB.BytesWritten())
 		}
 		atomic.AddUint64(&s.iStats.newSegBufBytesAdded, bufBytes)
-		if fsr, ok := newSegment.(segment.FieldStatsReporter); ok {
-			fsr.UpdateFieldStats(stats)
-		}
 	} else {
 		atomic.AddUint64(&s.stats.TotBatchesEmpty, 1)
 	}
 
-	err = s.prepareSegment(newSegment, ids, batch.InternalOps, batch.PersistedCallback(), stats)
+	err = s.prepareSegment(newSegment, ids, batch.InternalOps, batch.PersistedCallback())
 	if err != nil {
 		if newSegment != nil {
 			_ = newSegment.Close()
@@ -632,15 +628,13 @@ func (s *Scorch) Train(batch *index.Batch) error {
 }
 
 func (s *Scorch) prepareSegment(newSegment segment.Segment, ids []string,
-	internalOps map[string][]byte, persistedCallback index.BatchCallback, stats *fieldStats,
-) error {
+	internalOps map[string][]byte, persistedCallback index.BatchCallback) error {
 	// new introduction
 	introduction := &segmentIntroduction{
 		id:                atomic.AddUint64(&s.nextSegmentID, 1),
 		data:              newSegment,
 		ids:               ids,
 		internal:          internalOps,
-		stats:             stats,
 		applied:           make(chan error),
 		persistedCallback: persistedCallback,
 	}

--- a/index/scorch/scorch_knn_test.go
+++ b/index/scorch/scorch_knn_test.go
@@ -1,0 +1,168 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package scorch
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/document"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+const (
+	testVectorDims              = 3
+	testVectorSimilarity        = index.CosineSimilarity
+	testVectorIndexOptimizedFor = index.IndexOptimizedForRecall
+)
+
+func genVectorDoc(t *testing.T, fieldName string) index.Document {
+	t.Helper()
+	randNum := rand.Intn(1000000)
+	doc := document.NewDocument(fmt.Sprintf("vectest%d", randNum))
+	vector := make([]float32, testVectorDims)
+	for i := range vector {
+		vector[i] = float32(i+1) * float32(randNum+1)
+	}
+	doc.AddField(document.NewVectorField(fieldName, nil, vector, testVectorDims, testVectorSimilarity, testVectorIndexOptimizedFor))
+	doc.AddIDField()
+	doc.VisitFields(func(field index.Field) {
+		field.Analyze()
+	})
+	return doc
+}
+
+func TestFieldStatPersistence(t *testing.T) {
+	cfg := CreateConfig("TestFieldStatPersistence")
+	err := InitTest(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = DestroyTest(cfg) }()
+	dirPath := cfg["path"].(string)
+	if err = os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	analysisQueue := index.NewAnalysisQueue(1)
+	idx, err := NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to create Scorch: %v", err)
+	}
+	s, ok := idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", idx)
+	}
+	s.path = dirPath
+	if err = s.openBolt(); err != nil {
+		t.Fatalf("failed to open bolt: %v", err)
+	}
+	const (
+		numSegments = 3
+		fieldName   = "vector"
+		statName    = "field:" + fieldName + ":num_vectors"
+	)
+	docs := make([]index.Document, numSegments)
+	ids := make([]string, numSegments)
+	for i := 0; i < numSegments; i++ {
+		docs[i] = genVectorDoc(t, fieldName)
+		ids[i] = docs[i].ID()
+		seg, _, err := s.segPlugin.New([]index.Document{docs[i]})
+		if err != nil {
+			t.Fatalf("failed to create segment %d: %v", i, err)
+		}
+		intro := &segmentIntroduction{
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    seg,
+			ids:     []string{ids[i]},
+			applied: make(chan error),
+		}
+		if err = s.introduceSegment(intro); err != nil {
+			t.Fatalf("introduceSegment %d failed: %v", i, err)
+		}
+	}
+
+	errCh := make(chan error, 1)
+	doneCh := make(chan struct{})
+	go func() {
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
+		}
+		if persistErr := s.persistSnapshot(s.root, &po); persistErr != nil {
+			errCh <- persistErr
+			return
+		}
+		doneCh <- struct{}{}
+	}()
+	select {
+	case merge := <-s.merges:
+		s.introduceMerge(merge)
+	case err := <-errCh:
+		t.Fatalf("unexpected error during persist (merge phase): %v", err)
+	}
+	<-doneCh
+	snapshot := s.root
+	if len(snapshot.segment) != 1 {
+		t.Fatalf("expected 1 segment after introduce, got %d", len(snapshot.segment))
+	}
+	if !snapshot.segment[0].HasVector() {
+		t.Fatalf("expected HasVector() == true after index persist")
+	}
+	scorchStats := s.StatsMap()
+	numVecs := scorchStats[statName].(uint64)
+	if numVecs != uint64(numSegments) {
+		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
+	}
+	if err = idx.Close(); err != nil {
+		t.Fatalf("failed to close index: %v", err)
+	}
+	idx, err = NewScorch(Name, cfg, analysisQueue)
+	if err != nil {
+		t.Fatalf("failed to recreate Scorch: %v", err)
+	}
+	s, ok = idx.(*Scorch)
+	if !ok {
+		t.Fatalf("expected *Scorch, got %T", idx)
+	}
+	s.path = dirPath
+	if err = s.openBolt(); err != nil {
+		t.Fatalf("failed to open bolt on reopen: %v", err)
+	}
+	snapshot = s.root
+	if len(snapshot.segment) != 1 {
+		t.Fatalf("expected 1 segment after reopen, got %d", len(snapshot.segment))
+	}
+	if !snapshot.segment[0].HasVector() {
+		t.Fatalf("reopened segment: expected HasVector() == true after index reopen")
+	}
+	scorchStats = s.StatsMap()
+	numVecs = scorchStats[statName].(uint64)
+	if numVecs != uint64(numSegments) {
+		t.Fatalf("expected %d vectors in stats, got %d", numSegments, numVecs)
+	}
+	err = idx.Close()
+	if err != nil {
+		t.Fatalf("failed to close index on reopen: %v", err)
+	}
+}

--- a/index/scorch/scorch_test.go
+++ b/index/scorch/scorch_test.go
@@ -15,8 +15,8 @@
 package scorch
 
 import (
-	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +25,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2814,25 +2816,57 @@ func TestPersistorMergerOptions(t *testing.T) {
 	}
 }
 
-// TestPersistenceExclude tests that when we persist a snapshot, and exclude a
-// segment from being persisted, this means that any close and reopen of the index
-// will not retain the excluded segment since it was volatile and not updated in
-// the bolt storage. On reopen we check whether the addtional data associated with
-// the segment like the internal values are also not retained, since they're also
-// volatile.
-func TestPersistenceExclude(t *testing.T) {
-	// Setup config and analysis queue
-	cfg := CreateConfig("TestPersistenceExclude")
+// genDoc generates a random document with a random ID and a single field "name" with value "test".
+func genDoc(t *testing.T) index.Document {
+	t.Helper()
+	randNum := rand.Intn(1000000)
+	doc := document.NewDocument(fmt.Sprintf("test%d", randNum))
+	doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
+	doc.AddIDField()
+	doc.VisitFields(func(field index.Field) {
+		field.Analyze()
+	})
+	return doc
+}
+
+// getBatches generates a list of index.Batches.
+// 1. for each VB, create a batch with a random doc
+// 2. merge all the batches into a single batch
+// 3. repeat until numBatches is reached
+func getBatches(t *testing.T, numVB int, numBatches int) []*index.Batch {
+	t.Helper()
+	batches := make([]*index.Batch, 0, numBatches)
+	vbSeqNumbers := make([]uint64, numVB)
+	for i := 0; i < numVB; i++ {
+		vbSeqNumbers[i] = 0
+	}
+	for i := 0; i < numBatches; i++ {
+		mergedBatch := index.NewBatch()
+		for j := 0; j < numVB; j++ {
+			vbBatch := index.NewBatch()
+			doc := genDoc(t)
+			vbBatch.Update(doc)
+			vbKey := fmt.Sprintf("%d", j)
+			vbValue := make([]byte, 8)
+			binary.BigEndian.PutUint64(vbValue, vbSeqNumbers[j])
+			vbBatch.SetInternal([]byte(vbKey), vbValue)
+			vbSeqNumbers[j]++
+			mergedBatch.Merge(vbBatch)
+		}
+		batches = append(batches, mergedBatch)
+	}
+	return batches
+}
+
+func TestPersistenceMergedBatches(t *testing.T) {
+	cfg := CreateConfig("TestPersistenceMergedBatches")
 	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = DestroyTest(cfg)
-	}()
-
-	os.Mkdir(cfg["path"].(string), 0o755)
-
+	defer func() { _ = DestroyTest(cfg) }()
+	idxPath := cfg["path"].(string)
+	os.Mkdir(idxPath, 0o755)
 	analysisQueue := index.NewAnalysisQueue(1)
 	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
@@ -2842,226 +2876,212 @@ func TestPersistenceExclude(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *Scorch, got %T", s)
 	}
-
-	s.path = cfg["path"].(string)
+	s.path = idxPath
 	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	testDocs := [][]string{
-		{"doc1", "doc2"},
-		{"doc3", "doc4"},
-		{"doc5", "doc6"},
-	}
-
-	internalTestVals := []map[string][]byte{
-		{
-			"i1": []byte("v1"),
-			"i2": []byte("v2"),
-		},
-		{
-			"i3": []byte("v3"),
-			"i4": []byte("v4"),
-		},
-		{
-			"i5": []byte("v5"),
-			"i6": []byte("v6"),
-		},
-	}
-
-	// introduce 3 segments with 2 documents each, and no deletions
-	for i := 0; i < 3; i++ {
-		docs := make([]index.Document, 0, len(testDocs[i]))
-		for _, docID := range testDocs[i] {
-			doc := document.NewDocument(docID)
-			doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-			doc.AddIDField()
-			// analyze the document to create a segment
-			doc.VisitFields(func(field index.Field) {
-				field.Analyze()
-			})
+	const (
+		numSegments = 5
+		numVBs      = 5
+	)
+	batches := getBatches(t, numVBs, numSegments)
+	for i := 0; i < numSegments; i++ {
+		batch := batches[i]
+		var docs []index.Document
+		var ids []string
+		for _, doc := range batch.IndexOps {
 			docs = append(docs, doc)
+			ids = append(ids, doc.ID())
 		}
 		seg, _, err := s.segPlugin.New(docs)
 		if err != nil {
-			t.Fatalf("failed to create segment: %v", err)
+			t.Fatalf("failed to create segment %d: %v", i, err)
 		}
-		// Prepare segmentIntroduction
 		intro := &segmentIntroduction{
 			id:       atomic.AddUint64(&s.nextSegmentID, 1),
 			data:     seg,
-			ids:      testDocs[i],
-			internal: internalTestVals[i],
+			ids:      ids,
+			internal: batch.InternalOps,
 			applied:  make(chan error),
 		}
-
 		err = s.introduceSegment(intro)
 		if err != nil {
-			t.Fatalf("introduceSegment failed: %v", err)
+			t.Fatalf("introduceSegment %d failed: %v", i, err)
 		}
 	}
-
-	// current snapshot should have 3 segments, each with 2 documents, and no deletions
 	snapshot := s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
+	if len(snapshot.segment) != numSegments {
+		t.Fatalf("expected %d segments, got %d", numSegments, len(snapshot.segment))
 	}
-	for i, seg := range snapshot.segment {
-		if seg.Count() != 2 {
-			t.Fatalf("expected 2 documents in segment, got %d", seg.Count())
-		}
-
-		dict, err := seg.segment.Dictionary("_id")
-		if err != nil {
-			t.Fatalf("failed to get dictionary: %v", err)
-		}
-		// verify the _id field has the correct docID
-		for _, docID := range testDocs[i] {
-			cont, err := dict.Contains([]byte(docID))
-			if err != nil {
-				t.Fatalf("failed to check dictionary for docID %s: %v", docID, err)
-			}
-			if !cont {
-				t.Fatalf("expected to find docID %s in segment, but not found", docID)
-			}
-		}
-	}
-	// persist the snapshot, which will create a new snapshot with 2 persisted segments
-	// listen to persists channel and update root with the new snapshot
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
-		// avoid persisting the last segment
-		exclude := map[uint64]struct{}{
-			snapshot.segment[2].id: {},
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
 		}
-		err := s.persistSnapshotDirect(snapshot, exclude)
+		err := s.persistSnapshot(snapshot, &po)
 		if err != nil {
 			errCh <- err
 			return
 		}
 		doneCh <- struct{}{}
 	}()
-
 	select {
-	case persist := <-s.persists:
-		s.introducePersist(persist)
+	case merge := <-s.merges:
+		s.introduceMerge(merge)
 	case err := <-errCh:
 		t.Fatalf("unexpected error during persist: %v", err)
 	}
-
 	<-doneCh
-
-	snapshot = s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
-	}
-
-	// doc5, doc6
-	lastSeg := snapshot.segment[2]
-	if lastSeg.Count() != 2 {
-		t.Fatalf("expected 2 documents in last segment, got %d", lastSeg.Count())
-	}
-
+	// validate our snapshot's VB-seqMax mappings.
+	/*
+		Each Merged Batch has the following VB-seqMax mappings:
+		Each VB has its own batch, and when flushed to scorch, all 5 batches are merged into a single batch.
+			Batch 0:
+				0 - 0
+				1 - 0
+				2 - 0
+				3 - 0
+				4 - 0
+			Batch 1:
+				0 - 1
+				1 - 1
+				2 - 1
+				3 - 1
+				4 - 1
+			Batch 2:
+				0 - 2
+				1 - 2
+				2 - 2
+				3 - 2
+				4 - 2
+			Batch 3:
+				0 - 3
+				1 - 3
+				2 - 3
+				3 - 3
+				4 - 3
+			Batch 4:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		We expect that after persistance, the VB-seqMax mappings will be as follows:
+		1. In the Bolt Snapshot:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		2. In the in-memory snapshot:
+				0 - 4
+				1 - 4
+				2 - 4
+				3 - 4
+				4 - 4
+		This is because we MUST ensure that the
+		    - In-memory snapshot and Persisted snapshot are in sync with each other.
+			- The VB-seqMax mappings always pick the highest sequence number for each VB.
+	*/
 	reader, err := idx.Reader()
 	if err != nil {
 		t.Fatalf("failed to get reader: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err := reader.GetInternal([]byte("i1"))
+	expectedMappings := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		expectedMappings[i] = 4
+	}
+	actualMappings := make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		vbKey := []byte(strconv.Itoa(i))
+		val, err := reader.GetInternal(vbKey)
+		if err != nil {
+			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
+		}
+		if val == nil {
+			actualMappings[i] = 0
+		} else {
+			actualMappings[i] = binary.BigEndian.Uint64(val)
+		}
+	}
+	if !slices.Equal(expectedMappings, actualMappings) {
+		t.Fatalf("expected in-memory snapshot VB-seqMax mappings %v, got %v", expectedMappings, actualMappings)
+	}
+	err = reader.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to close reader: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// check the last segment's internal value
-	val, err = reader.GetInternal([]byte("i5"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if !bytes.Equal(val, internalTestVals[2]["i5"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[2]["i5"], val)
-	}
-
-	// close the index, the last segment data shouldn't be persisted
 	err = idx.Close()
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
-	// open it back up, the index loaded doesn't have the last segment in it
-	idx2, err := NewScorch(Name, cfg, analysisQueue)
+	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
 	}
-	defer idx2.Close()
-
-	s2, ok := idx2.(*Scorch)
+	s, ok = idx.(*Scorch)
 	if !ok {
-		t.Fatalf("expected *Scorch, got %T", s2)
+		t.Fatalf("expected *Scorch, got %T", s)
 	}
-	s2.path = cfg["path"].(string)
-	err = s2.openBolt()
+	s.path = idxPath
+	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	// only 2 segments were persisted
-	if len(s2.root.segment) != 2 {
-		t.Fatalf("expected 2 segments in root, got %d", len(s2.root.segment))
+	if len(s.root.segment) != 1 {
+		t.Fatalf("expected 1 segment in root after reopen, got %d", len(s.root.segment))
 	}
-
-	reader, err = idx2.Reader()
+	reader, err = idx.Reader()
 	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
+		t.Fatalf("failed to get reader after reopen: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err = reader.GetInternal([]byte("i1"))
+	expectedMappings = make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		expectedMappings[i] = 4
+	}
+	actualMappings = make([]uint64, numVBs)
+	for i := 0; i < numVBs; i++ {
+		vbKey := []byte(strconv.Itoa(i))
+		val, err := reader.GetInternal(vbKey)
+		if err != nil {
+			t.Fatalf("failed to get internal value for VB %d: %v", i, err)
+		}
+		if val == nil {
+			actualMappings[i] = 0
+		} else {
+			actualMappings[i] = binary.BigEndian.Uint64(val)
+		}
+	}
+	if !slices.Equal(expectedMappings, actualMappings) {
+		t.Fatalf("expected Bolt snapshot VB-seqMax mappings %v, got %v", expectedMappings, actualMappings)
+	}
+	err = reader.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to close reader: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
-	}
-
-	// last segment's internal value shouldn't be there since it was never persisted
-	val, err = reader.GetInternal([]byte("i5"))
+	err = idx.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if val != nil {
-		t.Fatalf("expected internal value to be nil, got %s", val)
+		t.Fatalf("failed to close index: %v", err)
 	}
 }
 
-// TestPersistenceWithoutExclude is homologous to TestPersistenceExclude but tests
-// persistence without excluding any segments and introducing another segment after
-// persistence works as expected, in the sense that we don't retain the volatile segment
-// since the next persister cycle never ran
-func TestPersistenceWithoutExclude(t *testing.T) {
-	// Setup config and analysis queue
-	cfg := CreateConfig("TestPersistenceWithoutExclude")
+func TestIneligibleForRemovalOnSkippedMerge(t *testing.T) {
+	cfg := CreateConfig("TestIneligibleForRemovalOnSkippedMerge")
 	err := InitTest(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = DestroyTest(cfg)
-	}()
-
-	os.Mkdir(cfg["path"].(string), 0o755)
-
+	defer func() { _ = DestroyTest(cfg) }()
+	dirPath := cfg["path"].(string)
+	if err = os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	analysisQueue := index.NewAnalysisQueue(1)
 	idx, err := NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
@@ -3071,229 +3091,166 @@ func TestPersistenceWithoutExclude(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *Scorch, got %T", s)
 	}
-
-	s.path = cfg["path"].(string)
+	s.path = dirPath
 	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	testDocs := [][]string{
-		{"doc1", "doc2"},
-		{"doc3", "doc4"},
-		{"doc5", "doc6"},
+	const (
+		numDocs = 3
+	)
+	docs := make([]index.Document, numDocs)
+	ids := make([]string, numDocs)
+	for i := 0; i < numDocs; i++ {
+		doc := genDoc(t)
+		docs[i] = doc
+		ids[i] = doc.ID()
 	}
-
-	internalTestVals := []map[string][]byte{
-		{
-			"i1": []byte("v1"),
-			"i2": []byte("v2"),
-		},
-		{
-			"i3": []byte("v3"),
-			"i4": []byte("v4"),
-		},
-		{
-			"i5": []byte("v5"),
-			"i6": []byte("v6"),
-		},
-	}
-
-	// introduce 2 segments with 2 documents each, and no deletions
-	for i := 0; i < 2; i++ {
-		docs := make([]index.Document, 0, len(testDocs[i]))
-		for _, docID := range testDocs[i] {
-			doc := document.NewDocument(docID)
-			doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-			doc.AddIDField()
-			// analyze the document to create a segment
-			doc.VisitFields(func(field index.Field) {
-				field.Analyze()
-			})
-			docs = append(docs, doc)
-		}
-		seg, _, err := s.segPlugin.New(docs)
+	for i := 0; i < numDocs; i++ {
+		doc := docs[i]
+		id := ids[i]
+		seg, _, err := s.segPlugin.New([]index.Document{doc})
 		if err != nil {
 			t.Fatalf("failed to create segment: %v", err)
 		}
-		// Prepare segmentIntroduction
 		intro := &segmentIntroduction{
-			id:       atomic.AddUint64(&s.nextSegmentID, 1),
-			data:     seg,
-			ids:      testDocs[i],
-			internal: internalTestVals[i],
-			applied:  make(chan error, 1),
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    seg,
+			ids:     []string{id},
+			applied: make(chan error),
 		}
-
-		err = s.introduceSegment(intro)
-		if err != nil {
-			t.Fatalf("introduceSegment failed: %v", err)
+		if err = s.introduceSegment(intro); err != nil {
+			t.Fatalf("introduceSegment: %v", err)
 		}
 	}
-
-	// current snapshot should have 2 segments, each with 2 documents, and no deletions
 	snapshot := s.root
-	if len(snapshot.segment) != 2 {
-		t.Fatalf("expected 2 segments, got %d", len(snapshot.segment))
+	if len(snapshot.segment) != numDocs {
+		t.Fatalf("expected %d segments, got %d", numDocs, len(snapshot.segment))
 	}
-	for i, seg := range snapshot.segment {
-		if seg.Count() != 2 {
-			t.Fatalf("expected 2 documents in segment, got %d", seg.Count())
-		}
-
-		dict, err := seg.segment.Dictionary("_id")
-		if err != nil {
-			t.Fatalf("failed to get dictionary: %v", err)
-		}
-		// verify the _id field has the correct docID
-		for _, docID := range testDocs[i] {
-			cont, err := dict.Contains([]byte(docID))
-			if err != nil {
-				t.Fatalf("failed to check dictionary for docID %s: %v", docID, err)
-			}
-			if !cont {
-				t.Fatalf("expected to find docID %s in segment, but not found", docID)
-			}
+	for _, seg := range snapshot.segment {
+		if seg.Count() != 1 {
+			t.Fatalf("expected %d docs, got %d", 1, seg.Count())
 		}
 	}
-	// persist the snapshot, which will create a new snapshot with 2 persisted segments
-	// listen to persists channel and update root with the new snapshot
 	var errCh = make(chan error, 1)
 	var doneCh = make(chan struct{})
 	go func() {
-		err := s.persistSnapshotDirect(snapshot, nil)
+		po := persisterOptions{
+			PersisterNapTimeMSec:          DefaultPersisterNapTimeMSec,
+			PersisterNapUnderNumFiles:     DefaultPersisterNapUnderNumFiles,
+			MemoryPressurePauseThreshold:  DefaultMemoryPressurePauseThreshold,
+			NumPersisterWorkers:           DefaultNumPersisterWorkers,
+			MaxSizeInMemoryMergePerWorker: DefaultMaxSizeInMemoryMergePerWorker,
+		}
+		err := s.persistSnapshot(snapshot, &po)
 		if err != nil {
 			errCh <- err
 			return
 		}
 		doneCh <- struct{}{}
 	}()
-
+	select {
+	case merge := <-s.merges:
+		intro := &segmentIntroduction{
+			id:      atomic.AddUint64(&s.nextSegmentID, 1),
+			data:    nil,
+			ids:     ids,
+			applied: make(chan error),
+		}
+		if err = s.introduceSegment(intro); err != nil {
+			t.Fatalf("introduceSegment: %v", err)
+		}
+		snapshot = s.root
+		if len(snapshot.segment) != 0 {
+			t.Fatalf("expected %d segments, got %d", 0, len(snapshot.segment))
+		}
+		docCount, err := snapshot.DocCount()
+		if err != nil {
+			t.Fatalf("failed to get doc count: %v", err)
+		}
+		if docCount != 0 {
+			t.Fatalf("expected %d docs, got %d", 0, docCount)
+		}
+		s.introduceMerge(merge)
+	case err := <-errCh:
+		t.Fatalf("unexpected error during persist: %v", err)
+	}
 	select {
 	case persist := <-s.persists:
 		s.introducePersist(persist)
 	case err := <-errCh:
 		t.Fatalf("unexpected error during persist: %v", err)
 	}
-
 	<-doneCh
-
-	docs := make([]index.Document, 0, 2)
-	for _, docID := range testDocs[2] {
-		doc := document.NewDocument(docID)
-		doc.AddField(document.NewTextField("name", []uint64{}, []byte("test")))
-		doc.AddIDField()
-		// analyze the document to create a segment
-		doc.VisitFields(func(field index.Field) {
-			field.Analyze()
-		})
-		docs = append(docs, doc)
-	}
-
-	seg, _, err := s.segPlugin.New(docs)
-	if err != nil {
-		t.Fatalf("failed to create segment: %v", err)
-	}
-	intro := &segmentIntroduction{
-		id:       atomic.AddUint64(&s.nextSegmentID, 1),
-		data:     seg,
-		ids:      testDocs[2],
-		internal: internalTestVals[2],
-		applied:  make(chan error, 1),
-	}
-
-	err = s.introduceSegment(intro)
-	if err != nil {
-		t.Fatalf("introduceSegment failed: %v", err)
-	}
-
 	snapshot = s.root
-	if len(snapshot.segment) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(snapshot.segment))
+	if len(snapshot.segment) != 0 {
+		t.Fatalf("expected %d segments, got %d", 0, len(snapshot.segment))
 	}
-
-	// doc5, doc6
-	lastSeg := snapshot.segment[2]
-	if lastSeg.Count() != 2 {
-		t.Fatalf("expected 2 documents in last segment, got %d", lastSeg.Count())
-	}
-
-	reader, err := idx.Reader()
+	docCount, err := snapshot.DocCount()
 	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
+		t.Fatalf("failed to get doc count: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err := reader.GetInternal([]byte("i1"))
+	if docCount != 0 {
+		t.Fatalf("expected %d docs, got %d", 0, docCount)
+	}
+	s.removeOldData()
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to read dir: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
+	var numZapFiles int
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".zap") {
+			numZapFiles++
+		}
 	}
-
-	// check the last segment's internal value
-	val, err = reader.GetInternal([]byte("i5"))
-	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+	if numZapFiles != numDocs {
+		t.Fatalf("expected %d zap files, got %d", numDocs, numZapFiles)
 	}
-
-	if !bytes.Equal(val, internalTestVals[2]["i5"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[2]["i5"], val)
-	}
-
-	// close the index, the last segment data shouldn't be persisted
 	err = idx.Close()
 	if err != nil {
 		t.Fatalf("failed to close index: %v", err)
 	}
-
-	// open it back up, the index loaded doesn't have the last segment in it
-	idx2, err := NewScorch(Name, cfg, analysisQueue)
+	idx, err = NewScorch(Name, cfg, analysisQueue)
 	if err != nil {
 		t.Fatalf("failed to create Scorch: %v", err)
 	}
-	s2, ok := idx2.(*Scorch)
+	s, ok = idx.(*Scorch)
 	if !ok {
-		t.Fatalf("expected *Scorch, got %T", s2)
+		t.Fatalf("expected *Scorch, got %T", s)
 	}
-	s2.path = cfg["path"].(string)
-	err = s2.openBolt()
+	s.path = dirPath
+	err = s.openBolt()
 	if err != nil {
 		t.Fatalf("failed to open bolt: %v", err)
 	}
-
-	// only 2 segments were persisted
-	if len(s2.root.segment) != 2 {
-		t.Fatalf("expected 2 segments in root, got %d", len(s2.root.segment))
+	snapshot = s.root
+	if len(snapshot.segment) != numDocs {
+		t.Fatalf("expected %d segments, got %d", numDocs, len(snapshot.segment))
 	}
-
-	reader, err = idx2.Reader()
+	docCount, err = snapshot.DocCount()
 	if err != nil {
-		t.Fatalf("failed to get reader: %v", err)
+		t.Fatalf("failed to get doc count: %v", err)
 	}
-	defer reader.Close()
-
-	// check the first segment's internal value
-	val, err = reader.GetInternal([]byte("i1"))
+	if docCount != numDocs {
+		t.Fatalf("expected %d docs, got %d", numDocs, docCount)
+	}
+	files, err = os.ReadDir(dirPath)
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
+		t.Fatalf("failed to read dir: %v", err)
 	}
-
-	if !bytes.Equal(val, internalTestVals[0]["i1"]) {
-		t.Fatalf("expected internal value %s, got %s", internalTestVals[0]["i1"], val)
+	numZapFiles = 0
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".zap") {
+			numZapFiles++
+		}
 	}
-
-	// last segment's internal value shouldn't be there since it was never persisted
-	val, err = reader.GetInternal([]byte("i5"))
+	if numZapFiles != numDocs {
+		t.Fatalf("expected %d zap files, got %d", numDocs, numZapFiles)
+	}
+	err = idx.Close()
 	if err != nil {
-		t.Fatalf("failed to get internal value: %v", err)
-	}
-
-	if val != nil {
-		t.Fatalf("expected internal value to be nil, got %s", val)
+		t.Fatalf("failed to close index: %v", err)
 	}
 }
 

--- a/index/scorch/snapshot_index.go
+++ b/index/scorch/snapshot_index.go
@@ -1026,7 +1026,7 @@ func (is *IndexSnapshot) CopyTo(d index.Directory) error {
 		return err
 	}
 
-	_, _, err = prepareBoltSnapshot(is, tx, "", is.parent.segPlugin, nil, d)
+	_, _, err = prepareBoltSnapshot(is, tx, "", is.parent.segPlugin, d)
 	if err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("error backing up index snapshot: %v", err)

--- a/index/scorch/snapshot_segment.go
+++ b/index/scorch/snapshot_segment.go
@@ -38,11 +38,6 @@ type SegmentSnapshot struct {
 	creator string
 	stats   *fieldStats
 
-	// if this segment is in-memory then we'll try to undo the internal values
-	// in the indexSnapshot internal map before updating the bolt, since its
-	// supposed to be reflective of the on-disk data.
-	internal map[string][]byte
-
 	updatedFields map[string]*index.UpdateFieldInfo
 
 	cachedMeta *cachedMeta


### PR DESCRIPTION
- In the current batch flush architecture, we employ a fixed number of persister workers each operating on a fixed number of segments based on the total size of the batch.
- Current algorithm:

>    **Inputs:** $N$ unpersisted segments, $P$ persister workers, $M$ max bytes per batch.
>   
>    **Partition:** Greedily assign segments to $P$ batches such that $dataSize(batch_i) \leq M$,
>    yielding batches with $K_1, K_2, \ldots, K_P$ segments where $\sum_{i=1}^{P} K_i \leq N$.
>    
>    **Merge:** Concurrently merge each batch, producing $P$ merged segments.
>    
>    **Persist:** Persist the $P$ merged segments; exclude the remaining
>    $N - \sum_{i=1}^{P} K_i$ segments from this persistence round.

- This breaks an invariant as we will persist the index snapshot which has the VB-SeqMax mapping of the unpersisted segments as well, leading to data loss if the index is reopened.
- An attempt to fix this issue was done in https://github.com/blevesearch/bleve/pull/2296, but this was not a complete fix, as it would completely erase the VB-SeqMax mapping from the persisted bolt snapshot based on the excluded unpersisted segment's vbucket, leading to bolt corruption, as we merge batches before dispatching them to scorch. 
- It must be noted that the index snapshot stores the max sequence number for each vbucket based on the overall set of segment snapshots, allowing us to have multiple batches contributing to the same vbucket.
- This PR, first off, reverts https://github.com/blevesearch/bleve/pull/2296.
- Second, we introduce a new algorithm for batch flush.

> **Inputs:** $N$ unpersisted segments, $P$ persister workers, $M$ max bytes per batch.
>
> **Partition:** Greedily assign all $N$ segments into $Q$ batches such that $dataSize(batch_i) \leq M$,
> yielding batches with $K_1, K_2, \ldots, K_{Q}$ segments where $\sum_{i=1}^{Q} K_i = N$
>
> **Merge:** Concurrently merge all $Q$ batches using a semaphore of size $P$,
> producing $Q$ merged segments.
>
> **Persist:** Persist all $Q$ merged segments; no segments are excluded.

- The main difference here is that we do NOT exclude any segment from persistence, ensuring that the persisted segment snapshots and the bolt store always remain in sync, eliminating index corruption, as the VB-SeqMax mapping will always be valid now.
- Add missing validation for persister worker config.
- Fixed a bug where we leak files when we skip introducing segments after performing in-memory segment merge.
- Fixed a bug where the field stats was not being persisted post merging in-memory segments, leading to loss of the stat upon reopening the index.
- Fixed a bug where the merger could remove a file which was being used by the persister to merge and persist in-memory segments.
- Fixed a bug where we introduce inconsistency into the search index when skipping introduction of a segment created from in-memory merge.