### PR TITLE
MB-72535: Cap leaf term searchers per index per search

### DIFF
--- a/index_impl.go
+++ b/index_impl.go
@@ -752,6 +752,9 @@ func (i *indexImpl) SearchInContext(ctx context.Context, req *SearchRequest) (sr
 			ctx = context.WithValue(ctx, search.NestedSearchKey, true)
 		}
 	}
+	// Install here, before presearch and the knn collector, so the counter also
+	// covers presearch and KNN filter searchers, not just the main query's.
+	ctx = search.ContextWithTermSearchersCounter(ctx)
 	// ------------------------------------------------------------------------------------------
 
 	if _, ok := ctx.Value(search.PreSearchKey).(bool); ok {

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -115,6 +115,12 @@ func bm25ScoreMetrics(ctx context.Context, field string,
 func newTermSearcherFromReader(ctx context.Context, indexReader index.IndexReader,
 	reader index.TermFieldReader, term []byte, field string, boost float64,
 	options search.SearcherOptions) (*TermSearcher, error) {
+	// Every leaf term searcher is built here, so this is where we count against
+	// the limit. Close the reader on failure since the caller won't get it back.
+	if err := search.RecordTermSearcher(ctx); err != nil {
+		_ = reader.Close()
+		return nil, err
+	}
 	var count uint64
 	var avgDocLength float64
 	var err error

--- a/search/term_limit.go
+++ b/search/term_limit.go
@@ -1,0 +1,63 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+// termSearchersCounter tracks the running total of leaf term searchers created
+// while searching a single index and the limit beyond which construction fails.
+type termSearchersCounter struct {
+	limit int
+	count atomic.Uint64
+}
+
+// ContextWithTermSearchersCounter installs a fresh counter for the limit at
+// MaxTermSearchersKey, when that limit is positive. It is called once per index
+// search (indexImpl.SearchInContext), so the counter is scoped to that index:
+// within a single index it spans the whole query tree (all fan-out nodes share
+// one counter), but across an IndexAlias each index is counted independently.
+// context is returned unchanged and RecordTermSearcher stays a no-op.
+func ContextWithTermSearchersCounter(ctx context.Context) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	limit, ok := ctx.Value(MaxTermSearchersKey).(int)
+	if !ok || limit <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, termSearchersCounterKey,
+		&termSearchersCounter{limit: limit})
+}
+
+// RecordTermSearcher counts one leaf term searcher, returning an error once the
+// running total exceeds the limit. It is a no-op when no counter was installed.
+func RecordTermSearcher(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	c, ok := ctx.Value(termSearchersCounterKey).(*termSearchersCounter)
+	if !ok || c == nil {
+		return nil
+	}
+	if n := c.count.Add(1); n > uint64(c.limit) {
+		return fmt.Errorf("TooManyTermSearchers [%d > bleveMaxTerms,"+
+			" which is set to %d]", n, c.limit)
+	}
+	return nil
+}

--- a/search/term_limit_test.go
+++ b/search/term_limit_test.go
@@ -1,0 +1,74 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRecordTermSearcher(t *testing.T) {
+	// No limit set: RecordTermSearcher must always be a no-op.
+	t.Run("no limit set", func(t *testing.T) {
+		ctx := ContextWithTermSearchersCounter(context.Background())
+		for i := 0; i < 1000; i++ {
+			if err := RecordTermSearcher(ctx); err != nil {
+				t.Fatalf("unexpected error with no limit at i=%d: %v", i, err)
+			}
+		}
+	})
+
+	// Non-positive limit disables the check.
+	for _, limit := range []int{0, -5} {
+		t.Run("disabled limit", func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), MaxTermSearchersKey, limit)
+			ctx = ContextWithTermSearchersCounter(ctx)
+			for i := 0; i < 100; i++ {
+				if err := RecordTermSearcher(ctx); err != nil {
+					t.Fatalf("limit %d should disable check, got err at i=%d: %v",
+						limit, i, err)
+				}
+			}
+		})
+	}
+
+	// Positive limit: exactly `limit` leaf term searchers are allowed; the
+	// one that pushes the total over the limit fails.
+	t.Run("limit enforced", func(t *testing.T) {
+		const limit = 3
+		ctx := context.WithValue(context.Background(), MaxTermSearchersKey, limit)
+		ctx = ContextWithTermSearchersCounter(ctx)
+		for i := 1; i <= limit; i++ {
+			if err := RecordTermSearcher(ctx); err != nil {
+				t.Fatalf("term searcher %d/%d should be allowed, got: %v", i, limit, err)
+			}
+		}
+		if err := RecordTermSearcher(ctx); err == nil {
+			t.Fatalf("term searcher %d should exceed limit %d, got nil error",
+				limit+1, limit)
+		}
+	})
+
+	// A nil context is tolerated.
+	t.Run("nil context", func(t *testing.T) {
+		if err := RecordTermSearcher(nil); err != nil {
+			t.Fatalf("nil ctx should be a no-op, got: %v", err)
+		}
+		//nolint:staticcheck // deliberately exercising nil-ctx tolerance
+		if got := ContextWithTermSearchersCounter(nil); got != nil {
+			t.Fatalf("nil ctx should be returned unchanged")
+		}
+	})
+}

