### PR TITLE
MB-72725: Unify batch merge logic

### DIFF
--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -438,14 +438,12 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 			atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
 		}
 		if err != nil {
-			s.unmarkIneligibleForRemoval(batch.newFilename)
 			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 			return err
 		}
 
 		batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
 		if err != nil {
-			s.unmarkIneligibleForRemoval(batch.newFilename)
 			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 			return err
 		}

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -546,7 +546,7 @@ func cumulateBytesRead(sbs []segment.Segment) uint64 {
 	return rv
 }
 
-func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable) (*IndexSnapshot, map[uint64]struct{}, error) {
+func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
 	var err error
@@ -565,7 +565,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable) (*IndexSn
 	}()
 
 	var numMergedSegments uint64
-	sem := make(chan struct{}, s.persisterOptions.NumPersisterWorkers)
+	sem := make(chan struct{}, po.NumPersisterWorkers)
 	var wg sync.WaitGroup
 	var errM sync.Mutex
 	var errs []error

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -45,11 +45,6 @@ const mergePlanFuncKey = "mergePlanFunc"
 
 type mergePlanFunc func(*IndexSnapshot) (*mergeplan.MergePlan, error)
 
-var (
-	// number workers which parallely execute merge tasks in a merge plan
-	DefaultNumMergeWorkers int = 1
-)
-
 func (s *Scorch) mergerLoop() {
 	defer func() {
 		if r := recover(); r != nil {
@@ -381,124 +376,83 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 	}()
 
 	var numMergedSegments uint64
-	sem := make(chan struct{}, s.mergerOptions.NumMergeWorkers)
-	var wg sync.WaitGroup
-	var errM sync.Mutex
-	var errs []error
 	for batchID := 0; batchID < numBatches; batchID++ {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(batchID int) {
-			var err error
-			defer func() {
-				if err != nil {
-					errM.Lock()
-					errs = append(errs, err)
-					errM.Unlock()
-				}
-				<-sem
-				wg.Done()
-			}()
-			task := mergePlan.Tasks[batchID]
-			if len(task.Segments) == 0 {
-				atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)
-			}
-			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegments, uint64(len(task.Segments)))
+		task := mergePlan.Tasks[batchID]
+		if len(task.Segments) == 0 {
+			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)
+		}
+		atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegments, uint64(len(task.Segments)))
 
-			newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
-			batch := &mergeBatch{
-				snapshots: make([]*SegmentSnapshot, 0, len(task.Segments)),
-				filenames: make([]string, 0, len(task.Segments)),
-				segments:  make([]segment.Segment, 0, len(task.Segments)),
-				drops:     make([]*roaring.Bitmap, 0, len(task.Segments)),
+		newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
+		batch := &mergeBatch{
+			snapshots: make([]*SegmentSnapshot, 0, len(task.Segments)),
+			filenames: make([]string, 0, len(task.Segments)),
+			segments:  make([]segment.Segment, 0, len(task.Segments)),
+			drops:     make([]*roaring.Bitmap, 0, len(task.Segments)),
 
-				new:         nil,
-				newID:       newSegmentID,
-				newDocNums:  nil,
-				newFilename: zapFileName(newSegmentID),
-			}
-			mergeBatches[batchID] = batch
+			new:         nil,
+			newID:       newSegmentID,
+			newDocNums:  nil,
+			newFilename: zapFileName(newSegmentID),
+		}
+		mergeBatches[batchID] = batch
 
-			for _, planSegment := range task.Segments {
-				if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
-					if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
-						if segSnapshot.LiveSize() == 0 {
-							atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
-						} else {
-							batch.snapshots = append(batch.snapshots, segSnapshot)
-							batch.segments = append(batch.segments, segSnapshot.segment)
-							batch.drops = append(batch.drops, segSnapshot.deleted)
-						}
-						// track the files getting merged for unsetting the
-						// removal ineligibility. This helps to unflip files
-						// even with fast merger, slow persister work flows.
-						path := persistedSeg.Path()
-						batch.filenames = append(batch.filenames,
-							strings.TrimPrefix(path, s.path+string(os.PathSeparator)))
+		for _, planSegment := range task.Segments {
+			if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
+				if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
+					if segSnapshot.LiveSize() == 0 {
+						atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
+					} else {
+						batch.snapshots = append(batch.snapshots, segSnapshot)
+						batch.segments = append(batch.segments, segSnapshot.segment)
+						batch.drops = append(batch.drops, segSnapshot.deleted)
 					}
+					// track the files getting merged for unsetting the
+					// removal ineligibility. This helps to unflip files
+					// even with fast merger, slow persister work flows.
+					path := persistedSeg.Path()
+					batch.filenames = append(batch.filenames,
+						strings.TrimPrefix(path, s.path+string(os.PathSeparator)))
 				}
 			}
