### PR TITLE
Panic on async errors if `onAsyncError` callback unset

### DIFF
--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -323,10 +323,12 @@ func (s *Scorch) fireEvent(kind EventKind, dur time.Duration) bool {
 }
 
 func (s *Scorch) fireAsyncError(err error) {
+	atomic.AddUint64(&s.stats.TotOnErrors, 1)
 	if s.onAsyncError != nil {
 		s.onAsyncError(err, s.path)
+	} else {
+		panic(err)
 	}
-	atomic.AddUint64(&s.stats.TotOnErrors, 1)
 }
 
 func (s *Scorch) Open() error {

--- a/index_test.go
+++ b/index_test.go
@@ -33,8 +33,6 @@ import (
 
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/v2/document"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/boltdb"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/null"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
 	"github.com/blevesearch/bleve/v2/search/query"
@@ -42,6 +40,8 @@ import (
 
 	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
+	"github.com/blevesearch/bleve/v2/index/upsidedown/store/boltdb"
+	"github.com/blevesearch/bleve/v2/index/upsidedown/store/null"
 )
 
 type Fatalfable interface {

--- a/search/collector/topn_test.go
+++ b/search/collector/topn_test.go
@@ -727,7 +727,7 @@ func setupIndex(t *testing.T) index.Index {
 	i, err := scorch.NewScorch(
 		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path": t.TempDir(),
 		},
 		analysisQueue)
 	if err != nil {
@@ -752,6 +752,16 @@ func TestSetFacetsBuilder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err := indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	fb := search.NewFacetsBuilder(indexReader)
 	facetBuilder := facet.NewTermsFacetBuilder(sortFacetsField, 100)

--- a/search/searcher/geoshape_contains_test.go
+++ b/search/searcher/geoshape_contains_test.go
@@ -111,6 +111,11 @@ func TestPointPolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestLinestringPolygonContains(t *testing.T) {
@@ -174,6 +179,11 @@ func TestLinestringPolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestEnvelopePointContains(t *testing.T) {
@@ -221,6 +231,11 @@ func TestEnvelopePointContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestEnvelopeLinestringContains(t *testing.T) {
@@ -267,6 +282,11 @@ func TestEnvelopeLinestringContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -331,6 +351,11 @@ func TestEnvelopePolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonPointContains(t *testing.T) {
@@ -393,6 +418,11 @@ func TestPolygonPointContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonLinestringContains(t *testing.T) {
@@ -439,6 +469,11 @@ func TestPolygonLinestringContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -495,6 +530,11 @@ func TestPolygonEnvelopeContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -562,6 +602,11 @@ func TestMultiPointPolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPointLinestringContains(t *testing.T) {
@@ -616,6 +661,11 @@ func TestMultiPointLinestringContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -672,6 +722,11 @@ func TestMultiPointContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonContains(t *testing.T) {
@@ -726,6 +781,11 @@ func TestPolygonContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -790,6 +850,11 @@ func TestPolygonMultiPointContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPolygonPolygonContains(t *testing.T) {
@@ -845,6 +910,11 @@ func TestMultiPolygonPolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiLinestringMultiPolygonContains(t *testing.T) {
@@ -898,6 +968,11 @@ func TestMultiLinestringMultiPolygonContains(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestGeometryCollectionPolygonContains(t *testing.T) {
@@ -945,6 +1020,11 @@ func TestGeometryCollectionPolygonContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1002,5 +1082,10 @@ func TestGeometryCollectionMultiPolygonContains(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }

--- a/search/searcher/geoshape_intersects_test.go
+++ b/search/searcher/geoshape_intersects_test.go
@@ -19,16 +19,15 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
 func setupIndex(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path": t.TempDir(),
 		},
 		analysisQueue)
 	if err != nil {
@@ -92,6 +91,11 @@ func TestPointIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPointMultiPointIntersects(t *testing.T) {
@@ -142,6 +146,11 @@ func TestPointMultiPointIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -203,6 +212,11 @@ func TestPointLinestringIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPointMultiLinestringIntersects(t *testing.T) {
@@ -262,6 +276,11 @@ func TestPointMultiLinestringIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -330,6 +349,11 @@ func TestPointPolygonIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -402,6 +426,11 @@ func TestPointMultiPolygonIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestEnvelopePointIntersects(t *testing.T) {
@@ -456,6 +485,11 @@ func TestEnvelopePointIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -520,6 +554,11 @@ func TestEnvelopeLinestringIntersect(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestEnvelopePolygonIntersect(t *testing.T) {
@@ -575,6 +614,11 @@ func TestEnvelopePolygonIntersect(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPointIntersects(t *testing.T) {
@@ -617,6 +661,11 @@ func TestMultiPointIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -703,6 +752,11 @@ func TestLinestringIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -807,6 +861,11 @@ func TestLinestringPolygonIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestLinestringPointIntersects(t *testing.T) {
@@ -886,6 +945,11 @@ func TestLinestringPointIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiLinestringIntersects(t *testing.T) {
@@ -937,6 +1001,11 @@ func TestMultiLinestringIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiLinestringMultiPointIntersects(t *testing.T) {
@@ -987,6 +1056,11 @@ func TestMultiLinestringMultiPointIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1132,6 +1206,11 @@ func TestPolygonIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonLinestringIntersects(t *testing.T) {
@@ -1204,6 +1283,11 @@ func TestPolygonLinestringIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1278,6 +1362,11 @@ func TestPolygonMultiLinestringIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonPointIntersects(t *testing.T) {
@@ -1329,6 +1418,11 @@ func TestPolygonPointIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1404,6 +1498,11 @@ func TestMultiPolygonIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPolygonMultiPointIntersects(t *testing.T) {
@@ -1461,6 +1560,11 @@ func TestMultiPolygonMultiPointIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPolygonMultiLinestringIntersects(t *testing.T) {
@@ -1511,6 +1615,11 @@ func TestMultiPolygonMultiLinestringIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestGeometryCollectionIntersects(t *testing.T) {
@@ -1557,6 +1666,11 @@ func TestGeometryCollectionIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1620,6 +1734,11 @@ func TestGeometryCollectionPointIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestGeometryCollectionLinestringIntersects(t *testing.T) {
@@ -1673,6 +1792,11 @@ func TestGeometryCollectionLinestringIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1728,6 +1852,11 @@ func TestGeometryCollectionPolygonIntersects(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPointGeometryCollectionIntersects(t *testing.T) {
@@ -1781,5 +1910,10 @@ func TestPointGeometryCollectionIntersects(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }

--- a/search/searcher/geoshape_within_test.go
+++ b/search/searcher/geoshape_within_test.go
@@ -120,6 +120,11 @@ func TestPointWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPointWithin(t *testing.T) {
@@ -174,6 +179,10 @@ func TestMultiPointWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -238,6 +247,10 @@ func TestEnvelopePointWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestEnvelopeLinestringWithin(t *testing.T) {
@@ -300,6 +313,10 @@ func TestEnvelopeLinestringWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -364,6 +381,10 @@ func TestEnvelopePolygonWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPointLinestringWithin(t *testing.T) {
@@ -417,6 +438,10 @@ func TestPointLinestringWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -472,6 +497,10 @@ func TestPointPolygonWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -552,6 +581,10 @@ func TestLinestringPointWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPointMultiLinestringWithin(t *testing.T) {
@@ -605,6 +638,10 @@ func TestMultiPointMultiLinestringWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -660,6 +697,10 @@ func TestLinestringWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestLinestringGeometryCollectionWithin(t *testing.T) {
@@ -707,6 +748,10 @@ func TestLinestringGeometryCollectionWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -824,6 +869,10 @@ func TestPolygonPointWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestPolygonLinestringWithin(t *testing.T) {
@@ -907,6 +956,11 @@ func TestPolygonLinestringWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -993,6 +1047,10 @@ func TestPolygonWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPolygonMultiPointWithin(t *testing.T) {
@@ -1065,6 +1123,10 @@ func TestMultiPolygonMultiPointWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiLinestringWithin(t *testing.T) {
@@ -1110,6 +1172,10 @@ func TestMultiLinestringWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1170,6 +1236,10 @@ func TestMultiPolygonMultiLinestringWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestMultiPolygonWithin(t *testing.T) {
@@ -1228,6 +1298,10 @@ func TestMultiPolygonWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }
 
@@ -1300,6 +1374,10 @@ func TestGeometryCollectionWithin(t *testing.T) {
 			t.Error(err.Error())
 		}
 	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
+	}
 }
 
 func TestGeometryCollectionPointWithin(t *testing.T) {
@@ -1347,5 +1425,9 @@ func TestGeometryCollectionPointWithin(t *testing.T) {
 		if err != nil {
 			t.Error(err.Error())
 		}
+	}
+	err := i.Close()
+	if err != nil {
+		t.Fatalf("error closing index: %v", err)
 	}
 }

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -247,6 +247,10 @@ func TestScorchCompositeSearchOptimizations(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = twoDocIndex.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	tests := []compositeSearchOptimizationTest{

--- a/search/searcher/search_disjunction_test.go
+++ b/search/searcher/search_disjunction_test.go
@@ -24,12 +24,18 @@ import (
 )
 
 func TestDisjunctionSearch(t *testing.T) {
+	dir := t.TempDir()
+	twoDocIndex := initTwoDocScorch(dir)
 	twoDocIndexReader, err := twoDocIndex.Reader()
 	if err != nil {
 		t.Error(err)
 	}
 	defer func() {
 		err := twoDocIndexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = twoDocIndex.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,26 +127,30 @@ func TestDisjunctionSearch(t *testing.T) {
 			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
 		}
 		next, err := test.searcher.Next(ctx)
-		i := 0
+		actualMatches := make(map[string]float64)
 		for err == nil && next != nil {
-			if i < len(test.results) {
-				if !next.IndexInternalID.Equals(test.results[i].IndexInternalID) {
-					t.Errorf("expected result %d to have id %s got %s for test %d", i, test.results[i].IndexInternalID, next.IndexInternalID, testIndex)
-				}
-				if !scoresCloseEnough(next.Score, test.results[i].Score) {
-					t.Errorf("expected result %d to have score %v got  %v for test %d", i, test.results[i].Score, next.Score, testIndex)
-					t.Logf("scoring explanation: %s", next.Expl)
-				}
+			extID, err := twoDocIndexReader.ExternalID(next.IndexInternalID)
+			if err != nil {
+				t.Fatalf("error getting external id: %v for test %d", err, testIndex)
 			}
+			actualMatches[extID] = next.Score
 			ctx.DocumentMatchPool.Put(next)
 			next, err = test.searcher.Next(ctx)
-			i++
 		}
 		if err != nil {
 			t.Fatalf("error iterating searcher: %v for test %d", err, testIndex)
 		}
-		if len(test.results) != i {
-			t.Errorf("expected %d results got %d for test %d", len(test.results), i, testIndex)
+		if len(test.results) != len(actualMatches) {
+			t.Errorf("expected %d results got %d for test %d", len(test.results), len(actualMatches), testIndex)
+		}
+		for i, expected := range test.results {
+			extID := string(expected.IndexInternalID)
+			actualScore, ok := actualMatches[extID]
+			if !ok {
+				t.Errorf("expected result with id %s not found for test %d", extID, testIndex)
+			} else if !scoresCloseEnough(actualScore, expected.Score) {
+				t.Errorf("expected result %d (id %s) to have score %v got %v for test %d", i, extID, expected.Score, actualScore, testIndex)
+			}
 		}
 	}
 }
@@ -235,6 +245,10 @@ func TestUnadornedDisjunctionAdvance(t *testing.T) {
 	}
 	defer func() {
 		err := twoDocIndexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = twoDocIndex.Close()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/search/searcher/search_docid_test.go
+++ b/search/searcher/search_docid_test.go
@@ -19,18 +19,18 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/document"
-	"github.com/blevesearch/bleve/v2/index/upsidedown"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
 
 func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
+	dir := t.TempDir()
 	analysisQueue := index.NewAnalysisQueue(1)
-	i, err := upsidedown.NewUpsideDownCouch(
-		gtreap.Name,
+	i, err := scorch.NewScorch(
+		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path": dir,
 		},
 		analysisQueue)
 	if err != nil {
@@ -40,6 +40,12 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err := i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 	for _, id := range indexed {
 		doc := document.NewDocument(id)
 		doc.AddField(document.NewTextField("desc", []uint64{}, []byte("beer")))
@@ -83,8 +89,12 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !index.IndexInternalID(id).Equals(m.IndexInternalID) {
-			t.Fatalf("expected %v at position %v, got %v", id, i, m.IndexInternalID)
+		gotID, err := indexReader.ExternalID(m.IndexInternalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotID != id {
+			t.Fatalf("expected %v at position %d, got %v", id, i, gotID)
 		}
 		ctx.DocumentMatchPool.Put(m)
 	}
@@ -97,26 +107,49 @@ func testDocIDSearcher(t *testing.T, indexed, searched, wanted []string) {
 	}
 	ctx.DocumentMatchPool.Put(m)
 
+	searcher, err = NewDocIDSearcher(context.TODO(), indexReader, searched, 1.0, explainOff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := searcher.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	// Check seeking
-	for _, id := range wanted {
-		if len(id) != 2 {
-			t.Fatalf("expected identifier must be 2 characters long, got %v", id)
+	for _, target := range wanted {
+		iid, err := indexReader.InternalID(target)
+		if err != nil {
+			t.Fatal(err)
 		}
-		before := id[:1]
-		for _, target := range []string{before, id} {
-			m, err := searcher.Advance(ctx, index.IndexInternalID(target))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if m == nil || !m.IndexInternalID.Equals(index.IndexInternalID(id)) {
-				t.Fatalf("advancing to %v returned %v instead of %v", before, m, id)
-			}
-			ctx.DocumentMatchPool.Put(m)
+		m, err := searcher.Advance(ctx, iid)
+		if err != nil {
+			t.Fatal(err)
 		}
+		if m == nil {
+			t.Fatalf("advancing to %v returned nil", target)
+		}
+		eid, err := indexReader.ExternalID(m.IndexInternalID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if eid != target {
+			t.Fatalf("advancing to %v returned %v instead of %v", target, eid, target)
+		}
+		ctx.DocumentMatchPool.Put(m)
+
 	}
 	// Seek after the end of the sequence
 	after := "zzz"
-	m, err = searcher.Advance(ctx, index.IndexInternalID(after))
+
+	iid, err := indexReader.InternalID(after)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, err = searcher.Advance(ctx, iid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -17,12 +17,12 @@ package searcher
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
-	"github.com/blevesearch/bleve/v2/index/upsidedown"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/numeric"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
@@ -57,6 +57,10 @@ func TestGeoBoundingBox(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for _, test := range tests {
@@ -82,21 +86,27 @@ func testGeoBoundingBoxSearch(i index.IndexReader, minLon, minLat, maxLon, maxLa
 	}
 	docMatch, err := gbs.Next(ctx)
 	for docMatch != nil && err == nil {
-		rv = append(rv, string(docMatch.IndexInternalID))
+		docID, err := i.ExternalID(docMatch.IndexInternalID)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, docID)
 		docMatch, err = gbs.Next(ctx)
 	}
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(rv)
 	return rv, nil
 }
 
 func setupGeo(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
-	i, err := upsidedown.NewUpsideDownCouch(
-		gtreap.Name,
+	i, err := scorch.NewScorch(
+		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path":          t.TempDir(),
+			"spatialPlugin": "s2",
 		},
 		analysisQueue)
 	if err != nil {

--- a/search/searcher/search_geopointdistance_test.go
+++ b/search/searcher/search_geopointdistance_test.go
@@ -17,6 +17,7 @@ package searcher
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/geo"
@@ -50,6 +51,10 @@ func TestGeoPointDistanceSearcher(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for _, test := range tests {
@@ -75,12 +80,17 @@ func testGeoPointDistanceSearch(i index.IndexReader, centerLon, centerLat, dist 
 	}
 	docMatch, err := gds.Next(ctx)
 	for docMatch != nil && err == nil {
-		rv = append(rv, string(docMatch.IndexInternalID))
+		docID, err := i.ExternalID(docMatch.IndexInternalID)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, docID)
 		docMatch, err = gds.Next(ctx)
 	}
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(rv)
 	return rv, nil
 }
 

--- a/search/searcher/search_geopolygon_test.go
+++ b/search/searcher/search_geopolygon_test.go
@@ -17,12 +17,12 @@ package searcher
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
-	"github.com/blevesearch/bleve/v2/index/upsidedown"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -46,6 +46,10 @@ func TestSimpleGeoPolygons(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,6 +118,10 @@ func TestRealGeoPolygons(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for _, test := range tests {
@@ -150,6 +158,10 @@ func TestGeoRectanglePolygon(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for _, test := range tests {
@@ -174,21 +186,27 @@ func testGeoPolygonSearch(i index.IndexReader, polygon []geo.Point, field string
 	}
 	docMatch, err := gbs.Next(ctx)
 	for docMatch != nil && err == nil {
-		rv = append(rv, string(docMatch.IndexInternalID))
+		docID, err := i.ExternalID(docMatch.IndexInternalID)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, docID)
 		docMatch, err = gbs.Next(ctx)
 	}
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(rv)
 	return rv, nil
 }
 
 func setupGeoPolygonPoints(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
-	i, err := upsidedown.NewUpsideDownCouch(
-		gtreap.Name,
+	i, err := scorch.NewScorch(
+		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path":          t.TempDir(),
+			"spatialPlugin": "s2",
 		},
 		analysisQueue)
 	if err != nil {
@@ -379,15 +397,20 @@ func TestComplexGeoPolygons(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
 func setupComplexGeoPolygonPoints(t *testing.T, points []geoPoint) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
-	i, err := upsidedown.NewUpsideDownCouch(
-		gtreap.Name,
+	i, err := scorch.NewScorch(
+		scorch.Name,
 		map[string]interface{}{
-			"path": "",
+			"path":          t.TempDir(),
+			"spatialPlugin": "s2",
 		},
 		analysisQueue)
 	if err != nil {

--- a/search/searcher/search_geoshape_circle_test.go
+++ b/search/searcher/search_geoshape_circle_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -101,6 +100,10 @@ func TestGeoJsonCircleIntersectsQuery(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,6 +188,10 @@ func TestGeoJsonCircleWithInQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -247,6 +254,10 @@ func TestGeoJsonCircleContainsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -290,9 +301,9 @@ func runGeoShapeCircleRelationQuery(relation string, i index.IndexReader,
 func setupGeoJsonShapesIndexForCircleQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_geoshape_envelope_test.go
+++ b/search/searcher/search_geoshape_envelope_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -131,6 +130,10 @@ func TestGeoJsonEnvelopeWithInQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -212,6 +215,10 @@ func TestGeoJsonEnvelopeIntersectsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -288,6 +295,10 @@ func TestGeoJsonEnvelopeContainsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -331,9 +342,9 @@ func runGeoShapeEnvelopeRelationQuery(relation string, i index.IndexReader,
 func setupGeoJsonShapesIndexForEnvelopeQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_geoshape_geometrycollection_test.go
+++ b/search/searcher/search_geoshape_geometrycollection_test.go
@@ -17,6 +17,7 @@ package searcher
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/document"
@@ -449,9 +450,11 @@ func TestGeoJSONContainsQueryAgainstGeometryCollection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(got, test.want) {
+		want := test.want
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
 			t.Errorf("test %d, expected %v, got %v for polygon: %+v",
-				n, test.want, got, test.points)
+				n, want, got, test.points)
 		}
 	}
 }
@@ -474,13 +477,17 @@ func runGeoShapeGeometryCollectionRelationQuery(relation string, i index.IndexRe
 	}
 	docMatch, err := gbs.Next(ctx)
 	for docMatch != nil && err == nil {
-		docID, _ := i.ExternalID(docMatch.IndexInternalID)
+		docID, err := i.ExternalID(docMatch.IndexInternalID)
+		if err != nil {
+			return nil, err
+		}
 		rv = append(rv, docID)
 		docMatch, err = gbs.Next(ctx)
 	}
 	if err != nil {
 		return nil, err
 	}
+	sort.Strings(rv)
 	return rv, nil
 }
 

--- a/search/searcher/search_geoshape_geometrycollection_test.go
+++ b/search/searcher/search_geoshape_geometrycollection_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -134,6 +133,10 @@ func TestGeoJSONIntersectsQueryAgainstGeometryCollection(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -276,6 +279,10 @@ func TestGeoJSONWithInQueryAgainstGeometryCollection(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,6 +437,10 @@ func TestGeoJSONContainsQueryAgainstGeometryCollection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -476,9 +487,9 @@ func runGeoShapeGeometryCollectionRelationQuery(relation string, i index.IndexRe
 func setupGeoJsonShapesIndexForGeometryCollectionQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_geoshape_linestring_test.go
+++ b/search/searcher/search_geoshape_linestring_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -124,6 +123,10 @@ func TestGeoJsonLinestringIntersectsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -208,6 +211,10 @@ func TestGeoJsonLinestringContainsQuery(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -339,6 +346,10 @@ func TestGeoJsonMultiLinestringContainsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -394,9 +405,9 @@ func executeSearch(relation string, i index.IndexReader,
 func setupGeoJsonShapesIndexForLinestringQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_geoshape_points_test.go
+++ b/search/searcher/search_geoshape_points_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -108,6 +107,10 @@ func TestGeoJsonPointContainsQuery(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -255,6 +258,10 @@ func TestGeoJsonMultiPointWithInQuery(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -413,6 +420,10 @@ func TestGeoJsonMultiPointIntersectsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -465,9 +476,9 @@ type Fatalfable interface {
 func setupGeoJsonShapesIndex(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_geoshape_polygon_test.go
+++ b/search/searcher/search_geoshape_polygon_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/blevesearch/bleve/v2/document"
 	"github.com/blevesearch/bleve/v2/geo"
 	"github.com/blevesearch/bleve/v2/index/scorch"
-	"github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap"
 	"github.com/blevesearch/bleve/v2/search"
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -136,6 +135,10 @@ func TestGeoJsonPolygonIntersectsQuery(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -291,6 +294,10 @@ func TestGeoJsonPolygonContainsQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -443,6 +450,10 @@ func TestGeoJsonPolygonWithInQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -486,9 +497,9 @@ func runGeoShapePolygonQueryWithRelation(relation string, i index.IndexReader,
 func setupGeoJsonShapesIndexForPolygonQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)
@@ -873,6 +884,10 @@ func TestGeoJsonMultiPolygonWithInQuery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -918,9 +933,9 @@ func runGeoShapeMultiPolygonQueryWithRelation(relation string,
 func setupGeoJsonShapesIndexForMultiPolygonQuery(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)
@@ -1000,9 +1015,9 @@ func setupGeoJsonShapesIndexForMultiPolygonQuery(t *testing.T) index.Index {
 func setupGeoJsonPolygonS2LoopPortingIssue(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)
@@ -1067,6 +1082,10 @@ func TestGeoJsonPolygonContainsQueryS2LoopPortingIssue(t *testing.T) {
 	}
 	defer func() {
 		err = indexReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = i.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1149,6 +1168,10 @@ func TestGeoJsonPolygonIntersectsQuery1(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = i.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	for n, test := range tests {
@@ -1167,9 +1190,9 @@ func TestGeoJsonPolygonIntersectsQuery1(t *testing.T) {
 func setupGeoJsonShapesIndexForPolygonQuery1(t *testing.T) index.Index {
 	analysisQueue := index.NewAnalysisQueue(1)
 	i, err := scorch.NewScorch(
-		gtreap.Name,
+		scorch.Name,
 		map[string]interface{}{
-			"path":          "",
+			"path":          t.TempDir(),
 			"spatialPlugin": "s2",
 		},
 		analysisQueue)

--- a/search/searcher/search_regexp_test.go
+++ b/search/searcher/search_regexp_test.go
@@ -40,24 +40,22 @@ func TestRegexpStringSearchUpsideDown(t *testing.T) {
 
 func TestRegexpSearchScorch(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "scorchTwoDoc")
+	twoDocIndex := initTwoDocScorch(dir)
 	defer func() {
+		_ = twoDocIndex.Close()
 		_ = os.RemoveAll(dir)
 	}()
-
-	twoDocIndex := initTwoDocScorch(dir)
 	testRegexpSearch(t, twoDocIndex, internalIDMakerScorch, searcherMaker)
-	_ = twoDocIndex.Close()
 }
 
 func TestRegexpStringSearchScorch(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "scorchTwoDoc")
+	twoDocIndex := initTwoDocScorch(dir)
 	defer func() {
+		_ = twoDocIndex.Close()
 		_ = os.RemoveAll(dir)
 	}()
-
-	twoDocIndex := initTwoDocScorch(dir)
 	testRegexpSearch(t, twoDocIndex, internalIDMakerScorch, searcherStringMaker)
-	_ = twoDocIndex.Close()
 }
 
 func internalIDMakerUpsideDown(id int) index.IndexInternalID {

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -226,6 +226,10 @@ func TestTermRangeSearchTooManyTerms(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = scorchIndex.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	want := []string{"1", "3", "4", "5"}

--- a/test/versus_test.go
+++ b/test/versus_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/index/upsidedown"
 	"github.com/blevesearch/bleve/v2/index/upsidedown/store/boltdb"
+
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
 )


### PR DESCRIPTION
- Earlier, if async error pops up from scorch and the `onAsyncError` handler is unset, all panics would silently close the index entirely, making it hard to catch undefined behaviour in unit tests.
- This PR panics on scorch errors if the handler is unset, allowing us to be aware of failures/index corruption when testing at the unit level itself.
- Fixes a lot of tests that would otherwise panic without this fix, mostly migrating old tests from legacy upside_down to scorch to increase coverage for scorch as only that is being actively maintained and `upside_down` is deprecated.