### PR TITLE
MB-72082: improve stats tracking on zap layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1
 	github.com/blevesearch/gtreap v0.1.1
-	github.com/blevesearch/scorch_segment_api/v2 v2.4.9-0.20260729090843-4313bda09bee
+	github.com/blevesearch/scorch_segment_api/v2 v2.4.9
 	github.com/blevesearch/segment v0.9.1
 	github.com/blevesearch/snowball v0.6.1
 	github.com/blevesearch/snowballstem v0.9.0
@@ -25,7 +25,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.3
 	github.com/blevesearch/zapx/v15 v15.4.3
 	github.com/blevesearch/zapx/v16 v16.3.4
-	github.com/blevesearch/zapx/v17 v17.2.2-0.20260806075952-6594f3d6bd0d
+	github.com/blevesearch/zapx/v17 v17.2.2
 	github.com/couchbase/moss v0.2.0
 	github.com/spf13/cobra v1.10.2
 	go.etcd.io/bbolt v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/bits-and-blooms/bitset v1.24.2
 	github.com/blevesearch/bleve_index_api v1.4.1
-	github.com/blevesearch/geo v0.2.6-0.20260805065110-a696685e93c5
+	github.com/blevesearch/geo v0.2.6
 	github.com/blevesearch/go-faiss v1.1.5
 	github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/blevesearch/goleveldb v1.0.1
 	github.com/blevesearch/gtreap v0.1.1
-	github.com/blevesearch/scorch_segment_api/v2 v2.4.9
+	github.com/blevesearch/scorch_segment_api/v2 v2.4.10
 	github.com/blevesearch/segment v0.9.1
 	github.com/blevesearch/snowball v0.6.1
 	github.com/blevesearch/snowballstem v0.9.0
@@ -25,7 +25,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.3
 	github.com/blevesearch/zapx/v15 v15.4.3
 	github.com/blevesearch/zapx/v16 v16.3.4
-	github.com/blevesearch/zapx/v17 v17.2.2
+	github.com/blevesearch/zapx/v17 v17.2.3
 	github.com/couchbase/moss v0.2.0
 	github.com/spf13/cobra v1.10.2
 	go.etcd.io/bbolt v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
-github.com/blevesearch/scorch_segment_api/v2 v2.4.9-0.20260729090843-4313bda09bee h1:RmX8uCxp4RDbsW0PRFsFED5f7X5xUvz6/9cYb9HrNTU=
-github.com/blevesearch/scorch_segment_api/v2 v2.4.9-0.20260729090843-4313bda09bee/go.mod h1:WUUkAocbkDlNK/kgAE13NvS9oxe+u618mYZ8sOvcCc4=
+github.com/blevesearch/scorch_segment_api/v2 v2.4.9 h1:q1shQvpwVGp0IISmX08Ead5XFOPNmZrB761Snpru3vk=
+github.com/blevesearch/scorch_segment_api/v2 v2.4.9/go.mod h1:WUUkAocbkDlNK/kgAE13NvS9oxe+u618mYZ8sOvcCc4=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -45,8 +45,8 @@ github.com/blevesearch/zapx/v15 v15.4.3 h1:iJiMJOHrz216jyO6lS0m9RTCEkprUnzvqAI2l
 github.com/blevesearch/zapx/v15 v15.4.3/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.3.4 h1:hDAqA8qusZTNbPEL7//w5P65UZ2de6yhSeUaTbp0Po0=
 github.com/blevesearch/zapx/v16 v16.3.4/go.mod h1:zqkPPqs9GS9FzVWzCO3Wf1X044yWAV17+4zb+FTiEHg=
-github.com/blevesearch/zapx/v17 v17.2.2-0.20260806075952-6594f3d6bd0d h1:NsgFVBOgq3lg7ClW4e7iJc5OsW7MFlsSIGxiGW7++Fw=
-github.com/blevesearch/zapx/v17 v17.2.2-0.20260806075952-6594f3d6bd0d/go.mod h1:hPt57M7CxaMgVQF1lYak7rRaO7Ge5j/sdYzrs8t8Htk=
+github.com/blevesearch/zapx/v17 v17.2.2 h1:v3as9jp2CFsrPKpBotYWn/Evp/EjElH4xpNvOhgsNTU=
+github.com/blevesearch/zapx/v17 v17.2.2/go.mod h1:r/ddAUuomMMcx12ZUBoDxf/9Fa4aqvFATf7AJzWp/Ac=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.4.1 h1:CYIyecFlI+/RYjzUm+NmDjYbSvk870Bb7f+Vl4b12q8=
 github.com/blevesearch/bleve_index_api v1.4.1/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/geo v0.2.6-0.20260805065110-a696685e93c5 h1:q5oEFAIvowWE/ADFp6diGDbQ4ZTFxr2MPxHWlIbYXiQ=
