### PR TITLE
MB-72489: Performance Optimizations

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -235,8 +235,10 @@ func (dm *DocumentMatch) Reset() *DocumentMatch {
 	}
 	// remember the score breakdown map
 	scoreBreakdown := dm.ScoreBreakdown
-	// clear out the score breakdown map
-	clear(scoreBreakdown)
+	if scoreBreakdown != nil {
+		// clear out the score breakdown map
+		clear(scoreBreakdown)
+	}
 	// remember the Descendants backing array
 	descendants := dm.Descendants
 	for i := range descendants { // recycle each IndexInternalID

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -69,6 +69,9 @@ func newDisjunctionSearcher(ctx context.Context, indexReader index.IndexReader,
 			rv, err := optimizeCompositeSearcher(ctx, "disjunction:unadorned",
 				indexReader, qsearchers, options)
 			if err != nil || rv != nil {
+				for _, s := range qsearchers {
+					_ = s.Close()
+				}
 				return rv, err
 			}
 		}

--- a/search/util.go
+++ b/search/util.go
@@ -54,7 +54,10 @@ func MergeFieldTermLocations(dest []FieldTermLocation, matches []*DocumentMatch)
 			n += len(dm.FieldTermLocations)
 		}
 	}
-	if cap(dest) < n {
+	if n == len(dest) {
+		return dest
+	}
+	if n > cap(dest) {
 		dest = append(make([]FieldTermLocation, 0, n), dest...)
 	}
 


### PR DESCRIPTION
- perf: §22 guard clear(scoreBreakdown) on nil; MergeFieldTermLocations fast path
- fix: close orphaned sub-searchers after unadorned disjunction optimization