-
-			if len(batch.segments) == 0 {
-				return
-			}
-
-			atomic.AddUint64(&numMergedSegments, uint64(len(batch.segments)))
-			s.markIneligibleForRemoval(batch.newFilename)
-			path := s.path + string(os.PathSeparator) + batch.newFilename
-
-			fileMergeZapStartTime := time.Now()
-			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
-			prevBytesReadTotal := cumulateBytesRead(batch.segments)
-			batch.newDocNums, _, err = s.segPlugin.MergeUsing(batch.segments, batch.drops, path,
-				cw.cancelCh, s, s.segmentConfig)
-			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
-
-			fileMergeZapTime := uint64(time.Since(fileMergeZapStartTime))
-			atomic.AddUint64(&s.stats.TotFileMergeZapTime, fileMergeZapTime)
-			if atomic.LoadUint64(&s.stats.MaxFileMergeZapTime) < fileMergeZapTime {
-				atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
-			}
-			if err != nil {
-				s.unmarkIneligibleForRemoval(batch.newFilename)
-				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
-				return
-			}
-
-			batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
-			if err != nil {
-				s.unmarkIneligibleForRemoval(batch.newFilename)
-				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
-				return
-			}
-
-			totalBytesRead := batch.new.BytesRead() + prevBytesReadTotal
-			batch.new.ResetBytesRead(totalBytesRead)
-			atomic.AddUint64(&s.stats.TotFileMergeSegments, uint64(len(batch.segments)))
-			mergeBatches[batchID] = batch
-		}(batchID)
-	}
-	wg.Wait()
-	close(sem)
-
-	if len(errs) > 0 {
-		var errf error
-		numClosed := 0
-		for _, e := range errs {
-			if e == segment.ErrClosed {
-				numClosed++
-			}
-			errf = errors.Join(errf, e)
 		}
-		if numClosed == len(errs) {
-			// the index snapshot was closed which will be handled gracefully
-			// by retrying the whole merge operation in a later iteration
-			// so its safe to early exit the same error.
-			err = segment.ErrClosed
-		} else {
-			err = errf
+
+		if len(batch.segments) == 0 {
+			continue
 		}
-		return err
+
+		atomic.AddUint64(&numMergedSegments, uint64(len(batch.segments)))
+		s.markIneligibleForRemoval(batch.newFilename)
+		path := s.path + string(os.PathSeparator) + batch.newFilename
+
+		fileMergeZapStartTime := time.Now()
+		atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
+		prevBytesReadTotal := cumulateBytesRead(batch.segments)
+		batch.newDocNums, _, err = s.segPlugin.MergeUsing(batch.segments, batch.drops, path,
+			cw.cancelCh, s, s.segmentConfig)
+		atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
+
+		fileMergeZapTime := uint64(time.Since(fileMergeZapStartTime))
+		atomic.AddUint64(&s.stats.TotFileMergeZapTime, fileMergeZapTime)
+		if atomic.LoadUint64(&s.stats.MaxFileMergeZapTime) < fileMergeZapTime {
+			atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
+		}
+		if err != nil {
+			s.unmarkIneligibleForRemoval(batch.newFilename)
+			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
+			return err
+		}
+
+		batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
+		if err != nil {
+			s.unmarkIneligibleForRemoval(batch.newFilename)
+			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
+			return err
+		}
+
+		totalBytesRead := batch.new.BytesRead() + prevBytesReadTotal
+		batch.new.ResetBytesRead(totalBytesRead)
+		atomic.AddUint64(&s.stats.TotFileMergeSegments, uint64(len(batch.segments)))
 	}
 
 	newSegmentIDs := make([]uint64, numBatches)

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -599,8 +599,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable) (*IndexSn
 			}
 			mergeBatches[batchID] = batch
 
-			sbsCount := uint64(len(flush.sbsBatch))
-			atomic.AddUint64(&numMergedSegments, sbsCount)
+			atomic.AddUint64(&numMergedSegments, uint64(len(flush.sbsBatch)))
 			s.markIneligibleForRemoval(batch.newFilename)
 			path := s.path + string(os.PathSeparator) + batch.newFilename
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -45,6 +45,46 @@ const mergePlanFuncKey = "mergePlanFunc"
 
 type mergePlanFunc func(*IndexSnapshot) (*mergeplan.MergePlan, error)
 
+var (
+	// number workers which parallely execute merge tasks in a merge plan
+	DefaultNumMergeWorkers int = 1
+)
+
+type mergerOptions struct {
+	// NumMergeWorkers decides the number of workers that will
+	// be used to perform the merge operations.
+	NumMergeWorkers int
+}
+
+func (s *Scorch) parseMergerOptions() (*mergerOptions, error) {
+	mo := mergerOptions{
+		NumMergeWorkers: DefaultNumMergeWorkers,
+	}
+	if v, ok := s.config["scorchMergerOptions"]; ok {
+		b, err := util.MarshalJSON(v)
+		if err != nil {
+			return &mo, err
+		}
+
+		err = util.UnmarshalJSON(b, &mo)
+		if err != nil {
+			return &mo, err
+		}
+	}
+	if err := validateMergerOptions(&mo); err != nil {
+		return nil, err
+	}
+	return &mo, nil
+}
+
+// validateMergerOptions validates the merger options
+func validateMergerOptions(options *mergerOptions) error {
+	if options.NumMergeWorkers <= 0 {
+		return fmt.Errorf("NumMergeWorkers must be greater than 0")
+	}
+	return nil
+}
+
 func (s *Scorch) mergerLoop() {
 	defer func() {
 		if r := recover(); r != nil {
@@ -284,17 +324,18 @@ func (w *closeChWrapper) listen() {
 	}
 }
 
-// mergeBatch represents a single merge task in a merge plan,
-// which may consist of multiple segments to be merged into a new segment.
+// mergeBatch represents a batch of segments to be merged together,
+// along with the new segment that will be created as a result of the merge.
 type mergeBatch struct {
-	snapshots  []*SegmentSnapshot
-	segments   []segment.Segment
-	drops      []*roaring.Bitmap
-	newDocNums [][]uint64
+	snapshots []*SegmentSnapshot
+	filenames []string
+	segments  []segment.Segment
+	drops     []*roaring.Bitmap
 
-	new      segment.Segment
-	id       uint64
-	filename string
+	new         segment.Segment
+	newID       uint64
+	newDocNums  [][]uint64
+	newFilename string
 }
 
 // planMergeAtSnapshot plans and executes the merge operations for a given snapshot
@@ -354,115 +395,145 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 		}
 	}()
 
