### PR TITLE
Performance Optimizations

### DIFF
--- a/index/scorch/empty.go
+++ b/index/scorch/empty.go
@@ -14,7 +14,10 @@
 
 package scorch
 
-import segment "github.com/blevesearch/scorch_segment_api/v2"
+import (
+	"github.com/RoaringBitmap/roaring/v2"
+	segment "github.com/blevesearch/scorch_segment_api/v2"
+)
 
 type emptyPostingsIterator struct{}
 
@@ -37,5 +40,13 @@ func (e *emptyPostingsIterator) BytesRead() uint64 {
 func (e *emptyPostingsIterator) ResetBytesRead(uint64) {}
 
 func (e *emptyPostingsIterator) BytesWritten() uint64 { return 0 }
+
+// Implement OptimizablePostingsIterator so that anEmptyPostingsIterator can
+// participate in nested conjunction/disjunction optimizations without aborting
+// them.  ActualBitmap returning nil and DocNum1Hit returning false cause the
+// iterator to contribute nothing to any AND or OR, which is correct.
+func (e *emptyPostingsIterator) ActualBitmap() *roaring.Bitmap { return nil }
+func (e *emptyPostingsIterator) DocNum1Hit() (uint64, bool)    { return 0, false }
+func (e *emptyPostingsIterator) ReplaceActual(*roaring.Bitmap) {}
 
 var anEmptyPostingsIterator = &emptyPostingsIterator{}

--- a/index/scorch/empty.go
+++ b/index/scorch/empty.go
@@ -39,14 +39,18 @@ func (e *emptyPostingsIterator) BytesRead() uint64 {
 
 func (e *emptyPostingsIterator) ResetBytesRead(uint64) {}
 
-func (e *emptyPostingsIterator) BytesWritten() uint64 { return 0 }
+func (e *emptyPostingsIterator) BytesWritten() uint64 {
+	return 0
+}
 
-// Implement OptimizablePostingsIterator so that anEmptyPostingsIterator can
-// participate in nested conjunction/disjunction optimizations without aborting
-// them.  ActualBitmap returning nil and DocNum1Hit returning false cause the
-// iterator to contribute nothing to any AND or OR, which is correct.
-func (e *emptyPostingsIterator) ActualBitmap() *roaring.Bitmap { return nil }
-func (e *emptyPostingsIterator) DocNum1Hit() (uint64, bool)    { return 0, false }
+func (e *emptyPostingsIterator) ActualBitmap() *roaring.Bitmap {
+	return nil
+}
+
+func (e *emptyPostingsIterator) DocNum1Hit() (uint64, bool) {
+	return 0, false
+}
+
 func (e *emptyPostingsIterator) ReplaceActual(*roaring.Bitmap) {}
 
 var anEmptyPostingsIterator = &emptyPostingsIterator{}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -337,18 +337,6 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 			}
 		}
 
-		// Fast path: no hits in this segment — reuse the zero-alloc empty sentinel.
-		if len(actualBMs) == 0 && len(docNums) == 0 {
-			oTFR.iterators[i] = anEmptyPostingsIterator
-			continue
-		}
-
-		// Fast path: exactly one 1-hit doc with no bitmaps.
-		if len(actualBMs) == 0 && len(docNums) == 1 {
-			oTFR.iterators[i] = newUnadornedPostingsIteratorFrom1Hit(uint64(docNums[0]))
-			continue
-		}
-
 		var bm *roaring.Bitmap
 		if len(actualBMs) > 2 {
 			bm = roaring.HeapOr(actualBMs...)
@@ -357,6 +345,13 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		} else if len(actualBMs) == 1 {
 			bm = actualBMs[0].Clone()
 		} else {
+			if len(docNums) == 0 {
+				oTFR.iterators[i] = anEmptyPostingsIterator
+				continue
+			} else if len(docNums) == 1 {
+				oTFR.iterators[i] = newUnadornedPostingsIteratorFrom1Hit(uint64(docNums[0]))
+				continue
+			}
 			bm = roaring.New()
 		}
 

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -308,24 +308,6 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		return nil, nil
 	}
 
-	for i := range o.snapshot.segment {
-		var cMax uint64
-
-		for _, tfr := range o.tfrs {
-			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
-			if !ok {
-				return nil, nil
-			}
-
-			if itr.ActualBitmap() != nil {
-				c := itr.ActualBitmap().GetCardinality()
-				if cMax < c {
-					cMax = c
-				}
-			}
-		}
-	}
-
 	// We use an artificial term and field because the optimized
 	// termFieldReader can represent multiple terms and fields.
 	oTFR := o.snapshot.unadornedTermFieldReader(
@@ -355,6 +337,18 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 			}
 		}
 
