### PR TITLE
MB-72690: Fixed issue where meta file reader was nil

### DIFF
--- a/index_meta.go
+++ b/index_meta.go
@@ -114,6 +114,11 @@ func openIndexMeta(path string) (*indexMeta, error) {
 		if err != nil {
 			return nil, ErrorIndexMetaCorrupt
 		}
+	} else {
+		fileReader, err = util.NewFileReader("", []byte(indexMetaPath))
+		if err != nil {
+			return nil, err
+		}
 	}
 	im.fileReader = fileReader
 


### PR DESCRIPTION
- meta file reader is expected to never be nil. Fixed unhandled case of opening older segments