### PR TITLE
MB-73497: fix nil pointer panic in term searcher cleanup

### DIFF
--- a/search/searcher/search_disjunction.go
+++ b/search/searcher/search_disjunction.go
@@ -120,8 +120,13 @@ func optimizeCompositeSearcher(ctx context.Context, optimizationKind string,
 		return nil, nil
 	}
 
-	return newTermSearcherFromReader(ctx, indexReader, tfr,
+	termSearcher, err := newTermSearcherFromReader(ctx, indexReader, tfr,
 		[]byte(optimizationKind), "*", 1.0, options)
+	if err != nil || termSearcher == nil {
+		return nil, err
+	}
+
+	return termSearcher, err
 }
 
 func tooManyClauses(count int) bool {

--- a/search/searcher/search_multi_term_test.go
+++ b/search/searcher/search_multi_term_test.go
@@ -1,0 +1,101 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2/search"
+)
+
+// ctxWithTermSearcherLimit caps the number of leaf term searchers, giving us a
+// deterministic way to make term searcher construction fail on purpose.
+func ctxWithTermSearcherLimit(limit int) context.Context {
+	ctx := context.WithValue(context.Background(), search.MaxTermSearchersKey, limit)
+	return search.ContextWithTermSearchersCounter(ctx)
+}
+
+// A term searcher that fails to build must come back as a nil search.Searcher
+// interface, never as an interface holding a nil *TermSearcher. Callers guard
+// their cleanup with `if searcher != nil`, and a typed nil slips past that guard
+// and panics on a nil receiver in (*TermSearcher).Close.
+func TestTermSearcherErrorReturnsNilSearcher(t *testing.T) {
+	twoDocIndexReader, err := twoDocIndex.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := twoDocIndexReader.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Room for exactly one leaf term searcher, so the second one fails inside
+	// newTermSearcherFromReader.
+	ctx := ctxWithTermSearcherLimit(1)
+
+	first, err := NewTermSearcher(ctx, twoDocIndexReader, "beer", "desc", 1.0,
+		search.SearcherOptions{})
+	if err != nil {
+		t.Fatalf("first term searcher should be within the limit, got: %v", err)
+	}
+	defer func() {
+		if err := first.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	second, err := NewTermSearcher(ctx, twoDocIndexReader, "angst", "desc", 1.0,
+		search.SearcherOptions{})
+	if err == nil {
+		_ = second.Close()
+		t.Fatal("second term searcher should have exceeded the limit of 1")
+	}
+	if second != nil {
+		t.Fatalf("expected a nil search.Searcher alongside the error, got an "+
+			"interface holding %T (typed nil: %v)", second, second == search.Searcher(nil))
+	}
+}
+
+// Regression test for the panic in makeBatchSearchers' cleanup: when one term in
+// the batch fails to build, closing the already-built searchers must not trip
+// over the failed entry.
+func TestMultiTermSearcherCleanupAfterError(t *testing.T) {
+	twoDocIndexReader, err := twoDocIndex.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := twoDocIndexReader.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Two of the three terms build; the third trips the limit, sending
+	// makeBatchSearchers down its qsearchersClose path.
+	ctx := ctxWithTermSearcherLimit(2)
+	terms := []string{"beer", "angst", "couch"}
+
+	searcher, err := NewMultiTermSearcher(ctx, twoDocIndexReader, terms, "desc",
+		1.0, search.SearcherOptions{}, true)
+	if err == nil {
+		_ = searcher.Close()
+		t.Fatalf("%d terms should have exceeded the limit of 2", len(terms))
+	}
+	if searcher != nil {
+		t.Fatalf("expected a nil search.Searcher alongside the error, got %T", searcher)
+	}
+}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -64,7 +64,12 @@ func NewTermSearcherBytes(ctx context.Context, indexReader index.IndexReader,
 	if err != nil {
 		return nil, err
 	}
-	return newTermSearcherFromReader(ctx, indexReader, reader, term, field, boost, options)
+	termSearcher, err := newTermSearcherFromReader(ctx, indexReader, reader, term, field, boost, options)
+	if err != nil || termSearcher == nil {
+		return nil, err
+	}
+
+	return termSearcher, err
 }
 
 func tfIDFScoreMetrics(indexReader index.IndexReader) (uint64, error) {
@@ -164,7 +169,12 @@ func NewSynonymSearcher(ctx context.Context, indexReader index.IndexReader, term
 		if err != nil {
 			return nil, err
 		}
-		return newTermSearcherFromReader(ctx, indexReader, reader, term, field, boostVal, options)
+		termSearcher, err := newTermSearcherFromReader(ctx, indexReader, reader, term, field, boostVal, options)
+		if err != nil || termSearcher == nil {
+			return nil, err
+		}
+
+		return termSearcher, err
 	}
 	// create a searcher for the term itself
 	termSearcher, err := createTermSearcher(term, boost)


### PR DESCRIPTION
newTermSearcherFromReader returns (*TermSearcher, error), and its callers return that as a search.Searcher. On error the nil *TermSearcher became a non-nil interface, so the `if searcher != nil` cleanup guards let it through and (*TermSearcher).Close panicked on a nil receiver instead of the error surfacing -- hit when a wide multi-term query trips the leaf term searcher cap from MB-72535.

Check the return value at all three call sites, and add regression tests that force the failure via MaxTermSearchersKey.