-github.com/blevesearch/geo v0.2.6-0.20260805065110-a696685e93c5/go.mod h1:6qzVUiB4BK47QkSZcRqiXEP2W3EeXuzM5XFTF8AdZ8A=
+github.com/blevesearch/geo v0.2.6 h1:7K1oyQKYlauC+mJuo2AfNPyjN/4mihEoJMfyClVH1Mo=
+github.com/blevesearch/geo v0.2.6/go.mod h1:6qzVUiB4BK47QkSZcRqiXEP2W3EeXuzM5XFTF8AdZ8A=
 github.com/blevesearch/go-faiss v1.1.5 h1:/IU5lkOahH9Ghfk9n3F6N0XD7PYVXZJWmNDc9TtXuco=
 github.com/blevesearch/go-faiss v1.1.5/go.mod h1:w3W9AiWsFRGVaMG+/cmJi7iHEAuGyC6blsgO1EzCK/M=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
@@ -19,8 +19,8 @@ github.com/blevesearch/gtreap v0.1.1/go.mod h1:QaQyDRAT51sotthUWAH4Sj08awFSSWzgY
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
-github.com/blevesearch/scorch_segment_api/v2 v2.4.9 h1:q1shQvpwVGp0IISmX08Ead5XFOPNmZrB761Snpru3vk=
-github.com/blevesearch/scorch_segment_api/v2 v2.4.9/go.mod h1:WUUkAocbkDlNK/kgAE13NvS9oxe+u618mYZ8sOvcCc4=
+github.com/blevesearch/scorch_segment_api/v2 v2.4.10 h1:C3873+iWZ0YJM2ijaSHhJJzSvD4x1k+5UaQdGygZVhM=
+github.com/blevesearch/scorch_segment_api/v2 v2.4.10/go.mod h1:WUUkAocbkDlNK/kgAE13NvS9oxe+u618mYZ8sOvcCc4=
 github.com/blevesearch/segment v0.9.1 h1:+dThDy+Lvgj5JMxhmOVlgFfkUtZV2kw49xax4+jTfSU=
 github.com/blevesearch/segment v0.9.1/go.mod h1:zN21iLm7+GnBHWTao9I+Au/7MBiL8pPFtJBJTsk6kQw=
 github.com/blevesearch/snowball v0.6.1 h1:cDYjn/NCH+wwt2UdehaLpr2e4BwLIjN4V/TdLsL+B5A=
@@ -45,8 +45,8 @@ github.com/blevesearch/zapx/v15 v15.4.3 h1:iJiMJOHrz216jyO6lS0m9RTCEkprUnzvqAI2l
 github.com/blevesearch/zapx/v15 v15.4.3/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.3.4 h1:hDAqA8qusZTNbPEL7//w5P65UZ2de6yhSeUaTbp0Po0=
 github.com/blevesearch/zapx/v16 v16.3.4/go.mod h1:zqkPPqs9GS9FzVWzCO3Wf1X044yWAV17+4zb+FTiEHg=