+		// Fast path: no hits in this segment — reuse the zero-alloc empty sentinel.
+		if len(actualBMs) == 0 && len(docNums) == 0 {
+			oTFR.iterators[i] = anEmptyPostingsIterator
+			continue
+		}
+
+		// Fast path: exactly one 1-hit doc with no bitmaps.
+		if len(actualBMs) == 0 && len(docNums) == 1 {
+			oTFR.iterators[i] = newUnadornedPostingsIteratorFrom1Hit(uint64(docNums[0]))
+			continue
+		}
+
 		var bm *roaring.Bitmap
 		if len(actualBMs) > 2 {
 			bm = roaring.HeapOr(actualBMs...)
@@ -362,9 +356,7 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 			bm = roaring.Or(actualBMs[0], actualBMs[1])
 		} else if len(actualBMs) == 1 {
 			bm = actualBMs[0].Clone()
-		}
-
-		if bm == nil {
+		} else {
 			bm = roaring.New()
 		}
 

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -175,12 +175,6 @@ OUTER:
 		var docNum1HitLastOk bool
 
 		for _, tfr := range o.tfrs {
-			if _, ok := tfr.iterators[i].(*emptyPostingsIterator); ok {
-				// An empty postings iterator means the entire AND is empty.
-				oTFR.iterators[i] = anEmptyPostingsIterator
-				continue OUTER
-			}
-
 			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
 			if !ok {
 				// We only optimize postings iterators that support this operation.

--- a/index/scorch/unadorned.go
+++ b/index/scorch/unadorned.go
@@ -173,6 +173,20 @@ func (i *unadornedPostingsIterator1Hit) ResetIterator() {
 	i.docNum = i.docNumOrig
 }
 
+func (i *unadornedPostingsIterator1Hit) ActualBitmap() *roaring.Bitmap {
+	return nil
+}
+
+func (i *unadornedPostingsIterator1Hit) DocNum1Hit() (uint64, bool) {
+	if i.docNum == docNum1HitFinished {
+		return 0, false
+	}
+	return i.docNumOrig, true
+}
+
+func (i *unadornedPostingsIterator1Hit) ReplaceActual(actual *roaring.Bitmap) {
+}
+
 func newUnadornedPostingsIteratorFrom1Hit(docNum1Hit uint64) segment.PostingsIterator {
 	return &unadornedPostingsIterator1Hit{
 		docNumOrig: docNum1Hit,

--- a/search/collector/heap.go
+++ b/search/collector/heap.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"container/heap"
+	"slices"
 
 	"github.com/blevesearch/bleve/v2/search"
 )
@@ -57,9 +58,14 @@ func (c *collectStoreHeap) Final(skip int, fixup collectorFixup) (search.Documen
 	if size <= 0 {
 		return make(search.DocumentMatchCollection, 0), nil
 	}
+	inner := c.Internal()
+	slices.SortFunc(inner, func(a, b *search.DocumentMatch) int {
+		return c.compare(a, b)
+	})
+	window := inner[skip:count]
 	rv := make(search.DocumentMatchCollection, size)
-	for i := size - 1; i >= 0; i-- {
-		doc := heap.Pop(c).(*search.DocumentMatch)
+	for i := 0; i < size; i++ {
+		doc := window[i]
 		rv[i] = doc
 		err := fixup(doc)
 		if err != nil {

--- a/search/collector/heap_test.go
+++ b/search/collector/heap_test.go
@@ -15,29 +15,18 @@
 package collector
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/search"
 )
 
-var (
-	errTestFixup error = errors.New("fixup error")
-	noFixup            = func(*search.DocumentMatch) error {
-		return nil
-	}
-	makeScoreDoc = func(score float64) *search.DocumentMatch {
-		return &search.DocumentMatch{Score: score}
-	}
-)
-
-func TestCollectStoreListRoundTrip(t *testing.T) {
-	l := newStoreList(20, search.ScoreCompare)
+func TestCollectStoreHeapRoundTrip(t *testing.T) {
+	l := newStoreHeap(20, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 4, 1, 5, 9, 2, 6} {
 		l.add(makeScoreDoc(s))
 	}
-	if l.len() != 8 {
-		t.Fatalf("len=%d want 8", l.len())
+	if l.Len() != 8 {
+		t.Fatalf("len=%d want 8", l.Len())
 	}
 	result, err := l.Final(0, noFixup)
 	if err != nil {
@@ -54,9 +43,9 @@ func TestCollectStoreListRoundTrip(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
+func TestCollectStoreHeapAddNotExceedingSize(t *testing.T) {
 	const k = 3
-	l := newStoreList(k, search.ScoreCompare)
+	l := newStoreHeap(k, search.ScoreCompare)
 	var evictedScores []float64
 	for _, s := range []float64{1, 5, 3, 7, 2} {
 		ev := l.AddNotExceedingSize(makeScoreDoc(s), k)
@@ -64,8 +53,8 @@ func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
 			evictedScores = append(evictedScores, ev.Score)
 		}
 	}
-	if l.len() != k {
-		t.Fatalf("list len=%d want %d after capping at k", l.len(), k)
+	if l.Len() != k {
+		t.Fatalf("heap len=%d want %d after capping at k", l.Len(), k)
 	}
 	// Inserted {1,5,3,7,2} with k=3 → evicted the 2 worst: 1 and 2.
 	if len(evictedScores) != 2 {
@@ -84,8 +73,8 @@ func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListSkip(t *testing.T) {
-	l := newStoreList(20, search.ScoreCompare)
+func TestCollectStoreHeapSkip(t *testing.T) {
+	l := newStoreHeap(20, search.ScoreCompare)
 	for _, s := range []float64{1, 2, 3, 4, 5} {
 		l.add(makeScoreDoc(s))
 	}
@@ -105,8 +94,8 @@ func TestCollectStoreListSkip(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListSkipAll(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreHeapSkipAll(t *testing.T) {
+	l := newStoreHeap(10, search.ScoreCompare)
 	for _, s := range []float64{1, 2, 3} {
 		l.add(makeScoreDoc(s))
 	}
@@ -115,12 +104,12 @@ func TestCollectStoreListSkipAll(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(result) != 0 {
-		t.Errorf("Final(skip=10) on 3-elem list returned %d docs, want 0", len(result))
+		t.Errorf("Final(skip=10) on 3-elem heap returned %d docs, want 0", len(result))
 	}
 }
 
-func TestCollectStoreListInternal(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreHeapInternal(t *testing.T) {
+	l := newStoreHeap(10, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 4} {
 		l.add(makeScoreDoc(s))
 	}
@@ -128,17 +117,21 @@ func TestCollectStoreListInternal(t *testing.T) {
 	if len(iv) != 3 {
 		t.Fatalf("Internal len=%d want 3", len(iv))
 	}
-	// Linked list: Front=worst→Back=best, so Internal() iterates Front→Back = ascending.
-	want := []float64{1, 3, 4}
-	for i, w := range want {
-		if iv[i].Score != w {
-			t.Errorf("Internal[%d]=%.2f want %.2f (ascending from worst)", i, iv[i].Score, w)
+	// Internal() exposes the raw heap array, whose order is not sorted,
+	// so only membership is checked here (ordering is covered by Final).
+	seen := make(map[float64]bool)
+	for _, dm := range iv {
+		seen[dm.Score] = true
+	}
+	for _, want := range []float64{3, 1, 4} {
+		if !seen[want] {
+			t.Errorf("Internal missing score %.2f: got %v", want, iv)
 		}
 	}
 }
 
-func TestCollectStoreListRemoveLast(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreHeapRemoveLast(t *testing.T) {
+	l := newStoreHeap(10, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 5} {
 		l.add(makeScoreDoc(s))
 	}
@@ -146,13 +139,13 @@ func TestCollectStoreListRemoveLast(t *testing.T) {
 	if evicted.Score != 1 {
 		t.Errorf("removeLast returned score=%.2f, want 1.0 (the worst)", evicted.Score)
 	}
-	if l.len() != 2 {
-		t.Errorf("len=%d after removeLast, want 2", l.len())
+	if l.Len() != 2 {
+		t.Errorf("len=%d after removeLast, want 2", l.Len())
 	}
 }
 
-func TestCollectStoreListSingleElement(t *testing.T) {
-	l := newStoreList(5, search.ScoreCompare)
+func TestCollectStoreHeapSingleElement(t *testing.T) {
+	l := newStoreHeap(5, search.ScoreCompare)
 	l.add(makeScoreDoc(7.5))
 
 	result, err := l.Final(0, noFixup)
@@ -169,13 +162,13 @@ func TestCollectStoreListSingleElement(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListEqualScores(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreHeapEqualScores(t *testing.T) {
+	l := newStoreHeap(10, search.ScoreCompare)
 	for range 5 {
 		l.add(makeScoreDoc(3.0))
 	}
-	if l.len() != 5 {
-		t.Fatalf("len=%d after 5 equal-scored adds, want 5", l.len())
+	if l.Len() != 5 {
+		t.Fatalf("len=%d after 5 equal-scored adds, want 5", l.Len())
 	}
 	result, err := l.Final(0, noFixup)
 	if err != nil {
@@ -188,8 +181,8 @@ func TestCollectStoreListEqualScores(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListFixupError(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreHeapFixupError(t *testing.T) {
+	l := newStoreHeap(10, search.ScoreCompare)
 	l.add(makeScoreDoc(1.0))
 
 	errFixup := func(*search.DocumentMatch) error {

--- a/search/collector/knn_test.go
+++ b/search/collector/knn_test.go
@@ -1,0 +1,412 @@
+// Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/search"
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+var errTestKNNSearch = errors.New("knn searcher error")
+
+func makeKNNDoc(sb map[int]float64) *search.DocumentMatch {
+	return &search.DocumentMatch{ScoreBreakdown: sb}
+}
+
+// knnStubSearcher is like stubSearcher, but also propagates ScoreBreakdown
+// (needed to exercise the per-heap routing in collectStoreKNN) and can be
+// made to fail on a specific match index.
+type knnStubSearcher struct {
+	matches []*search.DocumentMatch
+	index   int
+	errAt   int
+}
+
+func (ss *knnStubSearcher) Next(ctx *search.SearchContext) (*search.DocumentMatch, error) {
+	if ss.errAt >= 0 && ss.index == ss.errAt {
+		return nil, errTestKNNSearch
+	}
+	if ss.index < len(ss.matches) {
+		rv := ctx.DocumentMatchPool.Get()
+		rv.IndexInternalID = ss.matches[ss.index].IndexInternalID
+		rv.Score = ss.matches[ss.index].Score
+		for k, v := range ss.matches[ss.index].ScoreBreakdown {
+			if rv.ScoreBreakdown == nil {
+				rv.ScoreBreakdown = make(map[int]float64)
+			}
+			rv.ScoreBreakdown[k] = v
+		}
+		ss.index++
+		return rv, nil
+	}
+	return nil, nil
+}
+
+func (ss *knnStubSearcher) Advance(ctx *search.SearchContext, ID index.IndexInternalID) (*search.DocumentMatch, error) {
+	return nil, nil
+}
+func (ss *knnStubSearcher) Close() error               { return nil }
+func (ss *knnStubSearcher) Weight() float64            { return 0.0 }
+func (ss *knnStubSearcher) SetQueryNorm(float64)       {}
+func (ss *knnStubSearcher) Count() uint64              { return uint64(len(ss.matches)) }
+func (ss *knnStubSearcher) Min() int                   { return 0 }
+func (ss *knnStubSearcher) Size() int                  { return 0 }
+func (ss *knnStubSearcher) DocumentMatchPoolSize() int { return 0 }
+
+// errorIDReader wraps stubReader but fails ID lookups, to exercise the
+// error path in finalizeResults.
+type errorIDReader struct {
+	stubReader
+}
+
+func (r *errorIDReader) ExternalID(id index.IndexInternalID) (string, error) {
+	return "", errors.New("external id lookup failed")
+}
+
+func TestGetNewKNNCollectorStore(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{3, 12})
+	if len(store.internalHeaps) != 2 {
+		t.Fatalf("internalHeaps len=%d want 2", len(store.internalHeaps))
+	}
+	if len(store.kValues) != 2 || store.kValues[0] != 3 || store.kValues[1] != 12 {
+		t.Errorf("kValues=%v want [3 12]", store.kValues)
+	}
+	// size 3 (<=10) picks the slice-backed store, size 12 (>10) picks the heap.
+	if _, ok := store.internalHeaps[0].(*collectStoreSlice); !ok {
+		t.Errorf("internalHeaps[0] is %T, want *collectStoreSlice", store.internalHeaps[0])
+	}
+	if _, ok := store.internalHeaps[1].(*collectStoreHeap); !ok {
+		t.Errorf("internalHeaps[1] is %T, want *collectStoreHeap", store.internalHeaps[1])
+	}
+}
+
+func TestCollectStoreKNNAddDocumentSkipsNonParticipatingHeap(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{5})
+	released := store.AddDocument(makeKNNDoc(map[int]float64{}))
+	if len(released) != 0 {
+		t.Errorf("released=%v want none", released)
+	}
+	if len(store.internalHeaps[0].Internal()) != 0 {
+		t.Errorf("heap should stay empty when doc has no matching ScoreBreakdown entries")
+	}
+}
+
+func TestCollectStoreKNNAddDocumentDelayedEject(t *testing.T) {
+	// Two size-1 heaps; a doc evicted from one heap is only released once
+	// it has also been evicted from every other heap it participated in.
+	store := GetNewKNNCollectorStore([]int64{1, 1})
+
+	doc1 := makeKNNDoc(map[int]float64{0: 5, 1: 3})
+	if released := store.AddDocument(doc1); len(released) != 0 {
+		t.Fatalf("first insert should not release anything, got %v", released)
+	}
+
+	// Better in heap 0 only; evicts doc1 from heap 0, but doc1 survives in heap 1.
+	doc2 := makeKNNDoc(map[int]float64{0: 10})
+	if released := store.AddDocument(doc2); len(released) != 0 {
+		t.Fatalf("doc1 still lives in heap 1, should not be released, got %v", released)
+	}
+	if _, ok := doc1.ScoreBreakdown[0]; ok {
+		t.Errorf("doc1 ScoreBreakdown should have lost key 0 after eviction from heap 0")
+	}
+	if _, ok := doc1.ScoreBreakdown[1]; !ok {
+		t.Errorf("doc1 ScoreBreakdown should still have key 1")
+	}
+
+	// Better in heap 1 only; evicts doc1 from its last remaining heap.
+	doc3 := makeKNNDoc(map[int]float64{1: 100})
+	released := store.AddDocument(doc3)
+	if len(released) != 1 || released[0] != doc1 {
+		t.Fatalf("expected doc1 to be released once evicted from all heaps, got %v", released)
+	}
+}
+
+func TestCollectStoreKNNAddDocumentEjectSameCall(t *testing.T) {
+	// A single AddDocument call can evict the same old doc from more
+	// than one heap; it should only be released once, in that same call.
+	store := GetNewKNNCollectorStore([]int64{1, 1})
+
+	doc1 := makeKNNDoc(map[int]float64{0: 1, 1: 1})
+	store.AddDocument(doc1)
+
+	doc2 := makeKNNDoc(map[int]float64{0: 5, 1: 5})
+	released := store.AddDocument(doc2)
+	if len(released) != 1 || released[0] != doc1 {
+		t.Fatalf("expected doc1 released exactly once, got %v", released)
+	}
+	if len(doc1.ScoreBreakdown) != 0 {
+		t.Errorf("doc1 ScoreBreakdown should be empty, got %v", doc1.ScoreBreakdown)
+	}
+}
+
+func TestCollectStoreKNNFinalDedupesAcrossHeaps(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{5, 5})
+
+	docA := makeKNNDoc(map[int]float64{0: 1, 1: 2}) // in both heaps
+	docB := makeKNNDoc(map[int]float64{0: 2})       // heap 0 only
+	docC := makeKNNDoc(map[int]float64{1: 3})       // heap 1 only
+
+	for _, d := range []*search.DocumentMatch{docA, docB, docC} {
+		if released := store.AddDocument(d); len(released) != 0 {
+			t.Fatalf("no eviction expected with size-5 heaps, got %v", released)
+		}
+	}
+
+	fixupCalls := 0
+	result, err := store.Final(func(*search.DocumentMatch) error {
+		fixupCalls++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("Final len=%d want 3 (docA deduped across heaps)", len(result))
+	}
+	if fixupCalls != 3 {
+		t.Errorf("fixupCalls=%d want 3", fixupCalls)
+	}
+}
+
+func TestCollectStoreKNNFinalEmpty(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{5})
+	result, err := store.Final(noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 0 {
+		t.Errorf("Final on empty store len=%d want 0", len(result))
+	}
+}
+
+func TestCollectStoreKNNFinalNilFixup(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{5})
+	store.AddDocument(makeKNNDoc(map[int]float64{0: 1}))
+	result, err := store.Final(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 1 {
+		t.Errorf("Final(nil) len=%d want 1", len(result))
+	}
+}
+
+func TestCollectStoreKNNFinalFixupError(t *testing.T) {
+	store := GetNewKNNCollectorStore([]int64{5})
+	store.AddDocument(makeKNNDoc(map[int]float64{0: 1}))
+
+	_, err := store.Final(func(*search.DocumentMatch) error {
+		return errTestFixup
+	})
+	if err != errTestFixup {
+		t.Errorf("Final fixup error not propagated: got %v", err)
+	}
+}
+
+func TestMakeKNNDocMatchHandlerWrongCollectorType(t *testing.T) {
+	ctx := &search.SearchContext{Collector: NewTopNCollector(1, 0, search.SortOrder{&search.SortScore{Desc: true}})}
+	handler, err := MakeKNNDocMatchHandler(ctx)
+	if handler != nil || err != nil {
+		t.Errorf("expected (nil, nil) for a non-KNN collector, got (%v, %v)", handler, err)
+	}
+}
+
+func TestMakeKNNDocMatchHandlerAddsAndReleases(t *testing.T) {
+	hc := NewKNNCollector([]int64{1}, 1)
+	ctx := &search.SearchContext{
+		Collector:         hc,
+		DocumentMatchPool: search.NewDocumentMatchPool(0, 0),
+	}
+
+	handler, err := MakeKNNDocMatchHandler(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if handler == nil {
+		t.Fatal("expected a non-nil handler")
+	}
+
+	if err := handler(nil); err != nil {
+		t.Errorf("handler(nil) should be a no-op, got %v", err)
+	}
+
+	doc1 := makeKNNDoc(map[int]float64{0: 1})
+	if err := handler(doc1); err != nil {
+		t.Fatal(err)
+	}
+
+	doc2 := makeKNNDoc(map[int]float64{0: 5})
+	if err := handler(doc2); err != nil {
+		t.Fatal(err)
+	}
+
+	// doc1 lost its only heap slot to doc2, so it should have been
+	// recycled back into the document match pool.
+	recycled := ctx.DocumentMatchPool.Get()
+	if recycled != doc1 {
+		t.Errorf("expected doc1 to be recycled into the pool, got %v", recycled)
+	}
+}
+
+func TestKNNCollectorCollectBasic(t *testing.T) {
+	matches := []*search.DocumentMatch{
+		{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}},
+		{IndexInternalID: index.IndexInternalID("b"), ScoreBreakdown: map[int]float64{0: 5}},
+		{IndexInternalID: index.IndexInternalID("c"), ScoreBreakdown: map[int]float64{0: 3}},
+		{IndexInternalID: index.IndexInternalID("d"), ScoreBreakdown: map[int]float64{0: 0.5}},
+	}
+	searcher := &knnStubSearcher{matches: matches, errAt: -1}
+
+	hc := NewKNNCollector([]int64{2}, 2)
+	err := hc.Collect(context.Background(), searcher, &stubReader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hc.Total() != 4 {
+		t.Errorf("Total()=%d want 4", hc.Total())
+	}
+	if hc.MaxScore() != 0 {
+		t.Errorf("MaxScore()=%f want 0 (KNNCollector never tracks it)", hc.MaxScore())
+	}
+	if hc.Took() < 0 {
+		t.Errorf("Took()=%v want >= 0", hc.Took())
+	}
+
+	results := hc.Results()
+	if len(results) != 2 {
+		t.Fatalf("Results() len=%d want 2 (top-2 by ScoreBreakdown[0])", len(results))
+	}
+	got := map[string]bool{}
+	for _, r := range results {
+		got[r.ID] = true
+	}
+	if !got["b"] || !got["c"] {
+		t.Errorf("expected top-2 hits {b, c}, got %v", got)
+	}
+
+	hc.SetFacetsBuilder(nil)
+	if fr := hc.FacetResults(); fr != nil {
+		t.Errorf("FacetResults()=%v want nil (facets unsupported)", fr)
+	}
+}
+
+func TestKNNCollectorCollectContextCancelledBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hc := NewKNNCollector([]int64{1}, 1)
+	searcher := &knnStubSearcher{
+		matches: []*search.DocumentMatch{{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}}},
+		errAt:   -1,
+	}
+	err := hc.Collect(ctx, searcher, &stubReader{})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestKNNCollectorCollectSearcherError(t *testing.T) {
+	searcher := &knnStubSearcher{
+		matches: []*search.DocumentMatch{{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}}},
+		errAt:   0,
+	}
+	hc := NewKNNCollector([]int64{1}, 1)
+	err := hc.Collect(context.Background(), searcher, &stubReader{})
+	if err != errTestKNNSearch {
+		t.Errorf("expected searcher error to propagate, got %v", err)
+	}
+}
+
+func TestKNNCollectorCollectFinalizeIDLookupError(t *testing.T) {
+	searcher := &knnStubSearcher{
+		matches: []*search.DocumentMatch{{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}}},
+		errAt:   -1,
+	}
+	hc := NewKNNCollector([]int64{1}, 1)
+	err := hc.Collect(context.Background(), searcher, &errorIDReader{})
+	if err == nil {
+		t.Fatal("expected an error from the failing ExternalID lookup")
+	}
+}
+
+func TestKNNCollectorCollectCustomHandlerError(t *testing.T) {
+	searcher := &knnStubSearcher{
+		matches: []*search.DocumentMatch{{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}}},
+		errAt:   -1,
+	}
+	hc := NewKNNCollector([]int64{1}, 1)
+
+	var handlerMaker search.MakeKNNDocumentMatchHandler = func(ctx *search.SearchContext) (search.DocumentMatchHandler, error) {
+		return func(d *search.DocumentMatch) error {
+			if d == nil {
+				return nil
+			}
+			return errTestFixup
+		}, nil
+	}
+	ctx := context.WithValue(context.Background(), search.MakeKNNDocumentMatchHandlerKey, handlerMaker)
+
+	err := hc.Collect(ctx, searcher, &stubReader{})
+	if err != errTestFixup {
+		t.Errorf("expected custom handler error to propagate, got %v", err)
+	}
+}
+
+func TestKNNCollectorCollectCustomHandlerMakerError(t *testing.T) {
+	searcher := &knnStubSearcher{errAt: -1}
+	hc := NewKNNCollector([]int64{1}, 1)
+
+	var handlerMaker search.MakeKNNDocumentMatchHandler = func(ctx *search.SearchContext) (search.DocumentMatchHandler, error) {
+		return nil, errTestFixup
+	}
+	ctx := context.WithValue(context.Background(), search.MakeKNNDocumentMatchHandlerKey, handlerMaker)
+
+	err := hc.Collect(ctx, searcher, &stubReader{})
+	if err != errTestFixup {
+		t.Errorf("expected handler-maker error to propagate, got %v", err)
+	}
+}
+
+func TestKNNCollectorCollectFinalizeHandlerError(t *testing.T) {
+	searcher := &knnStubSearcher{
+		matches: []*search.DocumentMatch{{IndexInternalID: index.IndexInternalID("a"), ScoreBreakdown: map[int]float64{0: 1}}},
+		errAt:   -1,
+	}
+	hc := NewKNNCollector([]int64{1}, 1)
+
+	var handlerMaker search.MakeKNNDocumentMatchHandler = func(ctx *search.SearchContext) (search.DocumentMatchHandler, error) {
+		return func(d *search.DocumentMatch) error {
+			if d == nil {
+				// fail only on the final flush call
+				return errTestFixup
+			}
+			return nil
+		}, nil
+	}
+	ctx := context.WithValue(context.Background(), search.MakeKNNDocumentMatchHandlerKey, handlerMaker)
+
+	err := hc.Collect(ctx, searcher, &stubReader{})
+	if err != errTestFixup {
+		t.Errorf("expected finalize-flush handler error to propagate, got %v", err)
+	}
+}

--- a/search/collector/list_test.go
+++ b/search/collector/list_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/search"
+)
+
+var errTestFixup = errors.New("fixup error")
+
+// noFixup is a no-op fixup function used throughout the list tests.
+var noFixup collectorFixup = func(*search.DocumentMatch) error { return nil }
+
+// TestCollectStoreListRoundTrip verifies that add() keeps elements in
+// ascending-score order (Front=worst, Back=best) and that Final(0, ...) returns
+// them best-first.  This exercises the core insertion-sort invariant of the
+// linked-list store, which had 0% coverage before this test.
+func TestCollectStoreListRoundTrip(t *testing.T) {
+	l := newStoreList(20, scoreDesc)
+	for _, s := range []float64{3, 1, 4, 1, 5, 9, 2, 6} {
+		l.add(makeScoreDoc(s))
+	}
+	if l.len() != 8 {
+		t.Fatalf("len=%d want 8", l.len())
+	}
+	result, err := l.Final(0, noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 8 {
+		t.Fatalf("Final len=%d want 8", len(result))
+	}
+	for i := 1; i < len(result); i++ {
+		if result[i].Score > result[i-1].Score {
+			t.Errorf("Final not descending: result[%d]=%.2f > result[%d]=%.2f",
+				i, result[i].Score, i-1, result[i-1].Score)
+		}
+	}
+}
+
+// TestCollectStoreListAddNotExceedingSize verifies that AddNotExceedingSize caps
+// the list at k elements by evicting the worst (lowest-score) element.
+func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
+	const k = 3
+	l := newStoreList(k, scoreDesc)
+	var evictedScores []float64
+	for _, s := range []float64{1, 5, 3, 7, 2} {
+		ev := l.AddNotExceedingSize(makeScoreDoc(s), k)
+		if ev != nil {
+			evictedScores = append(evictedScores, ev.Score)
+		}
+	}
+	if l.len() != k {
+		t.Fatalf("list len=%d want %d after capping at k", l.len(), k)
+	}
+	// Inserted {1,5,3,7,2} with k=3 → evicted the 2 worst: 1 and 2.
+	if len(evictedScores) != 2 {
+		t.Fatalf("evicted %d docs want 2", len(evictedScores))
+	}
+	// Remaining best-3: {7, 5, 3} in descending order.
+	result, err := l.Final(0, noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []float64{7, 5, 3}
+	for i, w := range want {
+		if result[i].Score != w {
+			t.Errorf("result[%d]=%.2f want %.2f", i, result[i].Score, w)
+		}
+	}
+}
+
+// TestCollectStoreListSkip verifies that Final(skip, ...) skips the top-skip
+// best results and returns the remaining docs in descending order.
+// This models pagination: skip=page*pageSize to start at a later page.
+func TestCollectStoreListSkip(t *testing.T) {
+	l := newStoreList(20, scoreDesc)
+	for _, s := range []float64{1, 2, 3, 4, 5} {
+		l.add(makeScoreDoc(s))
+	}
+	// skip=2 omits the 2 best (scores 5 and 4) → returns [3, 2, 1].
+	result, err := l.Final(2, noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("Final(skip=2) len=%d want 3", len(result))
+	}
+	want := []float64{3, 2, 1}
+	for i, w := range want {
+		if result[i].Score != w {
+			t.Errorf("result[%d]=%.2f want %.2f", i, result[i].Score, w)
+		}
+	}
+}
+
+// TestCollectStoreListSkipAll verifies Final returns empty when skip ≥ len.
+func TestCollectStoreListSkipAll(t *testing.T) {
+	l := newStoreList(10, scoreDesc)
+	for _, s := range []float64{1, 2, 3} {
+		l.add(makeScoreDoc(s))
+	}
+	result, err := l.Final(10, noFixup) // skip > len
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 0 {
+		t.Errorf("Final(skip=10) on 3-elem list returned %d docs, want 0", len(result))
+	}
+}
+
+// TestCollectStoreListInternal verifies Internal() returns all elements in
+// ascending-score order (Front to Back of the linked list).
+func TestCollectStoreListInternal(t *testing.T) {
+	l := newStoreList(10, scoreDesc)
+	for _, s := range []float64{3, 1, 4} {
+		l.add(makeScoreDoc(s))
+	}
+	iv := l.Internal()
+	if len(iv) != 3 {
+		t.Fatalf("Internal len=%d want 3", len(iv))
+	}
+	// Linked list: Front=worst→Back=best, so Internal() iterates Front→Back = ascending.
+	want := []float64{1, 3, 4}
+	for i, w := range want {
+		if iv[i].Score != w {
+			t.Errorf("Internal[%d]=%.2f want %.2f (ascending from worst)", i, iv[i].Score, w)
+		}
+	}
+}
+
+// TestCollectStoreListRemoveLast verifies removeLast removes the Front element,
+// which is the worst (lowest-score) document in the list.
+func TestCollectStoreListRemoveLast(t *testing.T) {
+	l := newStoreList(10, scoreDesc)
+	for _, s := range []float64{3, 1, 5} {
+		l.add(makeScoreDoc(s))
+	}
+	evicted := l.removeLast()
+	if evicted.Score != 1 {
+		t.Errorf("removeLast returned score=%.2f, want 1.0 (the worst)", evicted.Score)
+	}
+	if l.len() != 2 {
+		t.Errorf("len=%d after removeLast, want 2", l.len())
+	}
+}
+
+// TestCollectStoreListSingleElement verifies that a list with one element
+// round-trips correctly through add / Final / Internal.
+func TestCollectStoreListSingleElement(t *testing.T) {
+	l := newStoreList(5, scoreDesc)
+	l.add(makeScoreDoc(7.5))
+
+	result, err := l.Final(0, noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 1 || result[0].Score != 7.5 {
+		t.Errorf("single-element Final: got %v", result)
+	}
+
+	iv := l.Internal()
+	if len(iv) != 1 || iv[0].Score != 7.5 {
+		t.Errorf("single-element Internal: got %v", iv)
+	}
+}
+
+// TestCollectStoreListEqualScores verifies correct handling of equal-scored
+// documents: they should all be retained, and Final preserves their relative
+// insertion order within equal-scored groups.
+func TestCollectStoreListEqualScores(t *testing.T) {
+	l := newStoreList(10, scoreDesc)
+	for range 5 {
+		l.add(makeScoreDoc(3.0))
+	}
+	if l.len() != 5 {
+		t.Fatalf("len=%d after 5 equal-scored adds, want 5", l.len())
+	}
+	result, err := l.Final(0, noFixup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dm := range result {
+		if dm.Score != 3.0 {
+			t.Errorf("expected all scores=3.0, got %.2f", dm.Score)
+		}
+	}
+}
+
+// TestCollectStoreListFixupError verifies that an error returned by the fixup
+// function propagates correctly from Final.
+func TestCollectStoreListFixupError(t *testing.T) {
+	l := newStoreList(10, scoreDesc)
+	l.add(makeScoreDoc(1.0))
+
+	errFixup := func(*search.DocumentMatch) error {
+		return errTestFixup
+	}
+	_, err := l.Final(0, errFixup)
+	if err != errTestFixup {
+		t.Errorf("Final fixup error not propagated: got %v", err)
+	}
+}

--- a/search/collector/slice_test.go
+++ b/search/collector/slice_test.go
@@ -15,24 +15,13 @@
 package collector
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/search"
 )
 
-var (
-	errTestFixup error = errors.New("fixup error")
-	noFixup            = func(*search.DocumentMatch) error {
-		return nil
-	}
-	makeScoreDoc = func(score float64) *search.DocumentMatch {
-		return &search.DocumentMatch{Score: score}
-	}
-)
-
-func TestCollectStoreListRoundTrip(t *testing.T) {
-	l := newStoreList(20, search.ScoreCompare)
+func TestCollectStoreSliceRoundTrip(t *testing.T) {
+	l := newStoreSlice(20, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 4, 1, 5, 9, 2, 6} {
 		l.add(makeScoreDoc(s))
 	}
@@ -54,9 +43,9 @@ func TestCollectStoreListRoundTrip(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
+func TestCollectStoreSliceAddNotExceedingSize(t *testing.T) {
 	const k = 3
-	l := newStoreList(k, search.ScoreCompare)
+	l := newStoreSlice(k, search.ScoreCompare)
 	var evictedScores []float64
 	for _, s := range []float64{1, 5, 3, 7, 2} {
 		ev := l.AddNotExceedingSize(makeScoreDoc(s), k)
@@ -84,8 +73,8 @@ func TestCollectStoreListAddNotExceedingSize(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListSkip(t *testing.T) {
-	l := newStoreList(20, search.ScoreCompare)
+func TestCollectStoreSliceSkip(t *testing.T) {
+	l := newStoreSlice(20, search.ScoreCompare)
 	for _, s := range []float64{1, 2, 3, 4, 5} {
 		l.add(makeScoreDoc(s))
 	}
@@ -105,8 +94,8 @@ func TestCollectStoreListSkip(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListSkipAll(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreSliceSkipAll(t *testing.T) {
+	l := newStoreSlice(10, search.ScoreCompare)
 	for _, s := range []float64{1, 2, 3} {
 		l.add(makeScoreDoc(s))
 	}
@@ -119,8 +108,8 @@ func TestCollectStoreListSkipAll(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListInternal(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreSliceInternal(t *testing.T) {
+	l := newStoreSlice(10, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 4} {
 		l.add(makeScoreDoc(s))
 	}
@@ -128,17 +117,17 @@ func TestCollectStoreListInternal(t *testing.T) {
 	if len(iv) != 3 {
 		t.Fatalf("Internal len=%d want 3", len(iv))
 	}
-	// Linked list: Front=worst→Back=best, so Internal() iterates Front→Back = ascending.
-	want := []float64{1, 3, 4}
+	// Slice is kept sorted best→worst, so Internal() is descending.
+	want := []float64{4, 3, 1}
 	for i, w := range want {
 		if iv[i].Score != w {
-			t.Errorf("Internal[%d]=%.2f want %.2f (ascending from worst)", i, iv[i].Score, w)
+			t.Errorf("Internal[%d]=%.2f want %.2f (descending from best)", i, iv[i].Score, w)
 		}
 	}
 }
 
-func TestCollectStoreListRemoveLast(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreSliceRemoveLast(t *testing.T) {
+	l := newStoreSlice(10, search.ScoreCompare)
 	for _, s := range []float64{3, 1, 5} {
 		l.add(makeScoreDoc(s))
 	}
@@ -151,8 +140,8 @@ func TestCollectStoreListRemoveLast(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListSingleElement(t *testing.T) {
-	l := newStoreList(5, search.ScoreCompare)
+func TestCollectStoreSliceSingleElement(t *testing.T) {
+	l := newStoreSlice(5, search.ScoreCompare)
 	l.add(makeScoreDoc(7.5))
 
 	result, err := l.Final(0, noFixup)
@@ -169,8 +158,8 @@ func TestCollectStoreListSingleElement(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListEqualScores(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreSliceEqualScores(t *testing.T) {
+	l := newStoreSlice(10, search.ScoreCompare)
 	for range 5 {
 		l.add(makeScoreDoc(3.0))
 	}
@@ -188,8 +177,8 @@ func TestCollectStoreListEqualScores(t *testing.T) {
 	}
 }
 
-func TestCollectStoreListFixupError(t *testing.T) {
-	l := newStoreList(10, search.ScoreCompare)
+func TestCollectStoreSliceFixupError(t *testing.T) {
+	l := newStoreSlice(10, search.ScoreCompare)
 	l.add(makeScoreDoc(1.0))
 
 	errFixup := func(*search.DocumentMatch) error {

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -66,6 +66,7 @@ type TopNCollector struct {
 	facetsBuilder *search.FacetsBuilder
 
 	store collectorStore
+	cmp   collectorCompare
 
 	needDocIds    bool
 	neededFields  []string
@@ -125,11 +126,19 @@ func NewNestedTopNCollectorAfter(size int, sort search.SortOrder, after []string
 }
 
 func newTopNCollector(size int, skip int, sort search.SortOrder, nr index.NestedReader) *TopNCollector {
-	hc := &TopNCollector{size: size, skip: skip, sort: sort}
+	hc := &TopNCollector{
+		size:          size,
+		skip:          skip,
+		sort:          sort,
+		neededFields:  sort.RequiredFields(),
+		cachedScoring: sort.CacheIsScore(),
+		cachedDesc:    sort.CacheDescending(),
+		needDocIds:    sort.RequiresDocID(),
+	}
 
-	hc.store = getOptimalCollectorStore(size, skip, func(i, j *search.DocumentMatch) int {
-		return hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, i, j)
-	})
+	hc.cmp = getOptimalCollectorCompare(sort, hc.cachedScoring, hc.cachedDesc)
+
+	hc.store = getOptimalCollectorStore(size, skip, hc.cmp)
 
 	if nr != nil {
 		descAdder := func(parent, child *search.DocumentMatch) error {
@@ -157,14 +166,6 @@ func newTopNCollector(size int, skip int, sort search.SortOrder, nr index.Nested
 		}
 		hc.nestedStore = newStoreNested(nr, search.DescendantAdderCallbackFn(descAdder))
 	}
-
-	// these lookups traverse an interface, so do once up-front
-	if sort.RequiresDocID() {
-		hc.needDocIds = true
-	}
-	hc.neededFields = sort.RequiredFields()
-	hc.cachedScoring = sort.CacheIsScore()
-	hc.cachedDesc = sort.CacheDescending()
 
 	return hc
 }
@@ -265,6 +266,15 @@ func getOptimalCollectorStore(size, skip int, comparator collectorCompare) colle
 		return newStoreHeap(backingSize, comparator)
 	} else {
 		return newStoreSlice(backingSize, comparator)
+	}
+}
+
+func getOptimalCollectorCompare(sort search.SortOrder, cachedScoring, cachedDesc []bool) collectorCompare {
+	if len(sort) == 1 && cachedScoring[0] && cachedDesc[0] {
+		return search.ScoreCompare
+	}
+	return func(i, j *search.DocumentMatch) int {
+		return sort.Compare(cachedScoring, cachedDesc, i, j)
 	}
 }
 
@@ -538,7 +548,7 @@ func MakeTopNDocumentMatchHandler(
 				// exact sort order matches use hit number to break tie
 				// but we want to allow for exact match, so we pretend
 				hc.searchAfter.HitNumber = d.HitNumber
-				if hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, d, hc.searchAfter) <= 0 {
+				if hc.cmp(d, hc.searchAfter) <= 0 {
 					ctx.DocumentMatchPool.Put(d)
 					return nil
 				}
@@ -548,9 +558,7 @@ func MakeTopNDocumentMatchHandler(
 			// with this one comparison, we can avoid all heap operations if
 			// this hit would have been added and then immediately removed
 			if hc.lowestMatchOutsideResults != nil {
-				cmp := hc.sort.Compare(hc.cachedScoring, hc.cachedDesc, d,
-					hc.lowestMatchOutsideResults)
-				if cmp >= 0 {
+				if hc.cmp(d, hc.lowestMatchOutsideResults) >= 0 {
 					// this hit can't possibly be in the result set, so avoid heap ops
 					ctx.DocumentMatchPool.Put(d)
 					return nil
@@ -562,9 +570,7 @@ func MakeTopNDocumentMatchHandler(
 				if hc.lowestMatchOutsideResults == nil {
 					hc.lowestMatchOutsideResults = removed
 				} else {
-					cmp := hc.sort.Compare(hc.cachedScoring, hc.cachedDesc,
-						removed, hc.lowestMatchOutsideResults)
-					if cmp < 0 {
+					if hc.cmp(removed, hc.lowestMatchOutsideResults) < 0 {
 						tmp := hc.lowestMatchOutsideResults
 						hc.lowestMatchOutsideResults = removed
 						ctx.DocumentMatchPool.Put(tmp)

--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -62,8 +62,13 @@ func (s *DisjunctionQueryScorer) Score(ctx *search.SearchContext, constituents [
 		rawExpl = &search.Explanation{Value: sum, Message: "sum of:", Children: childrenExplanations}
 	}
 
-	coord := float64(countMatch) / float64(countTotal)
-	newScore := sum * coord
+	var newScore float64
+	if countMatch == countTotal {
+		newScore = sum
+	} else {
+		coord := float64(countMatch) / float64(countTotal)
+		newScore = sum * coord
+	}
 	var newExpl *search.Explanation
 	if s.options.Explain {
 		ce := make([]*search.Explanation, 2)

--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -62,11 +62,12 @@ func (s *DisjunctionQueryScorer) Score(ctx *search.SearchContext, constituents [
 		rawExpl = &search.Explanation{Value: sum, Message: "sum of:", Children: childrenExplanations}
 	}
 
-	var newScore float64
+	var newScore, coord float64
 	if countMatch == countTotal {
+		coord = 1.0
 		newScore = sum
 	} else {
-		coord := float64(countMatch) / float64(countTotal)
+		coord = float64(countMatch) / float64(countTotal)
 		newScore = sum * coord
 	}
 	var newExpl *search.Explanation

--- a/search/scorer/scorer_disjunction.go
+++ b/search/scorer/scorer_disjunction.go
@@ -62,11 +62,9 @@ func (s *DisjunctionQueryScorer) Score(ctx *search.SearchContext, constituents [
 		rawExpl = &search.Explanation{Value: sum, Message: "sum of:", Children: childrenExplanations}
 	}
 
-	var newScore, coord float64
-	if countMatch == countTotal {
-		coord = 1.0
-		newScore = sum
-	} else {
+	newScore := sum
+	coord := 1.0
+	if countMatch != countTotal {
 		coord = float64(countMatch) / float64(countTotal)
 		newScore = sum * coord
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -235,8 +235,10 @@ func (dm *DocumentMatch) Reset() *DocumentMatch {
 	}
 	// remember the score breakdown map
 	scoreBreakdown := dm.ScoreBreakdown
-	// clear out the score breakdown map
-	clear(scoreBreakdown)
+	if scoreBreakdown != nil {
+		// clear out the score breakdown map
+		clear(scoreBreakdown)
+	}
 	// remember the Descendants backing array
 	descendants := dm.Descendants
 	for i := range descendants { // recycle each IndexInternalID

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -69,6 +69,15 @@ func newDisjunctionSearcher(ctx context.Context, indexReader index.IndexReader,
 			rv, err := optimizeCompositeSearcher(ctx, "disjunction:unadorned",
 				indexReader, qsearchers, options)
 			if err != nil || rv != nil {
+				if rv != nil {
+					// Finish() extracted all it needs (bitmaps are cloned/new).
+					// Close the original sub-searchers so their TFRs are returned
+					// to the snapshot per-field pool, avoiding re-allocation of
+					// Dictionary+FST Reader objects on the next query.
+					for _, s := range qsearchers {
+						_ = s.Close()
+					}
+				}
 				return rv, err
 			}
 		}

--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -68,17 +68,14 @@ func newDisjunctionSearcher(ctx context.Context, indexReader index.IndexReader,
 			optionsDisjunctionOptimizable(options) {
 			rv, err := optimizeCompositeSearcher(ctx, "disjunction:unadorned",
 				indexReader, qsearchers, options)
-			if err != nil || rv != nil {
-				if rv != nil {
-					// Finish() extracted all it needs (bitmaps are cloned/new).
-					// Close the original sub-searchers so their TFRs are returned
-					// to the snapshot per-field pool, avoiding re-allocation of
-					// Dictionary+FST Reader objects on the next query.
-					for _, s := range qsearchers {
-						_ = s.Close()
-					}
+			if err != nil {
+				return nil, err
+			}
+			if rv != nil {
+				for _, s := range qsearchers {
+					_ = s.Close()
 				}
-				return rv, err
+				return rv, nil
 			}
 		}
 	}

--- a/search/sort.go
+++ b/search/sort.go
@@ -274,6 +274,23 @@ func (so SortOrder) Compare(cachedScoring, cachedDesc []bool, i, j *DocumentMatc
 	return -1
 }
 
+// ScoreCompare will compare two document matches using the score and hit number
+func ScoreCompare(i, j *DocumentMatch) int {
+	if i.Score < j.Score {
+		return 1
+	}
+	if i.Score > j.Score {
+		return -1
+	}
+	if i.HitNumber > j.HitNumber {
+		return 1
+	}
+	if i.HitNumber < j.HitNumber {
+		return -1
+	}
+	return 0
+}
+
 func (so SortOrder) RequiresScore() bool {
 	for _, soi := range so {
 		if soi.RequiresScoring() {

--- a/search/util.go
+++ b/search/util.go
@@ -54,7 +54,10 @@ func MergeFieldTermLocations(dest []FieldTermLocation, matches []*DocumentMatch)
 			n += len(dm.FieldTermLocations)
 		}
 	}
-	if cap(dest) < n {
+	if n == len(dest) {
+		return dest
+	}
+	if n > cap(dest) {
 		dest = append(make([]FieldTermLocation, 0, n), dest...)
 	}
 


### PR DESCRIPTION
- perf: §22 guard clear(scoreBreakdown) on nil; MergeFieldTermLocations fast path.
- perf: §22: Compute coord only when required.
- perf: §22 skip empty bitmap allocs in disjunction:unadorned Finish().
- perf: specialize score-descending comparator + sort.Slice in heap Final.
- fix: close orphaned sub-searchers after unadorned disjunction optimization.
- test: cover collectStoreList linked-list store, collectStoreHeap and collectStoreKNN  (pre-perf-gar gap).