-	var filenames []string
-	defer func() {
-		s.rootLock.Lock()
-		for _, filename := range filenames {
-			delete(s.ineligibleForRemoval, filename)
-		}
-		s.rootLock.Unlock()
-	}()
-
 	numBatches := len(mergePlan.Tasks)
 	mergeBatches := make([]*mergeBatch, numBatches)
 	defer func() {
-		if err != nil {
-			for batchID := 0; batchID < numBatches; batchID++ {
-				batch := mergeBatches[batchID]
-				if batch == nil {
-					continue
+		for batchID := 0; batchID < numBatches; batchID++ {
+			batch := mergeBatches[batchID]
+			if err == nil {
+				s.rootLock.Lock()
+				for _, filename := range batch.filenames {
+					delete(s.ineligibleForRemoval, filename)
 				}
+				s.rootLock.Unlock()
+			} else {
 				if batch.new != nil {
 					_ = batch.new.Close()
 				}
-				s.unmarkIneligibleForRemoval(batch.filename)
+				s.unmarkIneligibleForRemoval(batch.newFilename)
 			}
 		}
 	}()
 
-	numMergedSegments := 0
-	for batchID, task := range mergePlan.Tasks {
-		if len(task.Segments) == 0 {
-			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)
-		}
-		atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegments, uint64(len(task.Segments)))
-		newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
+	var numMergedSegments uint64
+	sem := make(chan struct{}, s.mergerOptions.NumMergeWorkers)
+	var wg sync.WaitGroup
+	var errM sync.Mutex
+	var errs []error
+	for batchID := 0; batchID < numBatches; batchID++ {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(batchID int) {
+			var err error
+			defer func() {
+				if err != nil {
+					errM.Lock()
+					errs = append(errs, err)
+					errM.Unlock()
+				}
+				<-sem
+				wg.Done()
+			}()
+			task := mergePlan.Tasks[batchID]
+			if len(task.Segments) == 0 {
+				atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegmentsEmpty, 1)
+			}
+			atomic.AddUint64(&s.stats.TotFileMergePlanTasksSegments, uint64(len(task.Segments)))
 
-		batch := &mergeBatch{
-			snapshots: make([]*SegmentSnapshot, 0, len(task.Segments)),
-			segments:  make([]segment.Segment, 0, len(task.Segments)),
-			drops:     make([]*roaring.Bitmap, 0, len(task.Segments)),
+			newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
+			batch := &mergeBatch{
+				snapshots: make([]*SegmentSnapshot, 0, len(task.Segments)),
+				filenames: make([]string, 0, len(task.Segments)),
+				segments:  make([]segment.Segment, 0, len(task.Segments)),
+				drops:     make([]*roaring.Bitmap, 0, len(task.Segments)),
 
-			newDocNums: nil,
-			new:        nil,
+				new:         nil,
+				newID:       newSegmentID,
+				newDocNums:  nil,
+				newFilename: zapFileName(newSegmentID),
+			}
+			mergeBatches[batchID] = batch
 
-			id:       newSegmentID,
-			filename: zapFileName(newSegmentID),
-		}
-
-		for _, planSegment := range task.Segments {
-			if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
-				if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
-					if segSnapshot.LiveSize() == 0 {
-						atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
-					} else {
-						batch.snapshots = append(batch.snapshots, segSnapshot)
-						batch.segments = append(batch.segments, segSnapshot.segment)
-						batch.drops = append(batch.drops, segSnapshot.deleted)
+			for _, planSegment := range task.Segments {
+				if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
+					if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
+						if segSnapshot.LiveSize() == 0 {
+							atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
+						} else {
+							batch.snapshots = append(batch.snapshots, segSnapshot)
+							batch.segments = append(batch.segments, segSnapshot.segment)
+							batch.drops = append(batch.drops, segSnapshot.deleted)
+						}
+						// track the files getting merged for unsetting the
+						// removal ineligibility. This helps to unflip files
+						// even with fast merger, slow persister work flows.
+						path := persistedSeg.Path()
+						batch.filenames = append(batch.filenames,
+							strings.TrimPrefix(path, s.path+string(os.PathSeparator)))
 					}
-					// track the files getting merged for unsetting the
-					// removal ineligibility. This helps to unflip files
-					// even with fast merger, slow persister work flows.
-					path := persistedSeg.Path()
-					filenames = append(filenames,
-						strings.TrimPrefix(path, s.path+string(os.PathSeparator)))
 				}
 			}
-		}
 
-		if len(batch.segments) == 0 {
-			mergeBatches[batchID] = batch
-			continue
-		}
-
-		numMergedSegments += len(batch.snapshots)
-		s.markIneligibleForRemoval(batch.filename)
-		path := s.path + string(os.PathSeparator) + batch.filename
-
-		fileMergeZapStartTime := time.Now()
-		atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
-		prevBytesReadTotal := cumulateBytesRead(batch.segments)
-		batch.newDocNums, _, err = s.segPlugin.MergeUsing(batch.segments, batch.drops, path,
-			cw.cancelCh, s, s.segmentConfig)
-		atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
-
-		fileMergeZapTime := uint64(time.Since(fileMergeZapStartTime))
-		atomic.AddUint64(&s.stats.TotFileMergeZapTime, fileMergeZapTime)
-		if atomic.LoadUint64(&s.stats.MaxFileMergeZapTime) < fileMergeZapTime {
-			atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
-		}
-
-		if err != nil {
-			s.unmarkIneligibleForRemoval(batch.filename)
-			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
-			if err == segment.ErrClosed {
-				return err
+			if len(batch.segments) == 0 {
+				return
 			}
-			err = fmt.Errorf("merging failed: %v", err)
-			return err
-		}
 
-		batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
-		if err != nil {
-			s.unmarkIneligibleForRemoval(batch.filename)
-			atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
-			return err
-		}
+			atomic.AddUint64(&numMergedSegments, uint64(len(batch.segments)))
+			s.markIneligibleForRemoval(batch.newFilename)
+			path := s.path + string(os.PathSeparator) + batch.newFilename
 
-		totalBytesRead := batch.new.BytesRead() + prevBytesReadTotal
-		batch.new.ResetBytesRead(totalBytesRead)
-		atomic.AddUint64(&s.stats.TotFileMergeSegments, uint64(len(batch.segments)))
-		mergeBatches[batchID] = batch
+			fileMergeZapStartTime := time.Now()
+			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
+			prevBytesReadTotal := cumulateBytesRead(batch.segments)
+			batch.newDocNums, _, err = s.segPlugin.MergeUsing(batch.segments, batch.drops, path,
+				cw.cancelCh, s, s.segmentConfig)
+			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
+
+			fileMergeZapTime := uint64(time.Since(fileMergeZapStartTime))
+			atomic.AddUint64(&s.stats.TotFileMergeZapTime, fileMergeZapTime)
+			if atomic.LoadUint64(&s.stats.MaxFileMergeZapTime) < fileMergeZapTime {
+				atomic.StoreUint64(&s.stats.MaxFileMergeZapTime, fileMergeZapTime)
+			}
+			if err != nil {
+				s.unmarkIneligibleForRemoval(batch.newFilename)
+				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
+				return
+			}
+
+			batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
+			if err != nil {
+				s.unmarkIneligibleForRemoval(batch.newFilename)
+				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
+				return
+			}
+
+			totalBytesRead := batch.new.BytesRead() + prevBytesReadTotal
+			batch.new.ResetBytesRead(totalBytesRead)
+			atomic.AddUint64(&s.stats.TotFileMergeSegments, uint64(len(batch.segments)))
+			mergeBatches[batchID] = batch
+		}(batchID)
+	}
+	wg.Wait()
+	close(sem)
+
+	if len(errs) > 0 {
+		var errf error
+		numClosed := 0
+		for _, e := range errs {
+			if e == segment.ErrClosed {
+				numClosed++
+			}
+			errf = errors.Join(errf, e)
+		}
+		if numClosed == len(errs) {
+			// the index snapshot was closed which will be handled gracefully
+			// by retrying the whole merge operation in a later iteration
+			// so its safe to early exit the same error.
+			err = segment.ErrClosed
+		} else {
+			err = errf
+		}
+		return err
 	}
 
 	newSegmentIDs := make([]uint64, numBatches)
@@ -470,7 +541,7 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 	mergedSegHistory := make(map[uint64]*mergedSegmentHistory, numMergedSegments)
 	for batchID := 0; batchID < numBatches; batchID++ {
 		batch := mergeBatches[batchID]
-		newSegmentIDs[batchID] = batch.id
+		newSegmentIDs[batchID] = batch.newID
 		newSegments[batchID] = batch.new
 		for j, ss := range batch.snapshots {
 			mergedSegHistory[ss.id] = &mergedSegmentHistory{
@@ -517,7 +588,7 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 			if batch.new != nil {
 				_ = batch.new.Close()
 			}
-			s.unmarkIneligibleForRemoval(batch.filename)
+			s.unmarkIneligibleForRemoval(batch.newFilename)
 		}
 	}
 
@@ -556,170 +627,164 @@ func cumulateBytesRead(sbs []segment.Segment) uint64 {
 	return rv
 }
 
-// mergeAndPersistInMemorySegments takes an IndexSnapshot and a list of in-memory segments,
-// which are merged and persisted to disk concurrently. These are then introduced as
-// the new root snapshot in one-shot.
-func (s *Scorch) mergeAndPersistInMemorySegments(snapshot *IndexSnapshot,
-	flushes []*flushable, po *persisterOptions) (*IndexSnapshot, map[uint64]struct{}, error) {
+func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable) (*IndexSnapshot, map[uint64]struct{}, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
-	memMergeZapStartTime := time.Now()
+	var err error
+	numBatches := len(flushes)
+	mergeBatches := make([]*mergeBatch, numBatches)
+	defer func() {
+		if err != nil {
+			for batchID := 0; batchID < numBatches; batchID++ {
+				batch := mergeBatches[batchID]
+				if batch.new != nil {
+					_ = batch.new.Close()
+				}
+				s.unmarkIneligibleForRemoval(batch.newFilename)
+			}
+		}
+	}()
 
-	atomic.AddUint64(&s.stats.TotMemMergeZapBeg, 1)
-
-	// we're tracking the merged segments and their doc number per batch
-	// to be able to introduce them all at once, so the first dimension of the
-	// slices here correspond to flushID
-	numFlushes := len(flushes)
-	newDocIDsSet := make([][][]uint64, numFlushes)
-	newMergedSegmentIDs := make([]uint64, numFlushes)
-	newMergedSegmentFileNames := make([]string, numFlushes)
-	newMergedSegments := make([]segment.Segment, numFlushes)
-	var numSegments, newMergedCount uint64
-	var em sync.Mutex
-	var errs []error
-
-	// create a semaphore of the number of configured persister workers
-	// and a waitgroup to wait for all the flushes to complete
-	sem := make(chan struct{}, po.NumPersisterWorkers)
+	var numMergedSegments uint64
+	sem := make(chan struct{}, s.persisterOptions.NumPersisterWorkers)
 	var wg sync.WaitGroup
-	for flushID := 0; flushID < numFlushes; flushID++ {
+	var errM sync.Mutex
+	var errs []error
+	for batchID := 0; batchID < numBatches; batchID++ {
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(flushID int) {
+		go func(batchID int) {
+			var err error
 			defer func() {
+				if err != nil {
+					errM.Lock()
+					errs = append(errs, err)
+					errM.Unlock()
+				}
 				<-sem
 				wg.Done()
 			}()
+
+			flush := flushes[batchID]
 			newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
-			filename := zapFileName(newSegmentID)
-			path := s.path + string(os.PathSeparator) + filename
+			batch := &mergeBatch{
+				snapshots: flush.sbsBatchSnapshots,
+				filenames: nil,
+				segments:  flush.sbsBatch,
+				drops:     flush.sbsBatchDrops,
 
-			// to prevent accidental cleanup of this newly created file, mark it
-			// as ineligible for removal. this will be flipped back when the bolt
-			// is updated - which is valid, since the snapshot updated in bolt is
-			// cleaned up only if its zero ref'd (MB-66163 for more details)
-			s.markIneligibleForRemoval(filename)
-			newMergedSegmentFileNames[flushID] = filename
+				new:         nil,
+				newID:       newSegmentID,
+				newDocNums:  nil,
+				newFilename: zapFileName(newSegmentID),
+			}
+			mergeBatches[batchID] = batch
 
-			// the newly merged segment is already flushed out to disk, just needs
-			// to be opened using mmap.
-			newDocIDs, _, err := s.segPlugin.MergeUsing(flushes[flushID].sbsBatch, flushes[flushID].sbsBatchDrops, path, s.closeCh, s, s.segmentConfig)
+			sbsCount := uint64(len(flush.sbsBatch))
+			atomic.AddUint64(&numMergedSegments, sbsCount)
+			s.markIneligibleForRemoval(batch.newFilename)
+			path := s.path + string(os.PathSeparator) + batch.newFilename
+
+			memMergeZapStartTime := time.Now()
+			atomic.AddUint64(&s.stats.TotMemMergeZapBeg, 1)
+			batch.newDocNums, _, err = s.segPlugin.MergeUsing(batch.segments, batch.drops, path,
+				s.closeCh, s, s.segmentConfig)
+			atomic.AddUint64(&s.stats.TotMemMergeZapEnd, 1)
+			memMergeZapTime := uint64(time.Since(memMergeZapStartTime))
+			atomic.AddUint64(&s.stats.TotMemMergeZapTime, memMergeZapTime)
+			if atomic.LoadUint64(&s.stats.MaxMemMergeZapTime) < memMergeZapTime {
+				atomic.StoreUint64(&s.stats.MaxMemMergeZapTime, memMergeZapTime)
+			}
 			if err != nil {
-				em.Lock()
-				errs = append(errs, err)
-				em.Unlock()
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			newDocIDsSet[flushID] = newDocIDs
-			newMergedSegmentIDs[flushID] = newSegmentID
-			newMergedSegments[flushID], err = s.segPlugin.OpenUsing(path, s.segmentConfig)
+
+			batch.new, err = s.segPlugin.OpenUsing(path, s.segmentConfig)
 			if err != nil {
-				em.Lock()
-				errs = append(errs, err)
-				em.Unlock()
 				atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 				return
 			}
-			atomic.AddUint64(&newMergedCount, newMergedSegments[flushID].Count())
-			atomic.AddUint64(&numSegments, uint64(len(flushes[flushID].sbsBatch)))
-		}(flushID)
+		}(batchID)
 	}
 	wg.Wait()
 	close(sem)
 
-	// if any of the flushes failed, close the newly merged segments and return the error
-	if errs != nil {
-		// close all merged segments and flip their ineligible for removal flag
-		for flushID := 0; flushID < numFlushes; flushID++ {
-			if newMergedSegments[flushID] != nil {
-				_ = newMergedSegments[flushID].Close()
-			}
-			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
-		}
+	if len(errs) > 0 {
 		var errf error
-		for _, err := range errs {
-			if err == segment.ErrClosed {
-				// the index snapshot was closed which will be handled gracefully
-				// by retrying the whole merge+flush operation in a later iteration
-				// so its safe to early exit the same error.
-				return nil, nil, err
+		numClosed := 0
+		for _, e := range errs {
+			if e == segment.ErrClosed {
+				numClosed++
 			}
-			errf = errors.Join(errf, err)
+			errf = errors.Join(errf, e)
 		}
-		return nil, nil, errf
+		if numClosed == len(errs) {
+			// the index snapshot was closed which will be handled gracefully
+			// by retrying the whole merge+flush operation in a later iteration
+			// so its safe to early exit the same error.
+			err = segment.ErrClosed
+		} else {
+			err = errf
+		}
+		return nil, nil, err
 	}
 
-	atomic.AddUint64(&s.stats.TotMemMergeZapEnd, 1)
-	memMergeZapTime := uint64(time.Since(memMergeZapStartTime))
-	atomic.AddUint64(&s.stats.TotMemMergeZapTime, memMergeZapTime)
-	if atomic.LoadUint64(&s.stats.MaxMemMergeZapTime) < memMergeZapTime {
-		atomic.StoreUint64(&s.stats.MaxMemMergeZapTime, memMergeZapTime)
-	}
-
-	// update the segmentMerge task with the newly merged + flushed segments which
-	// are to be introduced atomically.
-	sm := &segmentMerge{
-		id:               newMergedSegmentIDs,
-		new:              newMergedSegments,
-		mergedSegHistory: make(map[uint64]*mergedSegmentHistory, numSegments),
-		notifyCh:         make(chan *mergeTaskIntroStatus),
-		mmaped:           1,
-	}
-
-	// create a history map which maps the old in-memory segments with the specific
-	// flush it was part of (also the specific file segment its going to be part of).
-	//  This map will be used on the introducer side to out-ref
-	// the in-memory segments and also track the new tombstones if present.
-	for flushID, flush := range flushes {
-		for j, idx := range flush.sbsBatchIndexes {
-			ss := snapshot.segment[idx]
-			sm.mergedSegHistory[ss.id] = &mergedSegmentHistory{
-				batchID:      flushID,
-				oldNewDocIDs: newDocIDsSet[flushID][j],
+	newSegmentIDs := make([]uint64, numBatches)
+	newSegments := make([]segment.Segment, numBatches)
+	mergedSegHistory := make(map[uint64]*mergedSegmentHistory, numMergedSegments)
+	for batchID := 0; batchID < numBatches; batchID++ {
+		batch := mergeBatches[batchID]
+		newSegmentIDs[batchID] = batch.newID
+		newSegments[batchID] = batch.new
+		for j, ss := range batch.snapshots {
+			mergedSegHistory[ss.id] = &mergedSegmentHistory{
+				batchID:      batchID,
+				oldNewDocIDs: batch.newDocNums[j],
 				oldSegment:   ss,
 			}
 		}
 	}
 
-	select { // send to introducer
+	sm := &segmentMerge{
+		id:               newSegmentIDs,
+		new:              newSegments,
+		mergedSegHistory: mergedSegHistory,
+		notifyCh:         make(chan *mergeTaskIntroStatus),
+		mmaped:           1,
+	}
+
+	select {
 	case <-s.closeCh:
-		// close all merged segments and flip their ineligible for removal flag
-		for flushID := 0; flushID < numFlushes; flushID++ {
-			if newMergedSegments[flushID] != nil {
-				_ = newMergedSegments[flushID].Close()
-			}
-			s.unmarkIneligibleForRemoval(newMergedSegmentFileNames[flushID])
-		}
-		return nil, nil, segment.ErrClosed
+		err = segment.ErrClosed
+		return nil, nil, err
 	case s.merges <- sm:
 	}
 
 	// blockingly wait for the introduction to complete
 	introStatus := <-sm.notifyCh
 	introducedSnapshot := introStatus.indexSnapshot
-	introducedSegmentIDs := make(map[uint64]struct{}, len(newMergedSegmentIDs))
-	atomic.AddUint64(&s.stats.TotMemMergeSegments, uint64(numSegments))
-	atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
-	for flushID, skipped := range introStatus.skipped {
-		seg := newMergedSegments[flushID]
-		segID := newMergedSegmentIDs[flushID]
-		segFileName := newMergedSegmentFileNames[flushID]
+	introducedSegmentIDs := make(map[uint64]struct{}, numBatches)
+	for batchID, skipped := range introStatus.skipped {
+		batch := mergeBatches[batchID]
 		if skipped {
-			_ = seg.Close()
-			s.unmarkIneligibleForRemoval(segFileName)
+			_ = batch.new.Close()
+			s.unmarkIneligibleForRemoval(batch.newFilename)
 		} else {
-			introducedSegmentIDs[segID] = struct{}{}
+			introducedSegmentIDs[batch.newID] = struct{}{}
 		}
 	}
 
+	atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
+
 	// if we could not introduce all of the newly merged segments,
 	// then we cannot cannot persist a snapshot with any merged segments at all
-	if len(introducedSegmentIDs) != len(newMergedSegmentIDs) {
+	if len(introducedSegmentIDs) != numBatches {
 		_ = introducedSnapshot.DecRef()
 		return nil, nil, nil
 	}
+
+	atomic.AddUint64(&s.stats.TotMemMergeSegments, numMergedSegments)
 
 	return introducedSnapshot, introducedSegmentIDs, nil
 }

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -50,41 +50,6 @@ var (
 	DefaultNumMergeWorkers int = 1
 )
 
-type mergerOptions struct {
-	// NumMergeWorkers decides the number of workers that will
-	// be used to perform the merge operations.
-	NumMergeWorkers int
-}
-
-func (s *Scorch) parseMergerOptions() (*mergerOptions, error) {
-	mo := mergerOptions{
-		NumMergeWorkers: DefaultNumMergeWorkers,
-	}
-	if v, ok := s.config["scorchMergerOptions"]; ok {
-		b, err := util.MarshalJSON(v)
-		if err != nil {
-			return &mo, err
-		}
-
-		err = util.UnmarshalJSON(b, &mo)
-		if err != nil {
-			return &mo, err
-		}
-	}
-	if err := validateMergerOptions(&mo); err != nil {
-		return nil, err
-	}
-	return &mo, nil
-}
-
-// validateMergerOptions validates the merger options
-func validateMergerOptions(options *mergerOptions) error {
-	if options.NumMergeWorkers <= 0 {
-		return fmt.Errorf("NumMergeWorkers must be greater than 0")
-	}
-	return nil
-}
-
 func (s *Scorch) mergerLoop() {
 	defer func() {
 		if r := recover(); r != nil {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -375,7 +375,7 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 		}
 	}()
 
-	var numMergedSegments uint64
+	numMergedSegments := 0
 	for batchID := 0; batchID < numBatches; batchID++ {
 		task := mergePlan.Tasks[batchID]
 		if len(task.Segments) == 0 {
@@ -421,7 +421,7 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 			continue
 		}
 
-		atomic.AddUint64(&numMergedSegments, uint64(len(batch.segments)))
+		numMergedSegments += len(batch.segments)
 		s.markIneligibleForRemoval(batch.newFilename)
 		path := s.path + string(os.PathSeparator) + batch.newFilename
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -421,7 +421,7 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 			continue
 		}
 
-		numMergedSegments += len(batch.segments)
+		numMergedSegments += len(batch.snapshots)
 		s.markIneligibleForRemoval(batch.newFilename)
 		path := s.path + string(os.PathSeparator) + batch.newFilename
 

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -360,6 +360,9 @@ func (s *Scorch) planMergeAtSnapshot(ctrlMsg *mergerCtrl, ourSnapshot *IndexSnap
 	defer func() {
 		for batchID := 0; batchID < numBatches; batchID++ {
 			batch := mergeBatches[batchID]
+			if batch == nil {
+				continue
+			}
 			if err == nil {
 				s.rootLock.Lock()
 				for _, filename := range batch.filenames {

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -697,7 +697,7 @@ func (s *Scorch) mergeAndPersistInMemorySegments(flushes []*flushable, po *persi
 	atomic.AddUint64(&s.stats.TotMemMergeDone, 1)
 
 	// if we could not introduce all of the newly merged segments,
-	// then we cannot cannot persist a snapshot with any merged segments at all
+	// then we cannot persist a snapshot with any merged segments at all
 	if len(introducedSegmentIDs) != numBatches {
 		_ = introducedSnapshot.DecRef()
 		return nil, nil, nil

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -196,7 +196,7 @@ OUTER:
 		if ourSnapshot != nil {
 			startTime := time.Now()
 
-			err := s.persistSnapshot(ourSnapshot, s.persisterOptions)
+			err := s.persistSnapshot(ourSnapshot)
 			for _, ch := range ourPersisted {
 				if err != nil {
 					ch <- err
@@ -419,14 +419,12 @@ func validatePersisterOptions(options *persisterOptions) error {
 	return nil
 }
 
-func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
-	po *persisterOptions,
-) error {
+func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
 	// Perform in-memory segment merging only when the memory pressure is
 	// below the configured threshold, else the persister performs the
 	// direct persistence of segments.
-	if s.NumEventsBlocking() < po.MemoryPressurePauseThreshold {
-		persisted, err := s.persistSnapshotMaybeMerge(snapshot, po)
+	if s.NumEventsBlocking() < s.persisterOptions.MemoryPressurePauseThreshold {
+		persisted, err := s.persistSnapshotMaybeMerge(snapshot, s.persisterOptions)
 		if err != nil {
 			return err
 		}
@@ -524,7 +522,7 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 
 	// now merge each batch into a new segment, and persist all of them to disk,
 	// and construct a new snapshot with the merged segments
-	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(flushSet)
+	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(flushSet, po)
 	if err != nil {
 		return false, err
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -439,9 +439,9 @@ func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot,
 }
 
 type flushable struct {
-	sbsBatch        []segment.Segment
-	sbsBatchDrops   []*roaring.Bitmap
-	sbsBatchIndexes []int
+	sbsBatch          []segment.Segment
+	sbsBatchDrops     []*roaring.Bitmap
+	sbsBatchSnapshots []*SegmentSnapshot
 }
 
 func legacyFlushBehaviour(maxSizeInMemoryMergePerWorker, numPersisterWorkers int) bool {
@@ -462,16 +462,14 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 	// collect details of the unpersisted segments
 	sbs := make([]segment.Segment, 0, numSegments)
 	sbsDrops := make([]*roaring.Bitmap, 0, numSegments)
-	sbsIndexes := make([]int, 0, numSegments)
 	sbsSizes := make([]int, 0, numSegments)
-	for idx, segmentSnapshot := range snapshot.segment {
+	for _, segmentSnapshot := range snapshot.segment {
 		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
 			persistedSegments = append(persistedSegments, segmentSnapshot)
 		} else {
 			unpersistedSegments = append(unpersistedSegments, segmentSnapshot)
 			sbs = append(sbs, segmentSnapshot.segment)
 			sbsDrops = append(sbsDrops, segmentSnapshot.deleted)
-			sbsIndexes = append(sbsIndexes, idx)
 			sbsSizes = append(sbsSizes, segmentSnapshot.Size())
 		}
 	}
@@ -490,43 +488,43 @@ func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot, po *persiste
 	var flushSet []*flushable
 	if legacyFlushBehaviour(po.MaxSizeInMemoryMergePerWorker, po.NumPersisterWorkers) {
 		val := &flushable{
-			sbsBatch:        slices.Clone(sbs),
-			sbsBatchDrops:   slices.Clone(sbsDrops),
-			sbsBatchIndexes: slices.Clone(sbsIndexes),
+			sbsBatch:          slices.Clone(sbs),
+			sbsBatchDrops:     slices.Clone(sbsDrops),
+			sbsBatchSnapshots: slices.Clone(unpersistedSegments),
 		}
 		flushSet = append(flushSet, val)
 	} else {
 		sbsBatch := make([]segment.Segment, 0, numUnpersistedSegments)
 		sbsBatchDrops := make([]*roaring.Bitmap, 0, numUnpersistedSegments)
-		sbsBatchIndexes := make([]int, 0, numUnpersistedSegments)
+		sbsBatchSnapshots := make([]*SegmentSnapshot, 0, numUnpersistedSegments)
 		runningSize := 0
 		for i := 0; i < numUnpersistedSegments; i++ {
 			sbsBatch = append(sbsBatch, sbs[i])
 			sbsBatchDrops = append(sbsBatchDrops, sbsDrops[i])
-			sbsBatchIndexes = append(sbsBatchIndexes, sbsIndexes[i])
+			sbsBatchSnapshots = append(sbsBatchSnapshots, unpersistedSegments[i])
 			runningSize += sbsSizes[i]
 			if runningSize >= po.MaxSizeInMemoryMergePerWorker && len(sbsBatch) >= DefaultMinSegmentsForInMemoryMerge {
 				flushSet = append(flushSet, &flushable{
-					sbsBatch:        slices.Clone(sbsBatch),
-					sbsBatchDrops:   slices.Clone(sbsBatchDrops),
-					sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
+					sbsBatch:          slices.Clone(sbsBatch),
+					sbsBatchDrops:     slices.Clone(sbsBatchDrops),
+					sbsBatchSnapshots: slices.Clone(sbsBatchSnapshots),
 				})
-				sbsBatch, sbsBatchDrops, sbsBatchIndexes = sbsBatch[:0], sbsBatchDrops[:0], sbsBatchIndexes[:0]
+				sbsBatch, sbsBatchDrops, sbsBatchSnapshots = sbsBatch[:0], sbsBatchDrops[:0], sbsBatchSnapshots[:0]
 				runningSize = 0
 			}
 		}
 		if len(sbsBatch) > 0 {
 			flushSet = append(flushSet, &flushable{
-				sbsBatch:        slices.Clone(sbsBatch),
-				sbsBatchDrops:   slices.Clone(sbsBatchDrops),
-				sbsBatchIndexes: slices.Clone(sbsBatchIndexes),
+				sbsBatch:          slices.Clone(sbsBatch),
+				sbsBatchDrops:     slices.Clone(sbsBatchDrops),
+				sbsBatchSnapshots: slices.Clone(sbsBatchSnapshots),
 			})
 		}
 	}
 
 	// now merge each batch into a new segment, and persist all of them to disk,
 	// and construct a new snapshot with the merged segments
-	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(snapshot, flushSet, po)
+	newSnapshot, newSegmentIDs, err := s.mergeAndPersistInMemorySegments(flushSet)
 	if err != nil {
 		return false, err
 	}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -196,7 +196,7 @@ OUTER:
 		if ourSnapshot != nil {
 			startTime := time.Now()
 
-			err := s.persistSnapshot(ourSnapshot)
+			err := s.persistSnapshot(ourSnapshot, s.persisterOptions)
 			for _, ch := range ourPersisted {
 				if err != nil {
 					ch <- err
@@ -419,12 +419,12 @@ func validatePersisterOptions(options *persisterOptions) error {
 	return nil
 }
 
-func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot) error {
+func (s *Scorch) persistSnapshot(snapshot *IndexSnapshot, po *persisterOptions) error {
 	// Perform in-memory segment merging only when the memory pressure is
 	// below the configured threshold, else the persister performs the
 	// direct persistence of segments.
-	if s.NumEventsBlocking() < s.persisterOptions.MemoryPressurePauseThreshold {
-		persisted, err := s.persistSnapshotMaybeMerge(snapshot, s.persisterOptions)
+	if s.NumEventsBlocking() < po.MemoryPressurePauseThreshold {
+		persisted, err := s.persistSnapshotMaybeMerge(snapshot, po)
 		if err != nil {
 			return err
 		}

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -71,7 +71,6 @@ type Scorch struct {
 	copyScheduled map[string]int
 
 	persisterOptions    *persisterOptions
-	mergerOptions       *mergerOptions
 	mergePlannerOptions *mergeplan.MergePlanOptions
 
 	numSnapshotsToKeep       int

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -277,12 +277,6 @@ func NewScorch(storeName string,
 	}
 	rv.persisterOptions = po
 
-	mo, err := rv.parseMergerOptions()
-	if err != nil {
-		return nil, err
-	}
-	rv.mergerOptions = mo
-
 	mpo, err := rv.parseMergePlannerOptions(po)
 	if err != nil {
 		return nil, err

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -71,6 +71,7 @@ type Scorch struct {
 	copyScheduled map[string]int
 
 	persisterOptions    *persisterOptions
+	mergerOptions       *mergerOptions
 	mergePlannerOptions *mergeplan.MergePlanOptions
 
 	numSnapshotsToKeep       int
@@ -275,6 +276,12 @@ func NewScorch(storeName string,
 		return nil, err
 	}
 	rv.persisterOptions = po
+
+	mo, err := rv.parseMergerOptions()
+	if err != nil {
+		return nil, err
+	}
+	rv.mergerOptions = mo
 
 	mpo, err := rv.parseMergePlannerOptions(po)
 	if err != nil {


### PR DESCRIPTION
- [refactor] Unify usage of `mergeBatch` struct across file and in-memory segment merge to simplify logic and enhance code readability
- [bug fix] Only mark segments as eligible for removal of file merge succeeds, we do not want to delete the old files and the new files from the merge tasks if the merge fails.
- [bug fix] Fix incorrect stat accounting in in-memory merge.