-github.com/blevesearch/zapx/v17 v17.2.2 h1:v3as9jp2CFsrPKpBotYWn/Evp/EjElH4xpNvOhgsNTU=
-github.com/blevesearch/zapx/v17 v17.2.2/go.mod h1:r/ddAUuomMMcx12ZUBoDxf/9Fa4aqvFATf7AJzWp/Ac=
+github.com/blevesearch/zapx/v17 v17.2.3 h1:UYYJPAt5b2tVxldx5h0jmv23RMsg8/UZKFVya7v92po=
+github.com/blevesearch/zapx/v17 v17.2.3/go.mod h1:r7mb4QWbDQSkbAnOjCb9iCfkcrzajB4yBdJpuBIo/fE=
 github.com/couchbase/ghistogram v0.1.0 h1:b95QcQTCzjTUocDXp/uMgSNQi8oj1tGwnJ4bODWZnps=
 github.com/couchbase/ghistogram v0.1.0/go.mod h1:s1Jhy76zqfEecpNWJfWUiKZookAFaiGOEoyzgHt9i7k=
 github.com/couchbase/moss v0.2.0 h1:VCYrMzFwEryyhRSeI+/b3tRBSeTpi/8gn5Kf6dxqn+o=

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -853,6 +853,10 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 			m["field:"+fieldName+":"+statName] = val
 		}
 	}
+
+	// these stats are the segment level stats captured throughout the index lifecycle
+	zapStats := s.segPlugin.StatsMap()
+	m["segment_stats"] = zapStats
 	return m
 }
 

