### PR TITLE
bug: Close bolt on error when updating index

### DIFF
--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -562,6 +562,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 				segment: segment.segment,
 				deleted: nil, // nil since merging handled deletions
 				stats:   segment.stats,
+				mmaped:  segment.mmaped,
 			})
 		}
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -562,7 +562,6 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 				segment: segment.segment,
 				deleted: nil, // nil since merging handled deletions
 				stats:   segment.stats,
-				mmaped:  segment.mmaped,
 			})
 		}
 	}

--- a/index_impl.go
+++ b/index_impl.go
@@ -213,9 +213,6 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 		if !ok {
 			return nil, fmt.Errorf("updated mapping present for unupdatable index")
 		}
-
-		// Load the meta data from bolt so that we can read the current index
-		// mapping to compare with
 		err = ui.OpenMeta()
 		if err != nil {
 			return nil, err

--- a/index_impl.go
+++ b/index_impl.go
@@ -225,12 +225,12 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 		if err != nil {
 			return nil, err
 		}
-		defer func(rv *indexImpl) {
-			if !rv.open {
-				rv.i.Close()
-			}
-		}(rv)
 	}
+	defer func(rv *indexImpl) {
+		if !rv.open {
+			rv.i.Close()
+		}
+	}(rv)
 
 	// now load the mapping
 	indexReader, err := rv.i.Reader()
@@ -269,7 +269,8 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 			return nil, err
 		}
 
-		fieldInfo, err := DeletedFields(im, um)
+		var fieldInfo map[string]*index.UpdateFieldInfo
+		fieldInfo, err = DeletedFields(im, um)
 		if err != nil {
 			return nil, err
 		}
@@ -284,11 +285,6 @@ func openIndexUsing(path string, runtimeConfig map[string]interface{}) (rv *inde
 		if err != nil {
 			return nil, err
 		}
-		defer func(rv *indexImpl) {
-			if !rv.open {
-				rv.i.Close()
-			}
-		}(rv)
 	}
 
 	// mark the index as open


### PR DESCRIPTION
- When updating an index with an updated mapping, we open bolt via scorch's `OpenMeta` API but we never close it on error. 
- The error case can happen if the user has given an invalid mapping or if the updated mapping does not satisfy the criterion required for index update.
- Scorch's `Close()` API handles the dual case:
    - If only bolt is opened but not scorch, it closes only bolt.
    - If both bolt and scorch is opened, it closes both.
- Fix the issue by always closing scorch on error, irrespective of whether it was opened using `OpenMeta` or `Open` or `OpenMeta + Open`.