### PR TITLE
Treat bare slash as query string term

### DIFF
--- a/search/query/query_string.y
+++ b/search/query/query_string.y
@@ -90,7 +90,7 @@ tSTRING {
 	str := $1
 	logDebugGrammar("STRING - %s", str)
 	var q FieldableQuery
-	if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+	if len(str) > 1 && strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
 	  q = NewRegexpQuery(str[1:len(str)-1])
 	} else if strings.ContainsAny(str, "*?"){
 	  q = NewWildcardQuery(str)
@@ -153,7 +153,7 @@ fieldName tCOLON tSTRING {
 	str := $3
 	logDebugGrammar("FIELD - %s STRING - %s", field, str)
 	var q FieldableQuery
-	if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+	if len(str) > 1 && strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
 		q = NewRegexpQuery(str[1:len(str)-1])
 	} else if strings.ContainsAny(str, "*?"){
 	  q = NewWildcardQuery(str)

--- a/search/query/query_string.y.go
+++ b/search/query/query_string.y.go
@@ -543,7 +543,7 @@ yydefault:
 			str := yyDollar[1].s
 			logDebugGrammar("STRING - %s", str)
 			var q FieldableQuery
-			if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+			if len(str) > 1 && strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
 				q = NewRegexpQuery(str[1 : len(str)-1])
 			} else if strings.ContainsAny(str, "*?") {
 				q = NewWildcardQuery(str)
@@ -616,7 +616,7 @@ yydefault:
 			str := yyDollar[3].s
 			logDebugGrammar("FIELD - %s STRING - %s", field, str)
 			var q FieldableQuery
-			if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+			if len(str) > 1 && strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
 				q = NewRegexpQuery(str[1 : len(str)-1])
 			} else if strings.ContainsAny(str, "*?") {
 				q = NewWildcardQuery(str)

--- a/search/query/query_string_parser_test.go
+++ b/search/query/query_string_parser_test.go
@@ -656,6 +656,30 @@ func TestQuerySyntaxParserValid(t *testing.T) {
 				nil),
 		},
 		{
+			input:   `\/`,
+			mapping: mapping.NewIndexMapping(),
+			result: NewBooleanQueryForQueryString(
+				nil,
+				[]Query{
+					NewMatchQuery("/"),
+				},
+				nil),
+		},
+		{
+			input:   `path:\/`,
+			mapping: mapping.NewIndexMapping(),
+			result: NewBooleanQueryForQueryString(
+				nil,
+				[]Query{
+					func() Query {
+						q := NewMatchQuery("/")
+						q.SetField("path")
+						return q
+					}(),
+				},
+				nil),
+		},
+		{
 			input:   `mart*`,
 			mapping: mapping.NewIndexMapping(),
 			result: NewBooleanQueryForQueryString(

--- a/search_test.go
+++ b/search_test.go
@@ -1192,6 +1192,42 @@ func TestQueryStringEmptyConjunctionSearcher(t *testing.T) {
 	_, _ = index.Search(searchReq)
 }
 
+func TestQueryStringSearchEscapedSlashPath(t *testing.T) {
+	mapping := NewIndexMapping()
+	pathFieldMapping := NewTextFieldMapping()
+	pathFieldMapping.Analyzer = keyword.Name
+	mapping.DefaultMapping.AddFieldMappingsAt("path", pathFieldMapping)
+
+	index, err := NewMemOnly(mapping)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = index.Close()
+	}()
+
+	if err := index.Index("root", map[string]interface{}{"path": "/"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Index("tmp", map[string]interface{}{"path": "/tmp"}); err != nil {
+		t.Fatal(err)
+	}
+
+	query := NewQueryStringQuery(`path:\/`)
+	searchReq := NewSearchRequest(query)
+
+	res, err := index.Search(searchReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Total != 1 {
+		t.Fatalf("expected 1 hit for escaped slash path, got %d", res.Total)
+	}
+	if res.Hits[0].ID != "root" {
+		t.Fatalf("expected root hit, got %s", res.Hits[0].ID)
+	}
+}
+
 func TestDisjunctionQueryIncorrectMin(t *testing.T) {
 	tmpIndexPath := createTmpIndexPath(t)
 	defer cleanupTmpIndexPath(t, tmpIndexPath)


### PR DESCRIPTION
## Summary
- Treat a single escaped `/` query-string term as a match term instead of an empty slash-delimited regexp.
- Add parser and search coverage for querying a `path` field with `/`.

## Tests
- `gofmt -w search/query/query_string.y.go search/query/query_string_parser_test.go search_test.go`
- `go test ./search/query -run 'TestQuerySyntaxParserValid' -count=1`
- `go test . -run 'TestQueryStringSearchEscapedSlashPath|TestQueryStringEmptyConjunctionSearcher' -count=1`
- `go test ./search/query . -count=1`
- `go vet ./search/query .`
- `git diff --check`

Fixes #2362

Note: CONTRIBUTING.md says Couchbase CLA applies.