--- a/index/scorch/scorch.go
+++ b/index/scorch/scorch.go
@@ -44,6 +44,7 @@ var ErrClosed = fmt.Errorf("scorch closed")
 type Scorch struct {
 	nextSegmentID uint64
 	stats         Stats
+	zapStats      segment.Stats
 	iStats        internalStats
 
 	readOnly      bool
@@ -212,6 +213,9 @@ func NewScorch(storeName string,
 	if ok {
 		rv.segmentConfig = segConfig
 	}
+
+	// NOTE: always register the stats handler in the config map to track zap layer stats
+	rv.segmentConfig[segment.StatsKey] = &rv.zapStats
 
 	typ, ok := config["spatialPlugin"].(string)
 	if ok {
@@ -854,9 +858,8 @@ func (s *Scorch) StatsMap() map[string]interface{} {
 		}
 	}
 
-	// these stats are the segment level stats captured throughout the index lifecycle
-	zapStats := s.segPlugin.StatsMap()
-	m["segment_stats"] = zapStats
+	// zap layer stats that are continously updated throughout the index lifecycle
+	m[segment.StatsKey] = s.zapStats.StatsMap()
 	return m
 }
 

--- a/index/scorch/segment_plugin.go
+++ b/index/scorch/segment_plugin.go
@@ -75,6 +75,8 @@ type SegmentPlugin interface {
 	MergeUsing(segments []segment.Segment, drops []*roaring.Bitmap, path string,
 		closeCh chan struct{}, s segment.StatsReporter, config map[string]interface{}) (
 		[][]uint64, uint64, error)
+
+	StatsMap() map[string]interface{}
 }
 
 var supportedSegmentPlugins map[string]map[uint32]SegmentPlugin
@@ -82,13 +84,13 @@ var defaultSegmentPlugin SegmentPlugin
 
 func init() {
 	ResetSegmentPlugins()
-	RegisterSegmentPlugin(&zapv17.ZapPlugin{}, true)
-	RegisterSegmentPlugin(&zapv16.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv15.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv14.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv13.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv12.ZapPlugin{}, false)
-	RegisterSegmentPlugin(&zapv11.ZapPlugin{}, false)
+	RegisterSegmentPlugin(zapv17.InitPlugin(), true)
+	RegisterSegmentPlugin(zapv16.InitPlugin(), false)
+	RegisterSegmentPlugin(zapv15.InitPlugin(), false)
+	RegisterSegmentPlugin(zapv14.InitPlugin(), false)
+	RegisterSegmentPlugin(zapv13.InitPlugin(), false)
+	RegisterSegmentPlugin(zapv12.InitPlugin(), false)
+	RegisterSegmentPlugin(zapv11.InitPlugin(), false)
 }
 
 func ResetSegmentPlugins() {

--- a/index/scorch/segment_plugin.go
+++ b/index/scorch/segment_plugin.go
@@ -75,8 +75,6 @@ type SegmentPlugin interface {
 	MergeUsing(segments []segment.Segment, drops []*roaring.Bitmap, path string,
 		closeCh chan struct{}, s segment.StatsReporter, config map[string]interface{}) (
 		[][]uint64, uint64, error)
-
-	StatsMap() map[string]interface{}
 }
 
 var supportedSegmentPlugins map[string]map[uint32]SegmentPlugin
@@ -84,13 +82,13 @@ var defaultSegmentPlugin SegmentPlugin
 
 func init() {
 	ResetSegmentPlugins()
-	RegisterSegmentPlugin(zapv17.InitPlugin(), true)
-	RegisterSegmentPlugin(zapv16.InitPlugin(), false)
-	RegisterSegmentPlugin(zapv15.InitPlugin(), false)
-	RegisterSegmentPlugin(zapv14.InitPlugin(), false)
-	RegisterSegmentPlugin(zapv13.InitPlugin(), false)
-	RegisterSegmentPlugin(zapv12.InitPlugin(), false)
-	RegisterSegmentPlugin(zapv11.InitPlugin(), false)
+	RegisterSegmentPlugin(&zapv17.ZapPlugin{}, true)
+	RegisterSegmentPlugin(&zapv16.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv15.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv14.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv13.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv12.ZapPlugin{}, false)
+	RegisterSegmentPlugin(&zapv11.ZapPlugin{}, false)
 }
 
 func ResetSegmentPlugins() {

--- a/index/scorch/stats.go
+++ b/index/scorch/stats.go
@@ -144,8 +144,10 @@ type Stats struct {
 
 	TotMemorySegmentsAtRoot uint64
 
-	TotTrainedSamples uint64
-	TotTrainTime      uint64
+	TotTrainedSamples          uint64
+	TotTrainTime               uint64
+	TotTrainFireIndexEventTime uint64
+	TotTrainFireIndexEvents    uint64
 }
 
 // atomically populates the returned map

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -69,7 +69,7 @@ func initTrainer(s *Scorch, config map[string]interface{}) *vectorTrainer {
 		if ok && feature {
 			trainer := vectorTrainer{
 				parent:  s,
-				config:  maps.Clone(s.config),
+				config:  maps.Clone(s.segmentConfig),
 				trainCh: make(chan *trainRequest, 1),
 				doneCh:  make(chan struct{}),
 			}
@@ -398,6 +398,9 @@ func (t *vectorTrainer) train(batch *index.Batch) error {
 	//
 	// todo: updates/deletes -> data drift detection
 	if len(trainData) > 0 {
+		if _, ok := config[segment.StatsKey]; !ok {
+			fmt.Println("missing stats in config")
+		}
 		trainReq.sample, _, err = t.parent.segPlugin.NewUsing(trainData, config)
 		if err != nil {
 			return err

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -340,7 +340,10 @@ func (t *vectorTrainer) loadTrainedData(bucket *util.BoltBucketImpl) error {
 
 func (t *vectorTrainer) train(batch *index.Batch) error {
 	// regulate the Train function
+	start := time.Now()
 	t.parent.FireIndexEvent()
+	atomic.AddUint64(&t.parent.stats.TotTrainFireIndexEventTime, uint64(time.Since(start)))
+	atomic.AddUint64(&t.parent.stats.TotTrainFireIndexEvents, 1)
 	if t.trainingComplete.Load() {
 		return fmt.Errorf("training is already complete, cannot accept more training data")
 	}

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -393,7 +393,6 @@ func (t *vectorTrainer) train(batch *index.Batch) error {
 	// is complete, the template will be used for other operations down the line
 	// like merge and search.
 	//
-	// note: this might index text data too, how to handle this? s.segmentConfig?
 	// todo: updates/deletes -> data drift detection
 	if len(trainData) > 0 {
 		trainReq.sample, _, err = t.parent.segPlugin.NewUsing(trainData, config)

--- a/index/scorch/train_vector.go
+++ b/index/scorch/train_vector.go
@@ -398,9 +398,6 @@ func (t *vectorTrainer) train(batch *index.Batch) error {
 	//
 	// todo: updates/deletes -> data drift detection
 	if len(trainData) > 0 {
-		if _, ok := config[segment.StatsKey]; !ok {
-			fmt.Println("missing stats in config")
-		}
 		trainReq.sample, _, err = t.parent.segPlugin.NewUsing(trainData, config)
 		if err != nil {
 			return err


### PR DESCRIPTION
- improves the visibility on zap layer by introducing a new stats framework
- This `Stats` construct is defined in the scorch_segment_api but instantiated and owned at the scorch level, which is passed to the zap layer via the config parameter.
- Also adds more training specific stats