--- a/search/util.go
+++ b/search/util.go
@@ -176,6 +176,16 @@ const (
 	// NestedSearchKey is used to communicate whether the search is performed
 	// in an index with nested documents
 	NestedSearchKey ContextKey = "_nested_search_key"
+
+	// MaxTermSearchersKey carries an application-set int limit on the total
+	// number of leaf term searchers created for a single search; <= 0 disables
+	// the check. Unlike DisjunctionMaxClauseCount, which is per fan-out node,
+	// this bounds the count across the whole query tree.
+	MaxTermSearchersKey ContextKey = "_max_term_searchers_key"
+
+	// termSearchersCounterKey carries the per-search counter installed by
+	// ContextWithTermSearchersCounter.
+	termSearchersCounterKey ContextKey = "_term_searchers_counter_key"
 )
 
 func RecordSearchCost(ctx context.Context,

--- a/term_limit_integration_test.go
+++ b/term_limit_integration_test.go
@@ -1,0 +1,146 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bleve
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/search/query"
+)
+
+// disjunctionOfTerms builds a disjunction of n distinct term queries over the
+// "name" field. Each term query becomes one leaf term searcher at construction
+// time, regardless of whether it matches any document.
+func disjunctionOfTerms(prefix string, n int) query.Query {
+	dq := NewDisjunctionQuery()
+	for i := 0; i < n; i++ {
+		tq := NewTermQuery(fmt.Sprintf("%s%d", prefix, i))
+		tq.SetField("name")
+		dq.AddQuery(tq)
+	}
+	return dq
+}
+
+// conjunctionOfDisjunctions builds a conjunction of `groups` disjunctions, each
+// containing `per` distinct term queries -> groups*per leaf term searchers, but
+// no single fan-out node has more than `per` children.
+func conjunctionOfDisjunctions(groups, per int) query.Query {
+	cq := NewConjunctionQuery()
+	for g := 0; g < groups; g++ {
+		cq.AddQuery(disjunctionOfTerms(fmt.Sprintf("g%d_", g), per))
+	}
+	return cq
+}
+
+// TestBleveMaxTermSearchers exercises the full bleveMaxTerms wiring end-to-end
+// through SearchInContext: the per-search counter is installed from the ctx
+// limit, every leaf term searcher is counted, and construction fails once the
+// running total exceeds the limit. This complements TestRecordTermSearcher
+// (which only covers the counter primitive) by validating that the counter is
+// actually installed and consulted along the real search path.
+func TestBleveMaxTermSearchers(t *testing.T) {
+	idx, err := NewMemOnly(NewIndexMapping())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if cerr := idx.Close(); cerr != nil {
+			t.Fatal(cerr)
+		}
+	}()
+
+	// A couple of real documents so the term searchers open real readers.
+	if err := idx.Index("doc0", map[string]interface{}{"name": "alpha beta gamma"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Index("doc1", map[string]interface{}{"name": "delta epsilon zeta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	runSearch := func(q query.Query, limit int) error {
+		ctx := context.WithValue(context.Background(), search.MaxTermSearchersKey, limit)
+		_, serr := idx.SearchInContext(ctx, NewSearchRequest(q))
+		return serr
+	}
+
+	t.Run("disabled when limit unset (0)", func(t *testing.T) {
+		if err := runSearch(disjunctionOfTerms("t", 6), 0); err != nil {
+			t.Fatalf("limit 0 should disable the check, got: %v", err)
+		}
+	})
+
+	t.Run("disabled when limit is negative", func(t *testing.T) {
+		// A non-positive limit (as produced upstream when a request explicitly
+		// disables bleveMaxTerms) must be treated as "no limit", not enforced.
+		if err := runSearch(disjunctionOfTerms("t", 6), -1); err != nil {
+			t.Fatalf("negative limit should disable the check, got: %v", err)
+		}
+	})
+
+	t.Run("under the limit succeeds", func(t *testing.T) {
+		// 6 leaf term searchers, limit 100.
+		if err := runSearch(disjunctionOfTerms("t", 6), 100); err != nil {
+			t.Fatalf("6 term searchers under limit 100 should succeed, got: %v", err)
+		}
+	})
+
+	t.Run("exactly at the limit succeeds", func(t *testing.T) {
+		// 6 leaf term searchers, limit 6: 6 is not > 6, so it is allowed.
+		if err := runSearch(disjunctionOfTerms("t", 6), 6); err != nil {
+			t.Fatalf("6 term searchers at limit 6 should succeed, got: %v", err)
+		}
+	})
+
+	t.Run("over the limit fails with TooManyTermSearchers", func(t *testing.T) {
+		// 6 leaf term searchers, limit 5 -> trips at the 6th.
+		err := runSearch(disjunctionOfTerms("t", 6), 5)
+		if err == nil {
+			t.Fatal("6 term searchers over limit 5 should fail, got nil")
+		}
+		if !strings.Contains(err.Error(), "TooManyTermSearchers") {
+			t.Fatalf("expected a TooManyTermSearchers error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "set to 5") {
+			t.Fatalf("error should report the effective limit (5), got: %v", err)
+		}
+	})
+
+	t.Run("counts globally across the whole query tree", func(t *testing.T) {
+		// 2 disjunctions * 4 terms = 8 leaf term searchers, but no single node
+		// has more than 4 children. With DisjunctionMaxClauseCount unset this
+		// can only be tripped by the global bleveMaxTerms count, proving the two
+		// checks are distinct: bleveMaxClauseCount is per-node, bleveMaxTerms is
+		// the sum across the tree.
+		err := runSearch(conjunctionOfDisjunctions(2, 4), 5)
+		if err == nil {
+			t.Fatal("8 term searchers over limit 5 should fail, got nil")
+		}
+		if !strings.Contains(err.Error(), "TooManyTermSearchers") {
+			t.Fatalf("expected a TooManyTermSearchers error, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "TooManyClauses") {
+			t.Fatalf("should be the global term-count check, not the per-node clause check: %v", err)
+		}
+
+		// Same query, limit 8 -> allowed (8 is not > 8).
+		if err := runSearch(conjunctionOfDisjunctions(2, 4), 8); err != nil {
+			t.Fatalf("8 term searchers at limit 8 should succeed, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Add MaxTermSearchersKey: count every leaf term searcher (at the single choke point newTermSearcherFromReader) and fail the search once the count exceeds the limit.

The cap is per leaf index, not global: within a single index it spans the whole query tree, but across an IndexAlias each index is counted independently, so the effective ceiling scales with the number of indexes.

Unlike DisjunctionMaxClauseCount, which is enforced per fan-out node, this bounds the total across a single index's query tree rather than at any one node.